### PR TITLE
Pricing anchor: show $20 crossed-out, $10 launch price

### DIFF
--- a/src/app/(app)/billing/page.tsx
+++ b/src/app/(app)/billing/page.tsx
@@ -142,15 +142,25 @@ export default function BillingPage() {
                 <Sparkles className="h-5 w-5 text-primary" />
                 Upgrade to Basic
               </span>
-              <span className="text-2xl font-bold">
-                $10
+              <div className="flex items-baseline gap-1.5">
+                <span className="text-base font-normal text-muted-foreground line-through">
+                  $20
+                </span>
+                <span className="text-2xl font-bold">$10</span>
                 <span className="text-sm font-normal text-muted-foreground">
                   /mo
                 </span>
-              </span>
+              </div>
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
+            <Badge
+              variant="secondary"
+              className="bg-amber-500/20 text-amber-200 border-amber-500/40"
+            >
+              <Sparkles className="h-3 w-3 mr-1" />
+              Launch pricing — 50% off
+            </Badge>
             <ul className="space-y-2 text-sm">
               {BASIC_BENEFITS.map((benefit) => (
                 <li key={benefit} className="flex items-start gap-2">
@@ -171,6 +181,7 @@ export default function BillingPage() {
                 <Sparkles className="mr-2 h-4 w-4" />
               )}
               Upgrade to Basic — $10/mo
+              <span className="ml-2 text-xs opacity-70 line-through">$20</span>
             </Button>
           </CardContent>
         </Card>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -361,16 +361,25 @@ export default function HomePage() {
 
               {/* Basic */}
               <Card className="border-primary/50 bg-card/40 backdrop-blur ring-1 ring-primary/30 relative">
-                <div className="absolute -top-3 left-1/2 -translate-x-1/2">
+                <div className="absolute -top-3 left-1/2 -translate-x-1/2 flex gap-2">
                   <Badge className="px-3">
                     <Sparkles className="h-3 w-3 mr-1" />
                     Most popular
+                  </Badge>
+                  <Badge
+                    variant="secondary"
+                    className="px-2 bg-amber-500/20 text-amber-200 border-amber-500/40"
+                  >
+                    Save 50%
                   </Badge>
                 </div>
                 <CardContent className="p-6 space-y-4 pt-8">
                   <div className="flex items-baseline justify-between">
                     <h3 className="text-xl font-bold">Basic</h3>
-                    <div className="flex items-baseline gap-1">
+                    <div className="flex items-baseline gap-1.5">
+                      <span className="text-base text-muted-foreground line-through">
+                        $20
+                      </span>
                       <span className="text-2xl font-bold">$10</span>
                       <span className="text-sm text-muted-foreground">
                         /mo
@@ -378,7 +387,10 @@ export default function HomePage() {
                     </div>
                   </div>
                   <p className="text-sm text-muted-foreground">
-                    Serious practice. More videos, longer clips.
+                    Serious practice. More videos, longer clips.{" "}
+                    <span className="text-amber-200">
+                      Launch pricing — $10/mo while it lasts.
+                    </span>
                   </p>
                   <ul className="space-y-2 text-sm pt-2">
                     <li className="flex items-start gap-2">
@@ -401,7 +413,7 @@ export default function HomePage() {
                     </li>
                   </ul>
                   <Button className="w-full mt-4" asChild>
-                    <Link href="/login">Upgrade to Basic</Link>
+                    <Link href="/login">Upgrade to Basic — $10/mo</Link>
                   </Button>
                 </CardContent>
               </Card>


### PR DESCRIPTION
Visual anchor only — actual Stripe charge stays $10/mo. Shows "$20 $10/mo" with the $20 struck through, plus a "Save 50% / Launch pricing" badge on both the landing page and /billing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added promotional pricing displays highlighting a 50% launch discount on the Basic plan
  * Introduced discount badges throughout pricing cards

* **Changes**
  * Updated pricing display with struck-through original price ($20) and current discounted price ($10/mo)
  * Added limited-time offer messaging to encourage early adoption

<!-- end of auto-generated comment: release notes by coderabbit.ai -->