### PR TITLE
Revert Gemini default to 2.5-flash + mobile polish pass

### DIFF
--- a/api/src/wcs_api/settings.py
+++ b/api/src/wcs_api/settings.py
@@ -19,7 +19,7 @@ class Settings(BaseSettings):
     stripe_price_id: str = ""
 
     gemini_api_key: str = ""
-    gemini_model: str = "gemini-3-pro-preview"
+    gemini_model: str = "gemini-2.5-flash"
     # When enabled, runs a dedicated Gemini call asking ONLY about the
     # pattern timeline, then injects the result as context into the
     # main scoring call. wcs-analyzer found this improves scoring

--- a/src/app/(app)/analyze/page.tsx
+++ b/src/app/(app)/analyze/page.tsx
@@ -225,7 +225,7 @@ export default function AnalyzePage() {
   const isPaywalled = quota && quota.remaining <= 0;
 
   return (
-    <div className="space-y-6 max-w-4xl mx-auto">
+    <div className="space-y-4 sm:space-y-6 max-w-4xl mx-auto">
       <div>
         <div className="flex items-center gap-2">
           <Video className="h-6 w-6 text-primary" />
@@ -787,7 +787,7 @@ function HistoryRow({
       </div>
       {expanded && (
         <div className="border-t border-border p-3 space-y-3">
-          <div className="flex items-center gap-2 flex-wrap">
+          <div className="flex items-center gap-1.5 flex-wrap">
             {canViewOrReanalyze && (
               <>
                 <Button
@@ -800,13 +800,16 @@ function HistoryRow({
                     deletingVideo ||
                     deletingAnalysis
                   }
+                  title={videoUrl ? "Reload video" : "Watch"}
                 >
                   {loadingVideo ? (
-                    <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
+                    <Loader2 className="h-3.5 w-3.5 animate-spin sm:mr-2" />
                   ) : (
-                    <Play className="mr-2 h-3.5 w-3.5" />
+                    <Play className="h-3.5 w-3.5 sm:mr-2" />
                   )}
-                  {videoUrl ? "Reload video" : "Watch"}
+                  <span className="hidden sm:inline">
+                    {videoUrl ? "Reload video" : "Watch"}
+                  </span>
                 </Button>
                 <Button
                   size="sm"
@@ -818,13 +821,14 @@ function HistoryRow({
                     deletingVideo ||
                     deletingAnalysis
                   }
+                  title="Re-analyze — uses 1 quota"
                 >
                   {reanalyzing ? (
-                    <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
+                    <Loader2 className="h-3.5 w-3.5 animate-spin sm:mr-2" />
                   ) : (
-                    <RotateCcw className="mr-2 h-3.5 w-3.5" />
+                    <RotateCcw className="h-3.5 w-3.5 sm:mr-2" />
                   )}
-                  Re-analyze (1 quota)
+                  <span className="hidden sm:inline">Re-analyze</span>
                 </Button>
                 <Button
                   size="sm"
@@ -837,13 +841,14 @@ function HistoryRow({
                     reanalyzing ||
                     loadingVideo
                   }
+                  title="Delete video file from storage"
                 >
                   {deletingVideo ? (
-                    <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
+                    <Loader2 className="h-3.5 w-3.5 animate-spin sm:mr-2" />
                   ) : (
-                    <Trash2 className="mr-2 h-3.5 w-3.5" />
+                    <Trash2 className="h-3.5 w-3.5 sm:mr-2" />
                   )}
-                  Delete video
+                  <span className="hidden sm:inline">Delete video</span>
                 </Button>
               </>
             )}
@@ -855,9 +860,10 @@ function HistoryRow({
                   variant="outline"
                   onClick={handleCopyShareLink}
                   disabled={sharing}
+                  title="Copy share link"
                 >
-                  <Copy className="mr-2 h-3.5 w-3.5" />
-                  Copy share link
+                  <Copy className="h-3.5 w-3.5 sm:mr-2" />
+                  <span className="hidden sm:inline">Copy link</span>
                 </Button>
                 <Button
                   size="sm"
@@ -865,13 +871,14 @@ function HistoryRow({
                   className="text-muted-foreground hover:text-destructive"
                   onClick={handleStopShare}
                   disabled={sharing}
+                  title="Stop sharing"
                 >
                   {sharing ? (
-                    <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
+                    <Loader2 className="h-3.5 w-3.5 animate-spin sm:mr-2" />
                   ) : (
-                    <Link2Off className="mr-2 h-3.5 w-3.5" />
+                    <Link2Off className="h-3.5 w-3.5 sm:mr-2" />
                   )}
-                  Stop sharing
+                  <span className="hidden sm:inline">Stop sharing</span>
                 </Button>
               </>
             ) : (
@@ -880,13 +887,14 @@ function HistoryRow({
                 variant="outline"
                 onClick={handleShare}
                 disabled={sharing}
+                title="Share this analysis via link"
               >
                 {sharing ? (
-                  <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
+                  <Loader2 className="h-3.5 w-3.5 animate-spin sm:mr-2" />
                 ) : (
-                  <Share2 className="mr-2 h-3.5 w-3.5" />
+                  <Share2 className="h-3.5 w-3.5 sm:mr-2" />
                 )}
-                Share link
+                <span className="hidden sm:inline">Share link</span>
               </Button>
             )}
 
@@ -896,13 +904,14 @@ function HistoryRow({
               className="text-muted-foreground hover:text-destructive ml-auto"
               onClick={handleDeleteAnalysis}
               disabled={deletingAnalysis || deletingVideo || reanalyzing}
+              title="Delete this analysis from history"
             >
               {deletingAnalysis ? (
-                <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
+                <Loader2 className="h-3.5 w-3.5 animate-spin sm:mr-2" />
               ) : (
-                <Trash2 className="mr-2 h-3.5 w-3.5" />
+                <Trash2 className="h-3.5 w-3.5 sm:mr-2" />
               )}
-              Delete analysis
+              <span className="hidden sm:inline">Delete analysis</span>
             </Button>
           </div>
 

--- a/src/app/(app)/billing/page.tsx
+++ b/src/app/(app)/billing/page.tsx
@@ -140,12 +140,12 @@ export default function BillingPage() {
       {!isBasic && (
         <Card className="border-primary/40">
           <CardHeader>
-            <CardTitle className="flex items-center justify-between">
+            <CardTitle className="flex items-start sm:items-center justify-between gap-3 flex-wrap sm:flex-nowrap">
               <span className="flex items-center gap-2">
-                <Sparkles className="h-5 w-5 text-primary" />
+                <Sparkles className="h-5 w-5 text-primary shrink-0" />
                 Upgrade to Basic
               </span>
-              <div className="flex items-baseline gap-1.5">
+              <div className="flex items-baseline gap-1.5 shrink-0">
                 <span className="text-base font-normal text-muted-foreground line-through">
                   $20
                 </span>
@@ -183,8 +183,10 @@ export default function BillingPage() {
               ) : (
                 <Sparkles className="mr-2 h-4 w-4" />
               )}
-              Upgrade to Basic — $10/mo
-              <span className="ml-2 text-xs opacity-70 line-through">$20</span>
+              <span className="truncate">Upgrade to Basic — $10/mo</span>
+              <span className="ml-2 text-xs opacity-70 line-through hidden sm:inline">
+                $20
+              </span>
             </Button>
           </CardContent>
         </Card>

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -59,7 +59,7 @@ export default function DashboardPage() {
   }, [history.records]);
 
   return (
-    <div className="space-y-6 max-w-5xl mx-auto">
+    <div className="space-y-4 sm:space-y-6 max-w-5xl mx-auto">
       <div>
         <h1 className="text-2xl font-bold">Dashboard</h1>
         <p className="text-muted-foreground">

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -14,7 +14,7 @@ export default function AppLayout({
         <SidebarNav />
         <div className="md:pl-64 flex flex-col min-h-screen">
           <Header />
-          <main className="flex-1 p-4 md:p-6 pb-20 md:pb-6">{children}</main>
+          <main className="flex-1 p-3 sm:p-4 md:p-6 pb-20 md:pb-6">{children}</main>
           <footer className="py-4 pb-20 md:pb-4 text-center text-xs text-muted-foreground">
             Created by{" "}
             <a

--- a/src/app/(app)/rhythm/page.tsx
+++ b/src/app/(app)/rhythm/page.tsx
@@ -311,7 +311,7 @@ export default function RhythmPage() {
       : { phraseIndex: -1, beatInPhrase: -1 };
 
   return (
-    <div className="space-y-6 max-w-2xl mx-auto">
+    <div className="space-y-4 sm:space-y-6 max-w-2xl mx-auto">
       {/* Header */}
       <div>
         <div className="flex items-center gap-2">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -46,17 +46,17 @@ export default function HomePage() {
         {/* ─── Hero ─── */}
         <section className="relative overflow-hidden">
           <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top,_var(--primary)/10,_transparent_60%)] pointer-events-none" />
-          <div className="container mx-auto px-4 pt-20 pb-16 sm:pt-28 sm:pb-20 relative">
-            <div className="max-w-3xl mx-auto text-center space-y-6">
+          <div className="container mx-auto px-4 pt-12 pb-12 sm:pt-28 sm:pb-20 relative">
+            <div className="max-w-3xl mx-auto text-center space-y-5 sm:space-y-6">
               <Badge variant="secondary" className="px-3 py-1 text-xs">
                 <Sparkles className="h-3 w-3 mr-1.5" />
                 Built for West Coast Swing dancers
               </Badge>
-              <h1 className="text-4xl sm:text-6xl font-bold tracking-tight">
+              <h1 className="text-3xl sm:text-6xl font-bold tracking-tight leading-tight">
                 See exactly where you&rsquo;re{" "}
                 <span className="text-primary">dancing off-beat</span>
               </h1>
-              <p className="text-lg sm:text-xl text-muted-foreground max-w-2xl mx-auto">
+              <p className="text-base sm:text-xl text-muted-foreground max-w-2xl mx-auto">
                 Upload a song and SwingFlow finds every anchor. Upload a dance
                 clip and you get WSDC-style scoring on timing, technique,
                 teamwork, and presentation — with the exact moments that need
@@ -86,13 +86,13 @@ export default function HomePage() {
           id="how-it-works"
           className="border-t border-border/60 bg-card/20"
         >
-          <div className="container mx-auto px-4 py-16 sm:py-24">
+          <div className="container mx-auto px-4 py-12 sm:py-24">
             <div className="text-center max-w-2xl mx-auto mb-12 space-y-3">
               <div className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-primary">
                 <Sparkles className="h-4 w-4" />
                 How it works
               </div>
-              <h2 className="text-3xl sm:text-4xl font-bold tracking-tight">
+              <h2 className="text-2xl sm:text-4xl font-bold tracking-tight">
                 From song to feedback in four steps
               </h2>
             </div>
@@ -126,14 +126,14 @@ export default function HomePage() {
         </section>
 
         {/* ─── Feature 1: Music analysis with the phrase-beat-grid mockup ─── */}
-        <section className="container mx-auto px-4 py-16 sm:py-24">
+        <section className="container mx-auto px-4 py-12 sm:py-24">
           <div className="grid lg:grid-cols-2 gap-10 items-center">
             <div className="space-y-5 order-2 lg:order-1">
               <div className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-primary">
                 <Music className="h-4 w-4" />
                 Precise music analysis
               </div>
-              <h2 className="text-3xl sm:text-4xl font-bold tracking-tight">
+              <h2 className="text-2xl sm:text-4xl font-bold tracking-tight">
                 Every anchor, marked precisely
               </h2>
               <p className="text-muted-foreground text-lg">
@@ -174,7 +174,7 @@ export default function HomePage() {
                     </span>
                     <span className="font-mono tabular-nums">3 / 9</span>
                   </div>
-                  <div className="grid grid-cols-8 gap-1.5">
+                  <div className="grid grid-cols-8 gap-1 sm:gap-1.5">
                     {["1", "2", "3", "4", "5", "6", "7", "8"].map((label, i) => {
                       const isDownbeat = i === 0;
                       const isAnchor = i === 4 || i === 5;
@@ -183,7 +183,7 @@ export default function HomePage() {
                         <div
                           key={i}
                           className={[
-                            "relative flex h-14 flex-col items-center justify-center rounded-md border font-semibold",
+                            "relative flex h-12 sm:h-14 flex-col items-center justify-center rounded-md border font-semibold",
                             isAnchor
                               ? "border-amber-400/50 bg-amber-400/10 text-amber-200"
                               : isDownbeat
@@ -194,9 +194,9 @@ export default function HomePage() {
                               : "",
                           ].join(" ")}
                         >
-                          <span className="text-base">{label}</span>
+                          <span className="text-sm sm:text-base">{label}</span>
                           {isAnchor && (
-                            <span className="absolute bottom-1 text-[8px] font-normal uppercase tracking-wider opacity-70">
+                            <span className="absolute bottom-0.5 sm:bottom-1 text-[7px] sm:text-[8px] font-normal uppercase tracking-wider opacity-70">
                               anchor
                             </span>
                           )}
@@ -225,7 +225,7 @@ export default function HomePage() {
 
         {/* ─── Feature 2: Video scoring ─── */}
         <section className="border-y border-border/60 bg-card/20">
-          <div className="container mx-auto px-4 py-16 sm:py-24">
+          <div className="container mx-auto px-4 py-12 sm:py-24">
             <div className="grid lg:grid-cols-2 gap-10 items-center">
               <div>
                 <Card className="border-border/60 bg-card/60 backdrop-blur">
@@ -279,7 +279,7 @@ export default function HomePage() {
                   <Video className="h-4 w-4" />
                   Dance video analysis
                 </div>
-                <h2 className="text-3xl sm:text-4xl font-bold tracking-tight">
+                <h2 className="text-2xl sm:text-4xl font-bold tracking-tight">
                   Honest feedback, in 60 seconds
                 </h2>
                 <p className="text-muted-foreground text-lg">
@@ -319,9 +319,9 @@ export default function HomePage() {
         </section>
 
         {/* ─── Feature 3 row: Rhythm trainer + Pattern library ─── */}
-        <section className="container mx-auto px-4 py-16 sm:py-24">
+        <section className="container mx-auto px-4 py-12 sm:py-24">
           <div className="text-center max-w-2xl mx-auto mb-12 space-y-3">
-            <h2 className="text-3xl sm:text-4xl font-bold tracking-tight">
+            <h2 className="text-2xl sm:text-4xl font-bold tracking-tight">
               Everything you need to practice with intention
             </h2>
             <p className="text-muted-foreground text-lg">
@@ -350,9 +350,9 @@ export default function HomePage() {
 
         {/* ─── Pricing ─── */}
         <section className="border-t border-border/60 bg-card/20">
-          <div className="container mx-auto px-4 py-16 sm:py-24">
+          <div className="container mx-auto px-4 py-12 sm:py-24">
             <div className="text-center max-w-2xl mx-auto mb-10 space-y-3">
-              <h2 className="text-3xl sm:text-4xl font-bold tracking-tight">
+              <h2 className="text-2xl sm:text-4xl font-bold tracking-tight">
                 Simple pricing
               </h2>
               <p className="text-muted-foreground text-lg">
@@ -510,7 +510,7 @@ export default function HomePage() {
               <HelpCircle className="h-4 w-4" />
               FAQ
             </div>
-            <h2 className="text-3xl sm:text-4xl font-bold tracking-tight">
+            <h2 className="text-2xl sm:text-4xl font-bold tracking-tight">
               Common questions
             </h2>
           </div>
@@ -549,7 +549,7 @@ export default function HomePage() {
         {/* ─── CTA ─── */}
         <section className="container mx-auto px-4 py-20 text-center">
           <div className="max-w-2xl mx-auto space-y-5">
-            <h2 className="text-3xl sm:text-4xl font-bold tracking-tight">
+            <h2 className="text-2xl sm:text-4xl font-bold tracking-tight">
               Ready to practice smarter?
             </h2>
             <p className="text-muted-foreground text-lg">

--- a/src/components/analyze/timeline-view.tsx
+++ b/src/components/analyze/timeline-view.tsx
@@ -60,6 +60,10 @@ export function TimelineView({
   const [currentTime, setCurrentTime] = useState(0);
   const [playing, setPlaying] = useState(false);
   const [hovered, setHovered] = useState<VideoPatternIdentified | null>(null);
+  const [selected, setSelected] = useState<VideoPatternIdentified | null>(null);
+  // On touch devices there's no hover — tap sticks a selection that
+  // shows the same detail card below the timeline.
+  const detail = hovered ?? selected;
 
   const effectiveDuration = useMemo(() => {
     if (duration > 0) return duration;
@@ -138,7 +142,7 @@ export function TimelineView({
         </div>
 
         <div
-          className="relative h-12 rounded-md bg-muted/30 overflow-hidden border border-border"
+          className="relative h-12 sm:h-14 rounded-md bg-muted/30 overflow-hidden border border-border"
           role="region"
           aria-label="Pattern timeline"
         >
@@ -155,12 +159,15 @@ export function TimelineView({
                 key={`${i}-${p.name}`}
                 type="button"
                 className={cn(
-                  "absolute h-full border-r border-background/40 flex items-center justify-start px-1 text-[10px] font-medium overflow-hidden whitespace-nowrap transition-opacity",
+                  "absolute h-full border-r border-background/40 flex items-center justify-start px-1 text-[9px] sm:text-[10px] font-medium overflow-hidden whitespace-nowrap transition-opacity",
                   colorForQuality(p.quality),
                   hovered === p ? "opacity-100" : "opacity-90 hover:opacity-100"
                 )}
                 style={{ left: `${left}%`, width: `${width}%` }}
-                onClick={() => seek(start)}
+                onClick={() => {
+                  seek(start);
+                  setSelected(p);
+                }}
                 onMouseEnter={() => setHovered(p)}
                 onMouseLeave={() => setHovered(null)}
                 title={`${p.name} — ${p.quality ?? "?"} · ${p.timing ?? "?"} · ${formatTime(start)}-${formatTime(end)}`}
@@ -248,23 +255,23 @@ export function TimelineView({
           </span>
         </div>
 
-        {/* Hovered pattern detail */}
-        {hovered && (
+        {/* Hovered / tap-selected pattern detail */}
+        {detail && (
           <div className="rounded-md border border-border bg-muted/20 p-2 text-xs">
-            <div className="flex items-baseline justify-between gap-3">
+            <div className="flex items-baseline justify-between gap-2 flex-wrap">
               <span className="font-semibold text-foreground">
-                {hovered.name}
+                {detail.name}
               </span>
               <span className="text-muted-foreground font-mono tabular-nums">
-                {formatTime(hovered.start_time ?? 0)} →{" "}
-                {formatTime(hovered.end_time ?? 0)}
+                {formatTime(detail.start_time ?? 0)} →{" "}
+                {formatTime(detail.end_time ?? 0)}
               </span>
             </div>
             <div className="text-muted-foreground mt-1">
-              {hovered.quality ?? "—"} · {hovered.timing ?? "—"}
-              {hovered.notes && (
-                <span className="block mt-1 whitespace-pre-wrap">
-                  {hovered.notes}
+              {detail.quality ?? "—"} · {detail.timing ?? "—"}
+              {detail.notes && (
+                <span className="block mt-1 whitespace-pre-wrap break-words">
+                  {detail.notes}
                 </span>
               )}
             </div>

--- a/src/components/rhythm/phrase-beat-grid.tsx
+++ b/src/components/rhythm/phrase-beat-grid.tsx
@@ -40,7 +40,7 @@ export function PhraseBeatGrid({
         <span className="font-mono tabular-nums">{phraseLabel}</span>
       </div>
 
-      <div className="grid grid-cols-8 gap-1.5">
+      <div className="grid grid-cols-8 gap-1 sm:gap-1.5">
         {BEAT_LABELS.map((label, i) => {
           const role = beatRole(i);
           const isActive = i === currentBeatInPhrase;
@@ -48,7 +48,7 @@ export function PhraseBeatGrid({
             <div
               key={i}
               className={cn(
-                "relative flex h-14 flex-col items-center justify-center rounded-md border font-semibold transition-all",
+                "relative flex h-12 sm:h-14 flex-col items-center justify-center rounded-md border font-semibold transition-all",
                 role === "anchor" &&
                   "border-amber-400/50 bg-amber-400/10 text-amber-200",
                 role === "downbeat" &&
@@ -59,9 +59,9 @@ export function PhraseBeatGrid({
                   "scale-[1.08] ring-2 ring-offset-2 ring-offset-background ring-primary"
               )}
             >
-              <span className="text-base">{label}</span>
+              <span className="text-sm sm:text-base">{label}</span>
               {role === "anchor" && (
-                <span className="absolute bottom-1 text-[8px] font-normal uppercase tracking-wider opacity-70">
+                <span className="absolute bottom-0.5 sm:bottom-1 text-[7px] sm:text-[8px] font-normal uppercase tracking-wider opacity-70">
                   anchor
                 </span>
               )}


### PR DESCRIPTION
**Fix:** Gemini 3.1 Pro requires a paid Google AI tier; free-tier limit is literally 0. Reverting default to `gemini-2.5-flash`. To switch back, enable Gemini billing and set GEMINI_MODEL env var.

**Mobile:** tightened padding, icon-only action buttons in history rows below sm, responsive score hero / phrase grids / timeline, pricing card fits on narrow screens.