### PR TITLE
Refocus dashboard on analysis + rhythm

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -1,236 +1,309 @@
 "use client";
 
+import { useMemo } from "react";
 import Link from "next/link";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Progress } from "@/components/ui/progress";
+import { Badge } from "@/components/ui/badge";
 import { useAppStore } from "@/components/store-provider";
-import { patterns } from "@/data";
+import { useAnalysisHistory } from "@/hooks/use-analysis-history";
 import {
-  Brain,
-  Library,
-  Timer,
+  Video,
+  Music,
   Flame,
-  Trophy,
   Clock,
-  CheckCircle2,
+  TrendingUp,
+  Target,
   ArrowRight,
+  Sparkles,
 } from "lucide-react";
 
-const totalPatterns = patterns.length;
-const totalChecklist = patterns.length * 16;
+function formatRelative(iso: string): string {
+  const now = Date.now();
+  const then = new Date(iso).getTime();
+  const diff = Math.max(0, now - then);
+  const minutes = Math.floor(diff / 60_000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Date(iso).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+  });
+}
 
 export default function DashboardPage() {
   const { getStats, loaded } = useAppStore();
+  const history = useAnalysisHistory();
 
-  if (!loaded) {
-    return (
-      <div className="flex items-center justify-center h-64">
-        <div className="animate-pulse text-muted-foreground">Loading...</div>
-      </div>
-    );
-  }
+  const stats = loaded ? getStats() : null;
 
-  const stats = getStats();
-  const checklistPercent =
-    totalChecklist > 0
-      ? Math.round((stats.completedChecklist / totalChecklist) * 100)
-      : 0;
+  const analysisStats = useMemo(() => {
+    const recs = history.records;
+    if (!recs.length) {
+      return { total: 0, avg: null as number | null, best: null as number | null };
+    }
+    const scores = recs
+      .map((r) => r.result?.overall?.score)
+      .filter((s): s is number => typeof s === "number" && !Number.isNaN(s));
+    const total = recs.length;
+    const avg =
+      scores.length > 0
+        ? scores.reduce((a, b) => a + b, 0) / scores.length
+        : null;
+    const best = scores.length > 0 ? Math.max(...scores) : null;
+    return { total, avg, best };
+  }, [history.records]);
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 max-w-5xl mx-auto">
       <div>
         <h1 className="text-2xl font-bold">Dashboard</h1>
-        <p className="text-muted-foreground">Your daily practice hub</p>
+        <p className="text-muted-foreground">
+          Your WCS practice at a glance
+        </p>
       </div>
 
-      {/* Quick Actions */}
-      {stats.reviewsDue > 0 && (
-        <Card className="border-primary/30 bg-primary/5">
-          <CardContent className="flex items-center justify-between py-4">
-            <div className="flex items-center gap-3">
-              <div className="h-10 w-10 rounded-full bg-primary/15 flex items-center justify-center">
-                <Brain className="h-5 w-5 text-primary" />
+      {/* ─── Hero actions ─── */}
+      <div className="grid gap-4 sm:grid-cols-2">
+        <Link href="/analyze" className="group">
+          <Card className="border-primary/30 bg-gradient-to-br from-card to-primary/5 h-full hover:border-primary/60 transition-colors">
+            <CardContent className="p-5 space-y-3">
+              <div className="flex items-center justify-between">
+                <div className="h-10 w-10 rounded-xl bg-primary/15 flex items-center justify-center">
+                  <Video className="h-5 w-5 text-primary" />
+                </div>
+                <ArrowRight className="h-4 w-4 text-muted-foreground group-hover:translate-x-0.5 group-hover:text-foreground transition-all" />
               </div>
               <div>
-                <p className="font-medium">
-                  {stats.reviewsDue} pattern
-                  {stats.reviewsDue !== 1 ? "s" : ""} due for review
-                </p>
-                <p className="text-sm text-muted-foreground">
-                  Keep your skills sharp with spaced repetition
+                <h3 className="font-semibold">Analyze a video</h3>
+                <p className="text-sm text-muted-foreground mt-0.5">
+                  Upload a dance clip. Get WSDC-style scoring across timing,
+                  technique, teamwork, and presentation.
                 </p>
               </div>
-            </div>
-            <Button asChild>
-              <Link href="/review">
-                Review Now
-                <ArrowRight className="ml-2 h-4 w-4" />
-              </Link>
-            </Button>
-          </CardContent>
-        </Card>
-      )}
+            </CardContent>
+          </Card>
+        </Link>
 
-      {/* Stats Grid */}
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">
-              Current Streak
-            </CardTitle>
-            <Flame className="h-4 w-4 text-orange-400" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-3xl font-bold">
-              {stats.streak.currentStreak}
-            </div>
-            <p className="text-xs text-muted-foreground">
-              day{stats.streak.currentStreak !== 1 ? "s" : ""} &middot; Best:{" "}
-              {stats.streak.longestStreak}
-            </p>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">
-              Patterns Learned
-            </CardTitle>
-            <Library className="h-4 w-4 text-primary" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-3xl font-bold">
-              {stats.totalReviews}
-              <span className="text-lg text-muted-foreground font-normal">
-                /{totalPatterns}
-              </span>
-            </div>
-            <p className="text-xs text-muted-foreground">
-              in your review deck
-            </p>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">
-              Total Reviews
-            </CardTitle>
-            <Brain className="h-4 w-4 text-violet-400" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-3xl font-bold">{stats.totalReviewLogs}</div>
-            <p className="text-xs text-muted-foreground">
-              flashcard interactions
-            </p>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">
-              Practice Time
-            </CardTitle>
-            <Clock className="h-4 w-4 text-emerald-400" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-3xl font-bold">
-              {stats.totalPracticeMinutes}
-              <span className="text-lg text-muted-foreground font-normal">
-                min
-              </span>
-            </div>
-            <p className="text-xs text-muted-foreground">
-              across {stats.streak.totalPracticeDays} day
-              {stats.streak.totalPracticeDays !== 1 ? "s" : ""}
-            </p>
-          </CardContent>
-        </Card>
+        <Link href="/rhythm" className="group">
+          <Card className="border-border hover:border-primary/60 h-full transition-colors">
+            <CardContent className="p-5 space-y-3">
+              <div className="flex items-center justify-between">
+                <div className="h-10 w-10 rounded-xl bg-violet-500/15 flex items-center justify-center">
+                  <Music className="h-5 w-5 text-violet-400" />
+                </div>
+                <ArrowRight className="h-4 w-4 text-muted-foreground group-hover:translate-x-0.5 group-hover:text-foreground transition-all" />
+              </div>
+              <div>
+                <h3 className="font-semibold">Rhythm trainer</h3>
+                <p className="text-sm text-muted-foreground mt-0.5">
+                  Drop in a song to see every anchor. Tap along, drill
+                  subdivisions, ramp tempo.
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+        </Link>
       </div>
 
-      <div className="grid gap-4 sm:grid-cols-2">
-        {/* Checklist Progress */}
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between pb-2">
-            <CardTitle className="text-sm font-medium">
-              Technique Checklist
-            </CardTitle>
-            <CheckCircle2 className="h-4 w-4 text-primary" />
+      {/* ─── Stats ─── */}
+      <div className="grid gap-4 grid-cols-2 lg:grid-cols-4">
+        <StatCard
+          icon={<Video className="h-4 w-4 text-primary" />}
+          label="Videos analyzed"
+          value={analysisStats.total.toString()}
+          hint={
+            analysisStats.total
+              ? `last ${Math.min(analysisStats.total, 20)}`
+              : "upload your first clip"
+          }
+        />
+        <StatCard
+          icon={<TrendingUp className="h-4 w-4 text-emerald-400" />}
+          label="Average score"
+          value={
+            analysisStats.avg !== null
+              ? analysisStats.avg.toFixed(1)
+              : "—"
+          }
+          hint={
+            analysisStats.avg !== null
+              ? "out of 10 across analyses"
+              : "needs at least one analysis"
+          }
+        />
+        <StatCard
+          icon={<Target className="h-4 w-4 text-amber-400" />}
+          label="Best score"
+          value={
+            analysisStats.best !== null
+              ? analysisStats.best.toFixed(1)
+              : "—"
+          }
+          hint={
+            analysisStats.best !== null
+              ? "your personal best"
+              : "room for greatness"
+          }
+        />
+        <StatCard
+          icon={<Flame className="h-4 w-4 text-orange-400" />}
+          label="Practice streak"
+          value={stats ? String(stats.streak.currentStreak) : "—"}
+          hint={
+            stats
+              ? `days · best ${stats.streak.longestStreak}`
+              : ""
+          }
+        />
+      </div>
+
+      {/* ─── Recent analyses ─── */}
+      <div className="grid gap-4 lg:grid-cols-3">
+        <Card className="lg:col-span-2">
+          <CardHeader className="flex flex-row items-center justify-between">
+            <CardTitle className="text-base">Recent analyses</CardTitle>
+            {history.records.length > 0 && (
+              <Link
+                href="/analyze"
+                className="text-xs text-muted-foreground hover:text-foreground"
+              >
+                View all →
+              </Link>
+            )}
           </CardHeader>
           <CardContent>
-            <div className="flex items-center justify-between mb-2">
-              <span className="text-2xl font-bold">{checklistPercent}%</span>
-              <span className="text-sm text-muted-foreground">
-                {stats.completedChecklist}/{totalChecklist}
-              </span>
-            </div>
-            <Progress value={checklistPercent} className="h-2" />
+            {history.loading ? (
+              <p className="text-sm text-muted-foreground">Loading…</p>
+            ) : history.records.length === 0 ? (
+              <div className="text-center py-6 space-y-3">
+                <Sparkles className="h-8 w-8 text-muted-foreground/50 mx-auto" />
+                <div className="text-sm text-muted-foreground">
+                  No analyses yet. Upload your first dance clip to get
+                  scored.
+                </div>
+                <Button asChild size="sm">
+                  <Link href="/analyze">
+                    <Video className="mr-2 h-4 w-4" />
+                    Analyze a video
+                  </Link>
+                </Button>
+              </div>
+            ) : (
+              <div className="space-y-2">
+                {history.records.slice(0, 5).map((rec) => {
+                  const overall = rec.result?.overall;
+                  return (
+                    <Link
+                      key={rec.id}
+                      href="/analyze"
+                      className="flex items-center justify-between rounded-md border border-border p-2.5 text-sm hover:bg-muted/30 transition-colors"
+                    >
+                      <div className="min-w-0 flex-1">
+                        <p className="font-medium truncate">
+                          {rec.filename || "Untitled"}
+                        </p>
+                        <div className="flex items-center gap-1.5 text-xs text-muted-foreground mt-0.5">
+                          <span>{formatRelative(rec.created_at)}</span>
+                          {rec.event_name && (
+                            <>
+                              <span>·</span>
+                              <span className="truncate">{rec.event_name}</span>
+                            </>
+                          )}
+                          {rec.role && (
+                            <Badge
+                              variant="outline"
+                              className="text-[9px] px-1.5 py-0 h-4"
+                            >
+                              {rec.role}
+                            </Badge>
+                          )}
+                        </div>
+                      </div>
+                      {overall && (
+                        <div className="flex items-center gap-2 shrink-0 ml-3">
+                          <span className="font-mono font-bold tabular-nums">
+                            {overall.score?.toFixed?.(1) ?? "—"}
+                          </span>
+                          <Badge variant="secondary" className="text-xs">
+                            {overall.grade ?? "—"}
+                          </Badge>
+                        </div>
+                      )}
+                    </Link>
+                  );
+                })}
+              </div>
+            )}
           </CardContent>
         </Card>
 
-        {/* Quick Actions */}
+        {/* Practice sidebar */}
         <Card>
           <CardHeader>
-            <CardTitle className="text-sm font-medium">Quick Actions</CardTitle>
+            <CardTitle className="text-base flex items-center gap-2">
+              <Clock className="h-4 w-4 text-emerald-400" />
+              Practice
+            </CardTitle>
           </CardHeader>
-          <CardContent className="space-y-2">
-            <Button asChild variant="outline" className="w-full justify-start">
-              <Link href="/patterns">
-                <Library className="mr-2 h-4 w-4" />
-                Browse Patterns
-              </Link>
-            </Button>
-            <Button asChild variant="outline" className="w-full justify-start">
+          <CardContent className="space-y-4">
+            <div>
+              <p className="text-3xl font-bold tabular-nums">
+                {stats?.totalPracticeMinutes ?? 0}
+                <span className="text-base font-normal text-muted-foreground ml-1">
+                  min
+                </span>
+              </p>
+              <p className="text-xs text-muted-foreground">
+                across {stats?.streak.totalPracticeDays ?? 0} day
+                {(stats?.streak.totalPracticeDays ?? 0) !== 1 ? "s" : ""}
+              </p>
+            </div>
+            <Button asChild variant="outline" size="sm" className="w-full">
               <Link href="/practice">
-                <Timer className="mr-2 h-4 w-4" />
-                Start Practice
+                Start a practice session
               </Link>
             </Button>
-            <Button asChild variant="outline" className="w-full justify-start">
-              <Link href="/review">
-                <Brain className="mr-2 h-4 w-4" />
-                Review Session
+            <Button asChild variant="ghost" size="sm" className="w-full">
+              <Link href="/rhythm">
+                Jump to rhythm trainer
               </Link>
             </Button>
           </CardContent>
         </Card>
       </div>
-
-      {/* Recent Sessions */}
-      {stats.recentSessions.length > 0 && (
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between">
-            <CardTitle className="text-sm font-medium">
-              Recent Practice
-            </CardTitle>
-            <Trophy className="h-4 w-4 text-amber-400" />
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-3">
-              {stats.recentSessions.map((session) => (
-                <div
-                  key={session.id}
-                  className="flex items-center justify-between text-sm"
-                >
-                  <span className="text-muted-foreground">
-                    {session.routineType
-                      .replace("warmup-", "")
-                      .replace("free", "Free")}
-                    min routine
-                  </span>
-                  <div className="flex items-center gap-3">
-                    <span>{Math.round(session.duration / 60)} min</span>
-                    <span className="text-xs text-muted-foreground">
-                      {new Date(session.createdAt).toLocaleDateString()}
-                    </span>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </CardContent>
-        </Card>
-      )}
     </div>
+  );
+}
+
+function StatCard({
+  icon,
+  label,
+  value,
+  hint,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+  hint: string;
+}) {
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between pb-2">
+        <CardTitle className="text-sm font-medium text-muted-foreground">
+          {label}
+        </CardTitle>
+        {icon}
+      </CardHeader>
+      <CardContent>
+        <div className="text-3xl font-bold tabular-nums">{value}</div>
+        <p className="text-xs text-muted-foreground mt-0.5">{hint}</p>
+      </CardContent>
+    </Card>
   );
 }


### PR DESCRIPTION
Dashboard now leads with two CTA cards (Analyze, Rhythm), shows analysis stats (count / avg / best / streak), a Recent analyses feed, and a compact Practice sidebar. Drops spaced-repetition and pattern-drill cards.