### PR TITLE
Add 'stage' to optional analysis metadata

### DIFF
--- a/api/src/wcs_api/routes/video.py
+++ b/api/src/wcs_api/routes/video.py
@@ -22,6 +22,7 @@ class VideoAnalyzeBody(BaseModel):
     role: str | None = None
     competition_level: str | None = None
     event_name: str | None = None
+    stage: str | None = None
     tags: list[str] | None = None
 
 
@@ -149,6 +150,7 @@ async def analyze_video_endpoint(
                 role=body.role,
                 competition_level=body.competition_level,
                 event_name=body.event_name,
+                stage=body.stage,
                 tags=body.tags,
             )
         except Exception:

--- a/api/src/wcs_api/services/supabase_admin.py
+++ b/api/src/wcs_api/services/supabase_admin.py
@@ -79,6 +79,7 @@ async def insert_video_analysis(
     role: str | None = None,
     competition_level: str | None = None,
     event_name: str | None = None,
+    stage: str | None = None,
     tags: list[str] | None = None,
 ) -> None:
     record: dict[str, Any] = {
@@ -94,6 +95,8 @@ async def insert_video_analysis(
         record["competition_level"] = competition_level
     if event_name:
         record["event_name"] = event_name
+    if stage:
+        record["stage"] = stage
     if tags:
         record["tags"] = tags
 

--- a/src/app/(app)/analyze/page.tsx
+++ b/src/app/(app)/analyze/page.tsx
@@ -72,6 +72,7 @@ export default function AnalyzePage() {
   const [role, setRole] = useState("");
   const [competitionLevel, setCompetitionLevel] = useState("");
   const [eventName, setEventName] = useState("");
+  const [stage, setStage] = useState("");
   const [tagsInput, setTagsInput] = useState("");
 
   const handleFileChange = useCallback(
@@ -129,9 +130,10 @@ export default function AnalyzePage() {
       role: role.trim() || undefined,
       competitionLevel: competitionLevel.trim() || undefined,
       eventName: eventName.trim() || undefined,
+      stage: stage.trim() || undefined,
       tags: tags.length ? tags : undefined,
     }).then(() => history.refresh());
-  }, [file, analyze, history, role, competitionLevel, eventName, tagsInput]);
+  }, [file, analyze, history, role, competitionLevel, eventName, stage, tagsInput]);
 
   const handleClear = useCallback(() => {
     setFile(null);
@@ -299,17 +301,31 @@ export default function AnalyzePage() {
                     />
                   </div>
                 </div>
-                <div className="space-y-1">
-                  <Label htmlFor="event" className="text-xs">
-                    Event
-                  </Label>
-                  <Input
-                    id="event"
-                    placeholder="Boogie by the Bay 2026 J&J"
-                    value={eventName}
-                    onChange={(e) => setEventName(e.target.value)}
-                    className="h-8 text-sm"
-                  />
+                <div className="grid grid-cols-2 gap-2.5">
+                  <div className="space-y-1">
+                    <Label htmlFor="event" className="text-xs">
+                      Event
+                    </Label>
+                    <Input
+                      id="event"
+                      placeholder="Boogie by the Bay 2026 J&J"
+                      value={eventName}
+                      onChange={(e) => setEventName(e.target.value)}
+                      className="h-8 text-sm"
+                    />
+                  </div>
+                  <div className="space-y-1">
+                    <Label htmlFor="stage" className="text-xs">
+                      Stage
+                    </Label>
+                    <Input
+                      id="stage"
+                      placeholder="prelims, quarters, semis, finals…"
+                      value={stage}
+                      onChange={(e) => setStage(e.target.value)}
+                      className="h-8 text-sm"
+                    />
+                  </div>
                 </div>
                 <div className="space-y-1">
                   <Label htmlFor="tags" className="text-xs">
@@ -584,6 +600,11 @@ function HistoryRow({
             {record.event_name && (
               <Badge variant="outline" className="text-[9px] px-1.5 py-0 h-4">
                 {record.event_name}
+              </Badge>
+            )}
+            {record.stage && (
+              <Badge variant="outline" className="text-[9px] px-1.5 py-0 h-4">
+                {record.stage}
               </Badge>
             )}
             {(record.tags ?? []).slice(0, 4).map((t) => (

--- a/src/hooks/use-analysis-history.ts
+++ b/src/hooks/use-analysis-history.ts
@@ -14,6 +14,7 @@ export type AnalysisRecord = {
   role: string | null;
   competition_level: string | null;
   event_name: string | null;
+  stage: string | null;
   tags: string[] | null;
   created_at: string;
 };
@@ -34,7 +35,7 @@ export function useAnalysisHistory() {
     const { data } = await sb
       .from("video_analyses")
       .select(
-        "id, filename, duration, result, object_key, role, competition_level, event_name, tags, created_at"
+        "id, filename, duration, result, object_key, role, competition_level, event_name, stage, tags, created_at"
       )
       .order("created_at", { ascending: false })
       .limit(20);

--- a/src/lib/wcs-api.ts
+++ b/src/lib/wcs-api.ts
@@ -314,6 +314,7 @@ export type VideoAnalyzeOptions = {
   role?: string;
   competitionLevel?: string;
   eventName?: string;
+  stage?: string;
   tags?: string[];
 };
 
@@ -328,6 +329,7 @@ export async function analyzeVideoFromKey(
     role: options.role || null,
     competition_level: options.competitionLevel || null,
     event_name: options.eventName || null,
+    stage: options.stage || null,
     tags: options.tags && options.tags.length ? options.tags : null,
   });
 }

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -85,12 +85,18 @@ create policy usage_events_self_select on public.usage_events
   for select using (auth.uid() = user_id);
 
 create table if not exists public.video_analyses (
-  id          uuid primary key default gen_random_uuid(),
-  user_id     uuid not null references public.profiles(id) on delete cascade,
-  filename    text,
-  duration    float,
-  result      jsonb not null,
-  created_at  timestamptz not null default now()
+  id                uuid primary key default gen_random_uuid(),
+  user_id           uuid not null references public.profiles(id) on delete cascade,
+  filename          text,
+  duration          float,
+  result            jsonb not null,
+  object_key        text,            -- R2 key while the source video is still in storage; NULL once deleted
+  role              text,            -- optional: lead / follow / solo
+  competition_level text,            -- optional: novice / intermediate / all-star / champion
+  event_name        text,            -- optional: "Boogie by the Bay 2026 J&J"
+  stage             text,            -- optional: prelims / quarters / semis / finals
+  tags              text[] default '{}',  -- optional free-form user tags
+  created_at        timestamptz not null default now()
 );
 create index if not exists video_analyses_user_idx
   on public.video_analyses(user_id, created_at desc);


### PR DESCRIPTION
Adds competition stage (prelims/quarters/semis/finals) as one more optional field alongside role, level, event, and tags.