### PR TITLE
Fix: switch Gemini default to gemini-2.5-flash

### DIFF
--- a/api/src/wcs_api/settings.py
+++ b/api/src/wcs_api/settings.py
@@ -19,7 +19,7 @@ class Settings(BaseSettings):
     stripe_price_id: str = ""
 
     gemini_api_key: str = ""
-    gemini_model: str = "gemini-2.0-flash-exp"
+    gemini_model: str = "gemini-2.5-flash"
     # When enabled, runs a dedicated Gemini call asking ONLY about the
     # pattern timeline, then injects the result as context into the
     # main scoring call. wcs-analyzer found this improves scoring


### PR DESCRIPTION
`gemini-2.0-flash-exp` was removed from the v1beta API. Railway env var already updated; this is just the code default.