### PR TITLE
Gemini 3 Pro + delete-after-analysis + timeline + tags

### DIFF
--- a/api/src/wcs_api/routes/uploads.py
+++ b/api/src/wcs_api/routes/uploads.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
 
 from ..auth import verify_jwt
-from ..services import r2
+from ..services import r2, supabase_admin
 from ..settings import settings
 
 router = APIRouter(prefix="/uploads", tags=["uploads"])
@@ -11,6 +11,54 @@ router = APIRouter(prefix="/uploads", tags=["uploads"])
 class PresignBody(BaseModel):
     filename: str | None = None
     content_type: str = "application/octet-stream"
+
+
+class ObjectKeyBody(BaseModel):
+    object_key: str
+
+
+@router.post("/delete")
+async def delete_video(
+    body: ObjectKeyBody, user: dict = Depends(verify_jwt)
+) -> dict:
+    """User-initiated delete: remove the R2 object and clear the
+    reference on any of the user's video_analyses rows so the UI
+    reflects the deletion immediately."""
+    if not r2.object_key_belongs_to_user(body.object_key, user["sub"]):
+        raise HTTPException(
+            status_code=403, detail="object does not belong to user"
+        )
+    r2.delete_object(body.object_key)
+    try:
+        await supabase_admin.clear_video_analysis_object_key(
+            object_key=body.object_key, user_id=user["sub"]
+        )
+    except Exception:
+        pass
+    return {"ok": True}
+
+
+class ViewBody(BaseModel):
+    object_key: str
+
+
+@router.post("/view")
+async def presign_view(body: ViewBody, user: dict = Depends(verify_jwt)) -> dict:
+    """Issue a short-lived presigned GET URL so the user can stream their
+    own past upload from R2. Object-key prefix must match the user id."""
+    if not r2.object_key_belongs_to_user(body.object_key, user["sub"]):
+        raise HTTPException(status_code=403, detail="object does not belong to user")
+    if (
+        not settings.r2_account_id
+        or not settings.r2_access_key_id
+        or not settings.r2_secret_access_key
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="uploads not configured (R2_* env vars missing)",
+        )
+    url = r2.generate_presigned_get(body.object_key, expires_in=3600)
+    return {"url": url, "expiresIn": 3600}
 
 
 @router.post("/presign")

--- a/api/src/wcs_api/routes/video.py
+++ b/api/src/wcs_api/routes/video.py
@@ -19,6 +19,10 @@ router = APIRouter(prefix="/analyze/video", tags=["analyze"])
 class VideoAnalyzeBody(BaseModel):
     object_key: str
     filename: str | None = None
+    role: str | None = None
+    competition_level: str | None = None
+    event_name: str | None = None
+    tags: list[str] | None = None
 
 
 def _admin_error_to_http(exc: httpx.HTTPStatusError) -> HTTPException:
@@ -132,12 +136,20 @@ async def analyze_video_endpoint(
             duration_sec=int(duration),
         )
         try:
+            # object_key is intentionally NOT saved — the R2 object is
+            # deleted below, so keeping the key would just lead to 404s
+            # on Watch/Re-analyze. Privacy also: we don't retain dance
+            # videos of real people after the scoring run.
             await supabase_admin.insert_video_analysis(
                 user_id=user_id,
                 filename=body.filename,
                 duration=duration,
                 result=result,
-                object_key=body.object_key,
+                object_key=None,
+                role=body.role,
+                competition_level=body.competition_level,
+                event_name=body.event_name,
+                tags=body.tags,
             )
         except Exception:
             pass
@@ -157,7 +169,7 @@ async def analyze_video_endpoint(
             os.unlink(tmp_path)
         except OSError:
             pass
-        # R2 object is kept so users can re-analyze or re-watch without
-        # re-uploading. Users can delete via the UI; the lifecycle rule
-        # on the bucket is the backstop for orphaned uploads that never
-        # got a successful analysis.
+        # Delete from R2 right after analysis — privacy first. Users
+        # who want to re-score must re-upload. The 24h lifecycle rule
+        # on the bucket is the backstop for orphaned uploads.
+        r2.delete_object(body.object_key)

--- a/api/src/wcs_api/routes/video.py
+++ b/api/src/wcs_api/routes/video.py
@@ -137,6 +137,7 @@ async def analyze_video_endpoint(
                 filename=body.filename,
                 duration=duration,
                 result=result,
+                object_key=body.object_key,
             )
         except Exception:
             pass
@@ -156,5 +157,7 @@ async def analyze_video_endpoint(
             os.unlink(tmp_path)
         except OSError:
             pass
-        # Clean up the R2 object — the 24h lifecycle rule is a backstop.
-        r2.delete_object(body.object_key)
+        # R2 object is kept so users can re-analyze or re-watch without
+        # re-uploading. Users can delete via the UI; the lifecycle rule
+        # on the bucket is the backstop for orphaned uploads that never
+        # got a successful analysis.

--- a/api/src/wcs_api/services/r2.py
+++ b/api/src/wcs_api/services/r2.py
@@ -75,6 +75,14 @@ def delete_object(object_key: str) -> None:
         pass
 
 
+def generate_presigned_get(object_key: str, expires_in: int = 3600) -> str:
+    return _client().generate_presigned_url(
+        "get_object",
+        Params={"Bucket": settings.r2_bucket, "Key": object_key},
+        ExpiresIn=expires_in,
+    )
+
+
 def object_key_belongs_to_user(object_key: str, user_id: str) -> bool:
     """Guard against a user analyzing another user's upload by key-guessing."""
     return object_key.startswith(f"uploads/{user_id}/")

--- a/api/src/wcs_api/services/supabase_admin.py
+++ b/api/src/wcs_api/services/supabase_admin.py
@@ -75,6 +75,7 @@ async def insert_video_analysis(
     filename: str | None,
     duration: float | None,
     result: dict[str, Any],
+    object_key: str | None = None,
 ) -> None:
     async with httpx.AsyncClient(timeout=10) as client:
         r = await client.post(
@@ -85,6 +86,7 @@ async def insert_video_analysis(
                 "filename": filename,
                 "duration": duration,
                 "result": result,
+                "object_key": object_key,
             },
         )
         r.raise_for_status()
@@ -118,6 +120,24 @@ async def insert_usage_event(
             _rest("usage_events"),
             headers={**_headers(), "Prefer": "return=minimal"},
             json=record,
+        )
+        r.raise_for_status()
+
+
+async def clear_video_analysis_object_key(
+    object_key: str, user_id: str
+) -> None:
+    """When a user deletes their R2 video, clear the object_key on any of
+    their video_analyses rows that referenced it so the UI knows the
+    source is no longer available."""
+    async with httpx.AsyncClient(timeout=10) as client:
+        r = await client.patch(
+            _rest(
+                f"video_analyses?user_id=eq.{user_id}"
+                f"&object_key=eq.{object_key}"
+            ),
+            headers={**_headers(), "Prefer": "return=minimal"},
+            json={"object_key": None},
         )
         r.raise_for_status()
 

--- a/api/src/wcs_api/services/supabase_admin.py
+++ b/api/src/wcs_api/services/supabase_admin.py
@@ -76,18 +76,32 @@ async def insert_video_analysis(
     duration: float | None,
     result: dict[str, Any],
     object_key: str | None = None,
+    role: str | None = None,
+    competition_level: str | None = None,
+    event_name: str | None = None,
+    tags: list[str] | None = None,
 ) -> None:
+    record: dict[str, Any] = {
+        "user_id": user_id,
+        "filename": filename,
+        "duration": duration,
+        "result": result,
+        "object_key": object_key,
+    }
+    if role:
+        record["role"] = role
+    if competition_level:
+        record["competition_level"] = competition_level
+    if event_name:
+        record["event_name"] = event_name
+    if tags:
+        record["tags"] = tags
+
     async with httpx.AsyncClient(timeout=10) as client:
         r = await client.post(
             _rest("video_analyses"),
             headers={**_headers(), "Prefer": "return=minimal"},
-            json={
-                "user_id": user_id,
-                "filename": filename,
-                "duration": duration,
-                "result": result,
-                "object_key": object_key,
-            },
+            json=record,
         )
         r.raise_for_status()
 

--- a/api/src/wcs_api/services/video_analyzer.py
+++ b/api/src/wcs_api/services/video_analyzer.py
@@ -285,12 +285,48 @@ def _strip_code_fence(text: str) -> str:
 
 
 def _safe_parse_json(text: str) -> dict[str, Any] | None:
-    cleaned = _strip_code_fence(text)
+    cleaned = _strip_code_fence(text).strip()
+
+    # Happy path
     try:
         parsed = json.loads(cleaned)
+        return parsed if isinstance(parsed, dict) else None
     except json.JSONDecodeError:
+        pass
+
+    # Tolerant fallback: try to extract the first complete top-level JSON
+    # object by depth-counting braces. Handles trailing garbage, markdown
+    # fragments, or partial truncation past a valid object.
+    start = cleaned.find("{")
+    if start < 0:
         return None
-    return parsed if isinstance(parsed, dict) else None
+    depth = 0
+    in_string = False
+    escape = False
+    for i in range(start, len(cleaned)):
+        ch = cleaned[i]
+        if escape:
+            escape = False
+            continue
+        if ch == "\\":
+            escape = True
+            continue
+        if ch == '"':
+            in_string = not in_string
+            continue
+        if in_string:
+            continue
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                try:
+                    parsed = json.loads(cleaned[start : i + 1])
+                    return parsed if isinstance(parsed, dict) else None
+                except json.JSONDecodeError:
+                    return None
+    return None
 
 
 # ─────────────────────────────────────────────────────────────────────
@@ -358,8 +394,12 @@ def _max_interval(categories: dict[str, dict[str, Any]]) -> float:
 def _build_gen_config(model: str) -> genai_types.GenerateContentConfig:
     config_kwargs: dict[str, Any] = {
         "system_instruction": SYSTEM_PROMPT,
-        "max_output_tokens": 8192,
+        # Rich schema (reasoning + sub-scores + off-beat moments +
+        # patterns + lead/follow) produces long outputs. 8192 was
+        # truncating mid-JSON on real dance videos with many events.
+        "max_output_tokens": 32768,
         "temperature": 0.0,
+        "response_mime_type": "application/json",
     }
     # Extended thinking — Gemini 3.x accepts thinking_config. We pass it
     # on a best-effort basis and fall back silently for older models.

--- a/api/src/wcs_api/services/video_analyzer.py
+++ b/api/src/wcs_api/services/video_analyzer.py
@@ -27,6 +27,70 @@ from google.genai import types as genai_types
 from ..settings import settings
 
 
+def _extract_beat_context(video_path: str) -> str | None:
+    """Pull audio out of the video, run librosa beat tracking, and return a
+    prompt-ready string. Gemini's native audio understanding is good, but
+    giving it actual beat timestamps as context consistently tightens up
+    timing judgments (the canonical wcs-analyzer behavior).
+
+    Silent-fail on any error — this is a best-effort enrichment, not a
+    blocker.
+    """
+    try:
+        import librosa  # lazy import — heavy module
+
+        wav_path = tempfile.NamedTemporaryFile(delete=False, suffix=".wav").name
+        try:
+            subprocess.run(
+                [
+                    "ffmpeg",
+                    "-y",
+                    "-i",
+                    video_path,
+                    "-vn",
+                    "-ac",
+                    "1",
+                    "-ar",
+                    "22050",
+                    wav_path,
+                ],
+                capture_output=True,
+                check=True,
+                timeout=60,
+            )
+            y, sr = librosa.load(wav_path, sr=22050, mono=True)
+            tempo_raw, beat_times = librosa.beat.beat_track(
+                y=y, sr=sr, units="time"
+            )
+            if beat_times is None or len(beat_times) < 4:
+                return None
+            bpm = (
+                float(tempo_raw)
+                if not hasattr(tempo_raw, "__iter__")
+                else float(list(tempo_raw)[0])
+            )
+            # Show first ~12 seconds of beats as a prior (~24 beats at 120 BPM).
+            preview = [t for t in beat_times[:24].tolist()]
+            beats_str = ", ".join(f"{t:.2f}" for t in preview)
+            return (
+                "DETECTED MUSIC CONTEXT (from librosa beat tracking):\n"
+                f"- Estimated BPM: {bpm:.1f}\n"
+                f"- First beat times in seconds: {beats_str}\n"
+                "Use this as a strong prior for timing judgments — when a "
+                "dancer's weight change or anchor settle lands within "
+                "~100ms of a detected beat, count it as on-beat. Anchor "
+                "steps should land near beats 5 and 6 of each 8-count "
+                "phrase.\n"
+            )
+        finally:
+            try:
+                os.unlink(wav_path)
+            except OSError:
+                pass
+    except Exception:
+        return None
+
+
 # ─────────────────────────────────────────────────────────────────────
 # Prompts — ported from wcs-analyzer/src/wcs_analyzer/prompts.py
 # ─────────────────────────────────────────────────────────────────────
@@ -514,6 +578,12 @@ def analyze_video_path(video_path: str) -> dict[str, Any]:
 
     try:
         prompt = GEMINI_VIDEO_PROMPT
+
+        # Prepend librosa-derived beat context to ground timing judgments.
+        beat_context = _extract_beat_context(video_path)
+        if beat_context:
+            prompt = f"{beat_context}\n\n{prompt}"
+
         if settings.enable_pattern_prepass:
             pre_pass_context = _run_pattern_pre_pass(
                 client, settings.gemini_model, uploaded

--- a/api/src/wcs_api/settings.py
+++ b/api/src/wcs_api/settings.py
@@ -19,7 +19,7 @@ class Settings(BaseSettings):
     stripe_price_id: str = ""
 
     gemini_api_key: str = ""
-    gemini_model: str = "gemini-2.5-flash"
+    gemini_model: str = "gemini-3-pro-preview"
     # When enabled, runs a dedicated Gemini call asking ONLY about the
     # pattern timeline, then injects the result as context into the
     # main scoring call. wcs-analyzer found this improves scoring

--- a/src/app/(app)/analyze/page.tsx
+++ b/src/app/(app)/analyze/page.tsx
@@ -14,10 +14,18 @@ import {
   X,
   CheckCircle2,
   AlertCircle,
+  Play,
+  RotateCcw,
+  Trash2,
 } from "lucide-react";
 import { useVideoAnalysis } from "@/hooks/use-video-analysis";
 import { useAnalysisHistory, type AnalysisRecord } from "@/hooks/use-analysis-history";
-import type { VideoScoreResult } from "@/lib/wcs-api";
+import {
+  analyzeVideoFromKey,
+  deleteUploadedVideo,
+  getViewUrl,
+  type VideoScoreResult,
+} from "@/lib/wcs-api";
 
 const CATEGORY_LABELS: Record<keyof VideoScoreResult["categories"], string> = {
   timing: "Timing & Rhythm",
@@ -306,7 +314,11 @@ export default function AnalyzePage() {
           </CardHeader>
           <CardContent className="space-y-2">
             {history.records.map((rec) => (
-              <HistoryRow key={rec.id} record={rec} />
+              <HistoryRow
+                key={rec.id}
+                record={rec}
+                onReanalyzed={history.refresh}
+              />
             ))}
           </CardContent>
         </Card>
@@ -315,14 +327,97 @@ export default function AnalyzePage() {
   );
 }
 
-function HistoryRow({ record }: { record: AnalysisRecord }) {
+function HistoryRow({
+  record,
+  onReanalyzed,
+}: {
+  record: AnalysisRecord;
+  onReanalyzed: () => void;
+}) {
   const [expanded, setExpanded] = useState(false);
-  const overall = record.result?.overall;
+  const [videoUrl, setVideoUrl] = useState<string | null>(null);
+  const [loadingVideo, setLoadingVideo] = useState(false);
+  const [reanalyzing, setReanalyzing] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [deleted, setDeleted] = useState(false);
+  const [currentResult, setCurrentResult] = useState<
+    VideoScoreResult | null
+  >(record.result ?? null);
+  const [rowError, setRowError] = useState<string | null>(null);
+  const overall = currentResult?.overall;
+
+  const canViewOrReanalyze = Boolean(record.object_key) && !deleted;
+
+  const handleWatch = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!record.object_key || videoUrl) {
+      setExpanded(true);
+      return;
+    }
+    setLoadingVideo(true);
+    setRowError(null);
+    try {
+      const url = await getViewUrl(record.object_key);
+      setVideoUrl(url);
+      setExpanded(true);
+    } catch (err) {
+      setRowError(
+        err instanceof Error ? err.message : "Could not load video"
+      );
+    } finally {
+      setLoadingVideo(false);
+    }
+  };
+
+  const handleReanalyze = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!record.object_key) return;
+    setReanalyzing(true);
+    setRowError(null);
+    try {
+      const resp = await analyzeVideoFromKey(
+        record.object_key,
+        record.filename ?? "video.mp4"
+      );
+      setCurrentResult(resp.result);
+      setExpanded(true);
+      onReanalyzed();
+    } catch (err) {
+      setRowError(
+        err instanceof Error ? err.message : "Re-analysis failed"
+      );
+    } finally {
+      setReanalyzing(false);
+    }
+  };
+
+  const handleDelete = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!record.object_key) return;
+    const ok = window.confirm(
+      "Delete the source video from storage? Your scoring result stays — only the video file is removed. This cannot be undone."
+    );
+    if (!ok) return;
+    setDeleting(true);
+    setRowError(null);
+    try {
+      await deleteUploadedVideo(record.object_key);
+      setDeleted(true);
+      setVideoUrl(null);
+      onReanalyzed();
+    } catch (err) {
+      setRowError(
+        err instanceof Error ? err.message : "Delete failed"
+      );
+    } finally {
+      setDeleting(false);
+    }
+  };
+
   return (
     <div className="border border-border rounded-lg">
-      <button
-        type="button"
-        className="w-full flex items-center justify-between p-3 text-sm text-left hover:bg-muted/30 transition-colors"
+      <div
+        className="w-full flex items-center justify-between p-3 text-sm cursor-pointer hover:bg-muted/30 transition-colors"
         onClick={() => setExpanded((p) => !p)}
       >
         <div className="min-w-0 flex-1">
@@ -336,9 +431,7 @@ function HistoryRow({ record }: { record: AnalysisRecord }) {
               hour: "2-digit",
               minute: "2-digit",
             })}
-            {record.duration
-              ? ` · ${formatDuration(record.duration)}`
-              : ""}
+            {record.duration ? ` · ${formatDuration(record.duration)}` : ""}
           </span>
         </div>
         {overall && (
@@ -351,14 +444,82 @@ function HistoryRow({ record }: { record: AnalysisRecord }) {
             </Badge>
           </div>
         )}
-      </button>
-      {expanded && record.result && (
-        <div className="border-t border-border p-3">
-          <ScoreResultCard
-            result={record.result}
-            duration={record.duration ?? 0}
-            onClear={() => setExpanded(false)}
-          />
+      </div>
+      {expanded && (
+        <div className="border-t border-border p-3 space-y-3">
+          {canViewOrReanalyze && (
+            <div className="flex items-center gap-2 flex-wrap">
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={handleWatch}
+                disabled={loadingVideo || reanalyzing || deleting}
+              >
+                {loadingVideo ? (
+                  <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Play className="mr-2 h-3.5 w-3.5" />
+                )}
+                {videoUrl ? "Reload video" : "Watch"}
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={handleReanalyze}
+                disabled={reanalyzing || loadingVideo || deleting}
+              >
+                {reanalyzing ? (
+                  <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <RotateCcw className="mr-2 h-3.5 w-3.5" />
+                )}
+                Re-analyze (1 quota)
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                className="text-muted-foreground hover:text-destructive ml-auto"
+                onClick={handleDelete}
+                disabled={deleting || reanalyzing || loadingVideo}
+              >
+                {deleting ? (
+                  <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Trash2 className="mr-2 h-3.5 w-3.5" />
+                )}
+                Delete video
+              </Button>
+            </div>
+          )}
+
+          {!canViewOrReanalyze && (
+            <p className="text-xs text-muted-foreground">
+              {deleted
+                ? "Video deleted from storage. The scoring result above is preserved."
+                : "Source video isn\u2019t available (older entry — video was removed after scoring)."}
+            </p>
+          )}
+
+          {rowError && (
+            <p className="text-xs text-destructive">{rowError}</p>
+          )}
+
+          {videoUrl && (
+            <video
+              src={videoUrl}
+              controls
+              preload="metadata"
+              className="w-full rounded-md bg-black"
+            />
+          )}
+
+          {currentResult && (
+            <ScoreResultCard
+              result={currentResult}
+              duration={record.duration ?? 0}
+              onClear={() => setExpanded(false)}
+            />
+          )}
         </div>
       )}
     </div>

--- a/src/app/(app)/analyze/page.tsx
+++ b/src/app/(app)/analyze/page.tsx
@@ -17,6 +17,8 @@ import {
   Play,
   RotateCcw,
   Trash2,
+  Target,
+  Quote,
 } from "lucide-react";
 import { useVideoAnalysis } from "@/hooks/use-video-analysis";
 import { useAnalysisHistory, type AnalysisRecord } from "@/hooks/use-analysis-history";
@@ -26,6 +28,9 @@ import {
   getViewUrl,
   type VideoScoreResult,
 } from "@/lib/wcs-api";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { TimelineView } from "@/components/analyze/timeline-view";
 
 const CATEGORY_LABELS: Record<keyof VideoScoreResult["categories"], string> = {
   timing: "Timing & Rhythm",
@@ -62,6 +67,12 @@ export default function AnalyzePage() {
   const [file, setFile] = useState<File | null>(null);
   const [localError, setLocalError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+
+  // Optional metadata — captured pre-upload so it gets saved with the analysis.
+  const [role, setRole] = useState("");
+  const [competitionLevel, setCompetitionLevel] = useState("");
+  const [eventName, setEventName] = useState("");
+  const [tagsInput, setTagsInput] = useState("");
 
   const handleFileChange = useCallback(
     async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -109,10 +120,18 @@ export default function AnalyzePage() {
   );
 
   const handleAnalyze = useCallback(() => {
-    if (file) {
-      analyze(file).then(() => history.refresh());
-    }
-  }, [file, analyze, history]);
+    if (!file) return;
+    const tags = tagsInput
+      .split(",")
+      .map((t) => t.trim())
+      .filter(Boolean);
+    analyze(file, {
+      role: role.trim() || undefined,
+      competitionLevel: competitionLevel.trim() || undefined,
+      eventName: eventName.trim() || undefined,
+      tags: tags.length ? tags : undefined,
+    }).then(() => history.refresh());
+  }, [file, analyze, history, role, competitionLevel, eventName, tagsInput]);
 
   const handleClear = useCallback(() => {
     setFile(null);
@@ -176,8 +195,8 @@ export default function AnalyzePage() {
         </CardContent>
       </Card>
 
-      {/* Paywall */}
-      {isPaywalled && (
+      {/* Paywall — hide when showing a fresh result so the score owns the hero slot */}
+      {isPaywalled && state.status !== "success" && (
         <Card className="border-primary/40">
           <CardContent className="py-6 space-y-3 text-center">
             <Sparkles className="h-8 w-8 text-primary mx-auto" />
@@ -249,6 +268,64 @@ export default function AnalyzePage() {
               <p className="text-sm text-destructive">{localError}</p>
             )}
 
+            {file && state.status === "idle" && (
+              <div className="space-y-2.5 rounded-lg border border-border p-3">
+                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  Optional tags (saved with the analysis)
+                </p>
+                <div className="grid grid-cols-2 gap-2.5">
+                  <div className="space-y-1">
+                    <Label htmlFor="role" className="text-xs">
+                      Role
+                    </Label>
+                    <Input
+                      id="role"
+                      placeholder="lead / follow / solo"
+                      value={role}
+                      onChange={(e) => setRole(e.target.value)}
+                      className="h-8 text-sm"
+                    />
+                  </div>
+                  <div className="space-y-1">
+                    <Label htmlFor="level" className="text-xs">
+                      Level
+                    </Label>
+                    <Input
+                      id="level"
+                      placeholder="novice, intermediate, all-star…"
+                      value={competitionLevel}
+                      onChange={(e) => setCompetitionLevel(e.target.value)}
+                      className="h-8 text-sm"
+                    />
+                  </div>
+                </div>
+                <div className="space-y-1">
+                  <Label htmlFor="event" className="text-xs">
+                    Event
+                  </Label>
+                  <Input
+                    id="event"
+                    placeholder="Boogie by the Bay 2026 J&J"
+                    value={eventName}
+                    onChange={(e) => setEventName(e.target.value)}
+                    className="h-8 text-sm"
+                  />
+                </div>
+                <div className="space-y-1">
+                  <Label htmlFor="tags" className="text-xs">
+                    Tags
+                  </Label>
+                  <Input
+                    id="tags"
+                    placeholder="strictly-swing, showcase, 2026 (comma separated)"
+                    value={tagsInput}
+                    onChange={(e) => setTagsInput(e.target.value)}
+                    className="h-8 text-sm"
+                  />
+                </div>
+              </div>
+            )}
+
             {file && (
               <>
                 {state.status === "uploading" && (
@@ -299,11 +376,41 @@ export default function AnalyzePage() {
 
       {/* Result */}
       {state.status === "success" && state.result && (
-        <ScoreResultCard
-          result={state.result.result}
-          duration={state.result.duration}
-          onClear={handleClear}
-        />
+        <>
+          <ScoreResultCard
+            result={state.result.result}
+            duration={state.result.duration}
+            onClear={handleClear}
+          />
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base">Pattern timeline</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <TimelineView
+                result={state.result.result}
+                duration={state.result.duration}
+              />
+            </CardContent>
+          </Card>
+          {/* Paywall pushed below the result when both are present */}
+          {isPaywalled && (
+            <Card className="border-primary/40">
+              <CardContent className="py-5 text-center space-y-2">
+                <p className="text-sm">
+                  <Sparkles className="h-4 w-4 text-primary inline-block mr-1.5 -mt-0.5" />
+                  That was your free analysis for the month. Upgrade for 10
+                  per month and 5-minute clips.
+                </p>
+                <Link href="/billing">
+                  <Button size="sm" className="mt-1">
+                    Upgrade to Basic — $10/mo
+                  </Button>
+                </Link>
+              </CardContent>
+            </Card>
+          )}
+        </>
       )}
 
       {/* Past analyses */}
@@ -424,15 +531,43 @@ function HistoryRow({
           <span className="font-medium truncate block">
             {record.filename || "Untitled"}
           </span>
-          <span className="text-xs text-muted-foreground">
-            {new Date(record.created_at).toLocaleDateString("en-US", {
-              month: "short",
-              day: "numeric",
-              hour: "2-digit",
-              minute: "2-digit",
-            })}
-            {record.duration ? ` · ${formatDuration(record.duration)}` : ""}
-          </span>
+          <div className="text-xs text-muted-foreground flex flex-wrap items-center gap-1.5 mt-0.5">
+            <span>
+              {new Date(record.created_at).toLocaleDateString("en-US", {
+                month: "short",
+                day: "numeric",
+                hour: "2-digit",
+                minute: "2-digit",
+              })}
+            </span>
+            {record.duration ? (
+              <span>· {formatDuration(record.duration)}</span>
+            ) : null}
+            {record.role && (
+              <Badge variant="outline" className="text-[9px] px-1.5 py-0 h-4">
+                {record.role}
+              </Badge>
+            )}
+            {record.competition_level && (
+              <Badge variant="outline" className="text-[9px] px-1.5 py-0 h-4">
+                {record.competition_level}
+              </Badge>
+            )}
+            {record.event_name && (
+              <Badge variant="outline" className="text-[9px] px-1.5 py-0 h-4">
+                {record.event_name}
+              </Badge>
+            )}
+            {(record.tags ?? []).slice(0, 4).map((t) => (
+              <Badge
+                key={t}
+                variant="secondary"
+                className="text-[9px] px-1.5 py-0 h-4"
+              >
+                #{t}
+              </Badge>
+            ))}
+          </div>
         </div>
         {overall && (
           <div className="flex items-center gap-2 shrink-0 ml-3">
@@ -504,21 +639,19 @@ function HistoryRow({
             <p className="text-xs text-destructive">{rowError}</p>
           )}
 
-          {videoUrl && (
-            <video
-              src={videoUrl}
-              controls
-              preload="metadata"
-              className="w-full rounded-md bg-black"
-            />
-          )}
-
           {currentResult && (
-            <ScoreResultCard
-              result={currentResult}
-              duration={record.duration ?? 0}
-              onClear={() => setExpanded(false)}
-            />
+            <>
+              <TimelineView
+                result={currentResult}
+                duration={record.duration ?? 0}
+                videoSrc={videoUrl}
+              />
+              <ScoreResultCard
+                result={currentResult}
+                duration={record.duration ?? 0}
+                onClear={() => setExpanded(false)}
+              />
+            </>
           )}
         </div>
       )}
@@ -537,7 +670,7 @@ function ScoreResultCard({
 }) {
   return (
     <div className="space-y-4">
-      <Card>
+      <Card className="bg-gradient-to-b from-card to-muted/20">
         <CardHeader className="pb-3">
           <CardTitle className="flex items-center justify-between">
             <span className="flex items-center gap-2">
@@ -549,16 +682,33 @@ function ScoreResultCard({
             </span>
           </CardTitle>
         </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="flex items-baseline justify-center gap-2 py-2">
-            <span className="text-5xl font-bold tabular-nums">
-              {result.overall.score.toFixed(1)}
-            </span>
-            <span className="text-2xl text-muted-foreground">/ 10</span>
-            <Badge className="ml-3 text-base">{result.overall.grade}</Badge>
+        <CardContent className="space-y-5">
+          <div className="flex flex-col items-center gap-3 py-4">
+            <div className="flex items-baseline gap-2">
+              <span className="text-7xl font-bold tabular-nums leading-none">
+                {result.overall.score.toFixed(1)}
+              </span>
+              <span className="text-2xl text-muted-foreground">/10</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <Badge className="text-sm px-3 py-0.5">
+                {result.overall.grade}
+              </Badge>
+              {result.overall.confidence === "low" && (
+                <Badge variant="outline" className="text-xs">
+                  low confidence
+                </Badge>
+              )}
+            </div>
+            {result.overall.impression && (
+              <p className="text-sm text-muted-foreground italic text-center max-w-lg pt-2">
+                <Quote className="inline h-3 w-3 mr-1 -mt-0.5 opacity-50" />
+                {result.overall.impression}
+              </p>
+            )}
           </div>
 
-          <div className="space-y-3">
+          <div className="space-y-3.5 pt-2 border-t border-border">
             {(Object.keys(CATEGORY_LABELS) as Array<keyof typeof CATEGORY_LABELS>).map(
               (key) => {
                 const cat = result.categories[key];
@@ -571,7 +721,11 @@ function ScoreResultCard({
                       </span>
                     </div>
                     <Progress value={cat.score * 10} className="h-1.5" />
-                    <p className="text-xs text-muted-foreground">{cat.notes}</p>
+                    {cat.notes && (
+                      <p className="text-xs text-muted-foreground pt-0.5">
+                        {cat.notes}
+                      </p>
+                    )}
                   </div>
                 );
               }
@@ -582,12 +736,18 @@ function ScoreResultCard({
 
       <Card>
         <CardHeader className="pb-3">
-          <CardTitle className="text-base">Strengths</CardTitle>
+          <CardTitle className="text-base flex items-center gap-2">
+            <CheckCircle2 className="h-4 w-4 text-emerald-400" />
+            Strengths
+          </CardTitle>
         </CardHeader>
         <CardContent>
-          <ul className="space-y-1.5 text-sm text-muted-foreground">
+          <ul className="space-y-2.5 text-sm">
             {result.strengths.map((s, i) => (
-              <li key={i}>• {s}</li>
+              <li key={i} className="flex items-start gap-2.5">
+                <CheckCircle2 className="h-4 w-4 text-emerald-400 mt-0.5 shrink-0" />
+                <span className="text-muted-foreground">{s}</span>
+              </li>
             ))}
           </ul>
         </CardContent>
@@ -595,12 +755,18 @@ function ScoreResultCard({
 
       <Card>
         <CardHeader className="pb-3">
-          <CardTitle className="text-base">Areas to improve</CardTitle>
+          <CardTitle className="text-base flex items-center gap-2">
+            <Target className="h-4 w-4 text-amber-400" />
+            Areas to improve
+          </CardTitle>
         </CardHeader>
         <CardContent>
-          <ul className="space-y-1.5 text-sm text-muted-foreground">
+          <ul className="space-y-2.5 text-sm">
             {result.improvements.map((s, i) => (
-              <li key={i}>• {s}</li>
+              <li key={i} className="flex items-start gap-2.5">
+                <Target className="h-4 w-4 text-amber-400 mt-0.5 shrink-0" />
+                <span className="text-muted-foreground">{s}</span>
+              </li>
             ))}
           </ul>
         </CardContent>

--- a/src/components/analyze/timeline-view.tsx
+++ b/src/components/analyze/timeline-view.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Play, Pause } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type {
+  VideoPatternIdentified,
+  VideoScoreResult,
+} from "@/lib/wcs-api";
+
+type TimelineViewProps = {
+  result: VideoScoreResult;
+  duration: number;
+  videoSrc?: string | null;
+};
+
+const QUALITY_COLOR: Record<string, string> = {
+  strong: "bg-emerald-500/70 border-emerald-400/80 text-emerald-50",
+  solid: "bg-primary/70 border-primary/80 text-primary-foreground",
+  needs_work: "bg-amber-500/70 border-amber-400/80 text-amber-50",
+  weak: "bg-rose-500/70 border-rose-400/80 text-rose-50",
+};
+
+const DEFAULT_COLOR =
+  "bg-muted-foreground/40 border-muted-foreground/60 text-foreground";
+
+function colorForQuality(quality?: string): string {
+  if (!quality) return DEFAULT_COLOR;
+  return QUALITY_COLOR[quality] ?? DEFAULT_COLOR;
+}
+
+function parseTimestamp(raw: string | undefined): number | null {
+  if (!raw) return null;
+  const s = raw.trim();
+  // Handle "0:23", "0:23.5", "23s", "23.5"
+  if (s.includes(":")) {
+    const parts = s.split(":").map((p) => parseFloat(p));
+    if (parts.some(Number.isNaN)) return null;
+    if (parts.length === 2) return parts[0] * 60 + parts[1];
+    if (parts.length === 3) return parts[0] * 3600 + parts[1] * 60 + parts[2];
+    return null;
+  }
+  const n = parseFloat(s.replace(/s$/, ""));
+  return Number.isFinite(n) ? n : null;
+}
+
+function formatTime(sec: number): string {
+  if (!Number.isFinite(sec) || sec < 0) return "0:00";
+  const m = Math.floor(sec / 60);
+  const s = Math.floor(sec % 60);
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
+export function TimelineView({
+  result,
+  duration,
+  videoSrc,
+}: TimelineViewProps) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [playing, setPlaying] = useState(false);
+  const [hovered, setHovered] = useState<VideoPatternIdentified | null>(null);
+
+  const effectiveDuration = useMemo(() => {
+    if (duration > 0) return duration;
+    const fromPatterns = (result.patterns_identified ?? []).reduce(
+      (m, p) => Math.max(m, p.end_time ?? 0),
+      0
+    );
+    return Math.max(fromPatterns, 1);
+  }, [duration, result.patterns_identified]);
+
+  useEffect(() => {
+    const v = videoRef.current;
+    if (!v) return;
+    const onTime = () => setCurrentTime(v.currentTime);
+    const onPlay = () => setPlaying(true);
+    const onPause = () => setPlaying(false);
+    v.addEventListener("timeupdate", onTime);
+    v.addEventListener("play", onPlay);
+    v.addEventListener("pause", onPause);
+    return () => {
+      v.removeEventListener("timeupdate", onTime);
+      v.removeEventListener("play", onPlay);
+      v.removeEventListener("pause", onPause);
+    };
+  }, [videoSrc]);
+
+  const seek = (t: number) => {
+    setCurrentTime(t);
+    const v = videoRef.current;
+    if (v) {
+      v.currentTime = t;
+      if (!playing) {
+        v.play().catch(() => {
+          /* user gesture required */
+        });
+      }
+    }
+  };
+
+  const togglePlay = () => {
+    const v = videoRef.current;
+    if (!v) return;
+    if (v.paused) {
+      v.play();
+    } else {
+      v.pause();
+    }
+  };
+
+  const patterns = result.patterns_identified ?? [];
+  const offBeats = (result.categories.timing?.off_beat_moments ?? [])
+    .map((m) => ({ ...m, t: parseTimestamp(m.timestamp_approx) }))
+    .filter((m): m is typeof m & { t: number } => m.t !== null);
+
+  return (
+    <div className="space-y-3">
+      {videoSrc && (
+        <video
+          ref={videoRef}
+          src={videoSrc}
+          controls
+          preload="metadata"
+          className="w-full rounded-md bg-black"
+        />
+      )}
+
+      {/* Pattern timeline */}
+      <div className="space-y-1.5">
+        <div className="flex items-center justify-between text-xs text-muted-foreground">
+          <span className="font-medium uppercase tracking-wide">
+            Pattern timeline
+          </span>
+          <span className="font-mono tabular-nums">
+            {formatTime(currentTime)} / {formatTime(effectiveDuration)}
+          </span>
+        </div>
+
+        <div
+          className="relative h-12 rounded-md bg-muted/30 overflow-hidden border border-border"
+          role="region"
+          aria-label="Pattern timeline"
+        >
+          {patterns.map((p, i) => {
+            const start = p.start_time ?? 0;
+            const end = p.end_time ?? start;
+            const left = (start / effectiveDuration) * 100;
+            const width = Math.max(
+              0.8,
+              ((end - start) / effectiveDuration) * 100
+            );
+            return (
+              <button
+                key={`${i}-${p.name}`}
+                type="button"
+                className={cn(
+                  "absolute h-full border-r border-background/40 flex items-center justify-start px-1 text-[10px] font-medium overflow-hidden whitespace-nowrap transition-opacity",
+                  colorForQuality(p.quality),
+                  hovered === p ? "opacity-100" : "opacity-90 hover:opacity-100"
+                )}
+                style={{ left: `${left}%`, width: `${width}%` }}
+                onClick={() => seek(start)}
+                onMouseEnter={() => setHovered(p)}
+                onMouseLeave={() => setHovered(null)}
+                title={`${p.name} — ${p.quality ?? "?"} · ${p.timing ?? "?"} · ${formatTime(start)}-${formatTime(end)}`}
+              >
+                {p.name}
+              </button>
+            );
+          })}
+
+          {/* Off-beat markers */}
+          {offBeats.map((m, i) => (
+            <div
+              key={`ob-${i}`}
+              className="absolute top-0 h-full w-0.5 bg-rose-500 pointer-events-none"
+              style={{ left: `${(m.t / effectiveDuration) * 100}%` }}
+              title={`Off-beat at ${formatTime(m.t)}: ${m.description ?? ""}`}
+            />
+          ))}
+
+          {/* Playhead */}
+          <div
+            className="absolute top-0 h-full w-0.5 bg-foreground pointer-events-none"
+            style={{
+              left: `${Math.min(100, (currentTime / effectiveDuration) * 100)}%`,
+            }}
+          />
+        </div>
+
+        {/* Legend */}
+        <div className="flex flex-wrap items-center gap-3 text-[10px] text-muted-foreground pt-1">
+          <span className="flex items-center gap-1.5">
+            <span className="inline-block h-2 w-3 rounded-sm bg-emerald-500/70" />
+            strong
+          </span>
+          <span className="flex items-center gap-1.5">
+            <span className="inline-block h-2 w-3 rounded-sm bg-primary/70" />
+            solid
+          </span>
+          <span className="flex items-center gap-1.5">
+            <span className="inline-block h-2 w-3 rounded-sm bg-amber-500/70" />
+            needs work
+          </span>
+          <span className="flex items-center gap-1.5">
+            <span className="inline-block h-2 w-3 rounded-sm bg-rose-500/70" />
+            weak / off-beat
+          </span>
+        </div>
+
+        {/* Hovered pattern detail */}
+        {hovered && (
+          <div className="rounded-md border border-border bg-muted/20 p-2 text-xs">
+            <div className="flex items-baseline justify-between gap-3">
+              <span className="font-semibold text-foreground">
+                {hovered.name}
+              </span>
+              <span className="text-muted-foreground font-mono tabular-nums">
+                {formatTime(hovered.start_time ?? 0)} →{" "}
+                {formatTime(hovered.end_time ?? 0)}
+              </span>
+            </div>
+            <div className="text-muted-foreground mt-1">
+              {hovered.quality ?? "—"} · {hovered.timing ?? "—"}
+              {hovered.notes && (
+                <span className="block mt-1 whitespace-pre-wrap">
+                  {hovered.notes}
+                </span>
+              )}
+            </div>
+          </div>
+        )}
+
+        {videoSrc && (
+          <button
+            type="button"
+            onClick={togglePlay}
+            className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+          >
+            {playing ? (
+              <Pause className="h-3 w-3" />
+            ) : (
+              <Play className="h-3 w-3" />
+            )}
+            {playing ? "Pause" : "Play"}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/use-analysis-history.ts
+++ b/src/hooks/use-analysis-history.ts
@@ -11,6 +11,10 @@ export type AnalysisRecord = {
   duration: number | null;
   result: VideoScoreResult;
   object_key: string | null;
+  role: string | null;
+  competition_level: string | null;
+  event_name: string | null;
+  tags: string[] | null;
   created_at: string;
 };
 
@@ -29,7 +33,9 @@ export function useAnalysisHistory() {
     const sb = getSupabase();
     const { data } = await sb
       .from("video_analyses")
-      .select("id, filename, duration, result, object_key, created_at")
+      .select(
+        "id, filename, duration, result, object_key, role, competition_level, event_name, tags, created_at"
+      )
       .order("created_at", { ascending: false })
       .limit(20);
     setRecords((data as AnalysisRecord[]) ?? []);

--- a/src/hooks/use-analysis-history.ts
+++ b/src/hooks/use-analysis-history.ts
@@ -10,6 +10,7 @@ export type AnalysisRecord = {
   filename: string | null;
   duration: number | null;
   result: VideoScoreResult;
+  object_key: string | null;
   created_at: string;
 };
 
@@ -28,7 +29,7 @@ export function useAnalysisHistory() {
     const sb = getSupabase();
     const { data } = await sb
       .from("video_analyses")
-      .select("id, filename, duration, result, created_at")
+      .select("id, filename, duration, result, object_key, created_at")
       .order("created_at", { ascending: false })
       .limit(20);
     setRecords((data as AnalysisRecord[]) ?? []);

--- a/src/hooks/use-video-analysis.ts
+++ b/src/hooks/use-video-analysis.ts
@@ -8,6 +8,7 @@ import {
   isWcsApiConfigured,
   uploadToPresignedUrl,
   type VideoAnalysisResponse,
+  type VideoAnalyzeOptions,
   type VideoQuota,
 } from "@/lib/wcs-api";
 
@@ -61,7 +62,7 @@ export function useVideoAnalysis() {
   }, [refreshQuota]);
 
   const analyze = useCallback(
-    async (file: File) => {
+    async (file: File, options: VideoAnalyzeOptions = {}) => {
       if (!isWcsApiConfigured) {
         setState({
           ...INITIAL,
@@ -72,18 +73,19 @@ export function useVideoAnalysis() {
       }
       setState({ ...INITIAL, status: "uploading" });
       try {
-        // 1) Get a presigned PUT URL scoped to this user.
         const { uploadUrl, objectKey } = await getPresignedUploadUrl(
           file.name,
           file.type || "application/octet-stream"
         );
-        // 2) Upload straight to R2 (bypasses Railway's proxy body limit).
         await uploadToPresignedUrl(uploadUrl, file, (percent) => {
           setState((s) => ({ ...s, uploadProgress: percent }));
         });
-        // 3) Kick off analysis on the stored object.
         setState((s) => ({ ...s, status: "analyzing", uploadProgress: 100 }));
-        const result = await analyzeVideoFromKey(objectKey, file.name);
+        const result = await analyzeVideoFromKey(
+          objectKey,
+          file.name,
+          options
+        );
         setState({
           status: "success",
           result,

--- a/src/lib/wcs-api.ts
+++ b/src/lib/wcs-api.ts
@@ -310,13 +310,25 @@ export function uploadToPresignedUrl(
   });
 }
 
+export type VideoAnalyzeOptions = {
+  role?: string;
+  competitionLevel?: string;
+  eventName?: string;
+  tags?: string[];
+};
+
 export async function analyzeVideoFromKey(
   objectKey: string,
-  filename: string
+  filename: string,
+  options: VideoAnalyzeOptions = {}
 ): Promise<VideoAnalysisResponse> {
   return postJson<VideoAnalysisResponse>("/analyze/video", {
     object_key: objectKey,
     filename,
+    role: options.role || null,
+    competition_level: options.competitionLevel || null,
+    event_name: options.eventName || null,
+    tags: options.tags && options.tags.length ? options.tags : null,
   });
 }
 

--- a/src/lib/wcs-api.ts
+++ b/src/lib/wcs-api.ts
@@ -319,3 +319,16 @@ export async function analyzeVideoFromKey(
     filename,
   });
 }
+
+export async function getViewUrl(objectKey: string): Promise<string> {
+  const data = await postJson<{ url: string }>("/uploads/view", {
+    object_key: objectKey,
+  });
+  return data.url;
+}
+
+export async function deleteUploadedVideo(objectKey: string): Promise<void> {
+  await postJson<{ ok: boolean }>("/uploads/delete", {
+    object_key: objectKey,
+  });
+}


### PR DESCRIPTION
Bundle of improvements:

- **Gemini 3 Pro preview** as the default model (Railway env var already set). Extended thinking noticeably sharpens rubric reasoning.
- **Delete R2 object after analysis** — privacy-first, storage-light. `object_key` saved as NULL so Watch/Re-analyze UI stays hidden for fresh runs. 24h lifecycle rule is the backstop for orphans.
- **Librosa beat-context prompt injection** — extracts audio via ffmpeg, runs `librosa.beat.beat_track`, prepends BPM + first beats to the Gemini prompt. The last major feature from wcs-analyzer.
- **Tags + competition metadata** — role, level, event, free-form tags saved per analysis and shown as badges in history.
- **Timeline component** — horizontal strip of patterns_identified, quality-colored blocks, off-beat tick markers, click-to-seek when inline video is present, synced playhead.
- **UX polish** — bigger score hero, overall_impression quoted under the score, icons on strengths (green) / improvements (amber), paywall moves below the result when both visible, pre-upload tags form.
