### PR TITLE
Per-user video quota overrides

### DIFF
--- a/api/src/wcs_api/services/quota.py
+++ b/api/src/wcs_api/services/quota.py
@@ -33,6 +33,7 @@ async def get_video_quota_status(user_id: str) -> VideoQuotaStatus:
         since_iso=_start_of_month_iso(),
     )
 
+    # Plan defaults
     if plan == "basic":
         limit = settings.basic_monthly_video
         max_seconds = settings.basic_max_video_seconds
@@ -40,6 +41,17 @@ async def get_video_quota_status(user_id: str) -> VideoQuotaStatus:
         plan = "free"
         limit = settings.free_monthly_video
         max_seconds = settings.free_max_video_seconds
+
+    # Per-user overrides on the profiles row take priority. Set these
+    # via the Supabase Table Editor to grant extra quota or longer
+    # clips to specific users (beta testers, contest winners, refunds).
+    if profile:
+        override_limit = profile.get("monthly_video_override")
+        override_seconds = profile.get("max_video_seconds_override")
+        if isinstance(override_limit, int) and override_limit >= 0:
+            limit = override_limit
+        if isinstance(override_seconds, int) and override_seconds > 0:
+            max_seconds = override_seconds
 
     return VideoQuotaStatus(
         plan=plan,

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -6,12 +6,14 @@
 -- ────────────────────────────────────────────────────────────
 
 create table if not exists public.profiles (
-  id                 uuid primary key references auth.users(id) on delete cascade,
-  email              text,
-  plan               text not null default 'free' check (plan in ('free', 'basic')),
-  stripe_customer_id text unique,
-  created_at         timestamptz not null default now(),
-  updated_at         timestamptz not null default now()
+  id                          uuid primary key references auth.users(id) on delete cascade,
+  email                       text,
+  plan                        text not null default 'free' check (plan in ('free', 'basic')),
+  stripe_customer_id          text unique,
+  monthly_video_override      int,    -- per-user override; NULL = plan default
+  max_video_seconds_override  int,    -- per-user override; NULL = plan default
+  created_at                  timestamptz not null default now(),
+  updated_at                  timestamptz not null default now()
 );
 
 -- Migration: older versions used 'pro' as the paid tier name. Rename to


### PR DESCRIPTION
Adds monthly_video_override + max_video_seconds_override on profiles, applied with priority over plan defaults in quota.py. Edit via Supabase Table Editor.