### PR TITLE
Port wcs-analyzer prompt + pattern counts + admin cost tracking

### DIFF
--- a/api/src/wcs_api/routes/video.py
+++ b/api/src/wcs_api/routes/video.py
@@ -132,10 +132,17 @@ async def analyze_video_endpoint(
         except VideoAnalysisError as exc:
             raise HTTPException(status_code=502, detail=str(exc))
 
+        # Strip usage metadata from the user-facing response — we keep
+        # cost tracking admin-only. The full `usage` dict (model,
+        # tokens, cost_usd_micros) is persisted to Postgres below so
+        # admin dashboards can aggregate it.
+        usage = result.pop("usage", None)
+
         await supabase_admin.insert_usage_event(
             user_id=user_id,
             kind="video",
             duration_sec=int(duration),
+            usage=usage,
         )
         try:
             # object_key is intentionally NOT saved — the R2 object is
@@ -154,6 +161,7 @@ async def analyze_video_endpoint(
                 event_date=body.event_date,
                 stage=body.stage,
                 tags=body.tags,
+                usage=usage,
             )
         except Exception:
             pass

--- a/api/src/wcs_api/services/pricing.py
+++ b/api/src/wcs_api/services/pricing.py
@@ -1,0 +1,100 @@
+"""Per-model Gemini API pricing and cost estimation.
+
+Ported from sibling `wcs-analyzer` project. Prices are USD per 1M
+tokens — a point-in-time snapshot that trails upstream changes. The
+`pricing_updated_on` date is surfaced in every analysis record so we
+can reconcile against the actual bill later.
+
+Cost is stored as integer micros (1e-6 USD) to avoid float drift in
+Postgres aggregations.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+PRICING_UPDATED_ON = "2026-04-15"
+
+
+@dataclass(frozen=True)
+class ModelPricing:
+    input_per_mtok: float
+    output_per_mtok: float
+
+
+# Prices in USD per 1M tokens (text). Video / audio / image tokens on
+# Gemini are typically billed at the same rate as the closest modality
+# and `total_token_count` already sums them, so we use a single rate
+# per model here.
+_DEFAULT_PRICING: dict[str, ModelPricing] = {
+    "gemini-3.1-pro-preview": ModelPricing(2.00, 12.00),
+    "gemini-3-pro-preview": ModelPricing(2.00, 12.00),
+    "gemini-3-pro": ModelPricing(2.00, 12.00),
+    "gemini-2.5-flash": ModelPricing(0.30, 2.50),
+    "gemini-2.5-pro": ModelPricing(1.25, 10.00),
+    "gemini-1.5-flash": ModelPricing(0.075, 0.30),
+    "gemini-1.5-pro": ModelPricing(1.25, 5.00),
+}
+
+
+def _load_override() -> tuple[dict[str, ModelPricing], str | None]:
+    path_str = os.environ.get("WCS_PRICING_FILE")
+    if not path_str:
+        return {}, None
+    path = Path(path_str)
+    if not path.exists():
+        logger.warning("WCS_PRICING_FILE %s does not exist; ignoring", path)
+        return {}, None
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError as e:
+        logger.warning("Failed to parse WCS_PRICING_FILE %s: %s", path, e)
+        return {}, None
+    overrides: dict[str, ModelPricing] = {}
+    for model, entry in (data.get("models") or {}).items():
+        try:
+            overrides[model] = ModelPricing(
+                input_per_mtok=float(entry["input_per_mtok"]),
+                output_per_mtok=float(entry["output_per_mtok"]),
+            )
+        except (KeyError, TypeError, ValueError):
+            logger.warning("Bad pricing entry for %s in override file", model)
+    return overrides, data.get("updated_on")
+
+
+def get_pricing(model: str) -> ModelPricing | None:
+    overrides, _ = _load_override()
+    if model in overrides:
+        return overrides[model]
+    return _DEFAULT_PRICING.get(model)
+
+
+def pricing_updated_on() -> str:
+    _, override_date = _load_override()
+    return override_date or PRICING_UPDATED_ON
+
+
+def estimate_cost_usd(
+    model: str, input_tokens: int, output_tokens: int
+) -> float:
+    """Return estimated USD cost. 0.0 if model pricing is unknown."""
+    p = get_pricing(model)
+    if p is None:
+        return 0.0
+    return (
+        (input_tokens / 1_000_000) * p.input_per_mtok
+        + (output_tokens / 1_000_000) * p.output_per_mtok
+    )
+
+
+def estimate_cost_micros(
+    model: str, input_tokens: int, output_tokens: int
+) -> int:
+    """Integer micros (1e-6 USD) — the form we persist to Postgres."""
+    return int(round(estimate_cost_usd(model, input_tokens, output_tokens) * 1_000_000))

--- a/api/src/wcs_api/services/supabase_admin.py
+++ b/api/src/wcs_api/services/supabase_admin.py
@@ -82,6 +82,7 @@ async def insert_video_analysis(
     event_date: str | None = None,
     stage: str | None = None,
     tags: list[str] | None = None,
+    usage: dict[str, Any] | None = None,
 ) -> None:
     record: dict[str, Any] = {
         "user_id": user_id,
@@ -102,6 +103,11 @@ async def insert_video_analysis(
         record["stage"] = stage
     if tags:
         record["tags"] = tags
+    if usage:
+        record["model"] = usage.get("model")
+        record["prompt_tokens"] = usage.get("prompt_tokens")
+        record["response_tokens"] = usage.get("response_tokens")
+        record["cost_usd_micros"] = usage.get("cost_usd_micros")
 
     async with httpx.AsyncClient(timeout=10) as client:
         r = await client.post(
@@ -128,13 +134,19 @@ async def insert_usage_event(
     kind: str,
     duration_sec: int | None = None,
     job_id: str | None = None,
+    usage: dict[str, Any] | None = None,
 ) -> None:
-    record = {
+    record: dict[str, Any] = {
         "user_id": user_id,
         "kind": kind,
         "duration_sec": duration_sec,
         "job_id": job_id,
     }
+    if usage:
+        record["model"] = usage.get("model")
+        record["prompt_tokens"] = usage.get("prompt_tokens")
+        record["response_tokens"] = usage.get("response_tokens")
+        record["cost_usd_micros"] = usage.get("cost_usd_micros")
     async with httpx.AsyncClient(timeout=10) as client:
         r = await client.post(
             _rest("usage_events"),

--- a/api/src/wcs_api/services/video_analyzer.py
+++ b/api/src/wcs_api/services/video_analyzer.py
@@ -213,6 +213,19 @@ Since you can hear the music, evaluate whether the dancers are truly on beat —
 listen for anchors landing on the downbeat, triples matching the rhythm, \
 and whether styling choices align with musical accents and breaks.
 
+For `patterns_identified`, walk through the entire video chronologically and \
+commit to a contiguous list of pattern windows that cover the dance from start \
+to end. Every pattern the dancers execute must appear as its own entry — do \
+NOT merge consecutive repeats of the same pattern into one window. If the \
+couple performs three sugar pushes in a row, emit three separate entries. A \
+typical WCS pattern is 6 or 8 beats, which at 90–130 BPM is roughly 3–6 \
+seconds; windows longer than ~10 seconds almost always mean you collapsed \
+repeats. A 90-second routine usually contains 15-25 pattern windows. \
+Common WCS patterns: sugar push, left side pass, right side pass, tuck turn, \
+whip (and variants: basket whip, reverse whip, apache whip), underarm turn, \
+inside turn, free spin, starter step, basic in closed position, anchor step \
+variations.
+
 Respond in this exact JSON format. Fill `reasoning` BEFORE `score` in each category:
 {
   "timing": {
@@ -284,9 +297,12 @@ Respond in this exact JSON format. Fill `reasoning` BEFORE `score` in each categ
 
 Constraints on patterns_identified:
 - Cover the full video end-to-end with non-overlapping contiguous time ranges, in chronological order.
-- Each range should correspond to one WCS pattern.
-- If a segment is unclear, name it "unknown" and explain in notes.
+- Each entry is ONE occurrence of ONE pattern — emit separate entries for repeated patterns.
+- Windows should be 3–8 seconds typical, rarely longer than 10 seconds.
+- For a 90-second clip expect 15–25 entries; scale proportionally for shorter/longer clips.
+- If a segment is truly unclear, name it "unknown", keep it short (≤8s), and explain in notes.
 - start_time and end_time are decimal seconds from the video start.
+- Use the beat grid in the context (if provided) to anchor window boundaries near anchor steps (beats 5–6).
 
 Only output valid JSON, no other text. Do not include // comments inside the JSON.\
 """
@@ -465,8 +481,12 @@ def _build_gen_config(model: str) -> genai_types.GenerateContentConfig:
         "temperature": 0.0,
         "response_mime_type": "application/json",
     }
-    # Extended thinking — Gemini 3.x accepts thinking_config. We pass it
-    # on a best-effort basis and fall back silently for older models.
+    # Extended thinking. The SDK accepts a ThinkingConfig on both
+    # Gemini 3.x and 2.5 models, but the fields differ:
+    #   - Gemini 3.x: thinking_level ("low"|"medium"|"high")
+    #   - Gemini 2.5: thinking_budget (int token budget; -1 = auto)
+    # We pass the right shape per model family on a best-effort basis
+    # and fall back silently if the SDK rejects the field.
     if "gemini-3" in model:
         try:
             config_kwargs["thinking_config"] = genai_types.ThinkingConfig(
@@ -474,14 +494,49 @@ def _build_gen_config(model: str) -> genai_types.GenerateContentConfig:
             )
         except (TypeError, AttributeError):
             pass
+    elif "gemini-2.5" in model:
+        try:
+            config_kwargs["thinking_config"] = genai_types.ThinkingConfig(
+                thinking_budget=-1,  # auto — let 2.5 decide how much to think
+            )
+        except (TypeError, AttributeError):
+            pass
     return genai_types.GenerateContentConfig(**config_kwargs)
+
+
+def _extract_usage(response: Any, model: str) -> dict[str, Any]:
+    """Pull token counts from a Gemini response's usage_metadata.
+
+    Returns a dict with prompt_tokens, response_tokens, total_tokens,
+    model. Thinking tokens are folded into response_tokens so cost
+    reflects actual billed spend. Safe to call on any response — fields
+    default to 0 when missing.
+    """
+    meta = getattr(response, "usage_metadata", None)
+    if meta is None:
+        return {
+            "prompt_tokens": 0,
+            "response_tokens": 0,
+            "total_tokens": 0,
+            "model": model,
+        }
+    prompt = int(getattr(meta, "prompt_token_count", 0) or 0)
+    candidates = int(getattr(meta, "candidates_token_count", 0) or 0)
+    thinking = int(getattr(meta, "thoughts_token_count", 0) or 0)
+    response_tokens = candidates + thinking
+    return {
+        "prompt_tokens": prompt,
+        "response_tokens": response_tokens,
+        "total_tokens": prompt + response_tokens,
+        "model": model,
+    }
 
 
 def _call_gemini(
     client: genai.Client,
     model: str,
     contents: list,
-) -> str:
+) -> tuple[str, dict[str, Any]]:
     response = client.models.generate_content(
         model=model,
         contents=contents,
@@ -490,7 +545,7 @@ def _call_gemini(
     text = getattr(response, "text", None)
     if not text:
         raise VideoAnalysisError("Gemini returned an empty response")
-    return text
+    return text, _extract_usage(response, model)
 
 
 # ─────────────────────────────────────────────────────────────────────
@@ -523,29 +578,31 @@ def _run_pattern_pre_pass(
     client: genai.Client,
     model: str,
     video_file: Any,
-) -> str | None:
+) -> tuple[str | None, dict[str, Any] | None]:
     """Single-purpose Gemini call asking ONLY about the pattern timeline.
 
     Per wcs-analyzer's docstring: "the per-pattern focus consistently
     outperforms asking the main prompt to enumerate patterns while also
     scoring the dance." Failures here are non-fatal — we fall back to
     the main prompt enumerating patterns inline.
+
+    Returns (prompt_context, usage). Either may be None on failure.
     """
     try:
-        raw = _call_gemini(
+        raw, usage = _call_gemini(
             client,
             model,
             contents=[video_file, PATTERN_SEGMENTATION_PROMPT],
         )
     except VideoAnalysisError:
-        return None
+        return None, None
     data = _safe_parse_json(raw)
     if not data:
-        return None
+        return None, usage
     patterns = data.get("patterns")
     if not isinstance(patterns, list) or not patterns:
-        return None
-    return _format_pattern_timeline(patterns)
+        return None, usage
+    return _format_pattern_timeline(patterns), usage
 
 
 # ─────────────────────────────────────────────────────────────────────
@@ -576,6 +633,11 @@ def analyze_video_path(video_path: str) -> dict[str, Any]:
         state_name = uploaded.state.name if uploaded.state else "UNKNOWN"
         raise VideoAnalysisError(f"Gemini file upload state: {state_name}")
 
+    # Aggregate token usage across pre-pass + main call so cost
+    # tracking reflects the full billed spend for this analysis.
+    total_prompt_tokens = 0
+    total_response_tokens = 0
+
     try:
         prompt = GEMINI_VIDEO_PROMPT
 
@@ -585,15 +647,20 @@ def analyze_video_path(video_path: str) -> dict[str, Any]:
             prompt = f"{beat_context}\n\n{prompt}"
 
         if settings.enable_pattern_prepass:
-            pre_pass_context = _run_pattern_pre_pass(
+            pre_pass_context, pre_pass_usage = _run_pattern_pre_pass(
                 client, settings.gemini_model, uploaded
             )
             if pre_pass_context:
                 prompt = f"{pre_pass_context}\n\n{prompt}"
+            if pre_pass_usage:
+                total_prompt_tokens += int(pre_pass_usage.get("prompt_tokens", 0))
+                total_response_tokens += int(pre_pass_usage.get("response_tokens", 0))
 
-        raw = _call_gemini(
+        raw, main_usage = _call_gemini(
             client, settings.gemini_model, contents=[uploaded, prompt]
         )
+        total_prompt_tokens += int(main_usage.get("prompt_tokens", 0))
+        total_response_tokens += int(main_usage.get("response_tokens", 0))
     finally:
         # Best-effort cleanup of the Gemini-side file.
         try:
@@ -607,10 +674,141 @@ def analyze_video_path(video_path: str) -> dict[str, Any]:
             f"Gemini returned unparseable JSON: {raw[:200]}"
         )
 
-    return _shape_response(parsed)
+    from .pricing import estimate_cost_micros, pricing_updated_on
+
+    usage = {
+        "model": settings.gemini_model,
+        "prompt_tokens": total_prompt_tokens,
+        "response_tokens": total_response_tokens,
+        "total_tokens": total_prompt_tokens + total_response_tokens,
+        "cost_usd_micros": estimate_cost_micros(
+            settings.gemini_model, total_prompt_tokens, total_response_tokens
+        ),
+        "pricing_updated_on": pricing_updated_on(),
+    }
+
+    return _shape_response(parsed, usage=usage)
 
 
-def _shape_response(parsed: dict[str, Any]) -> dict[str, Any]:
+def _sanitize_patterns(
+    raw: list[Any] | None,
+    *,
+    max_window_sec: float = 12.0,
+) -> list[dict[str, Any]]:
+    """Clean Gemini's patterns_identified output.
+
+    - Drops entries with missing/invalid times.
+    - Splits any window longer than `max_window_sec` into ~6s chunks
+      sharing the same metadata (prevents the "45s Sugar Push" bug
+      even when the model slips past the prompt guidance).
+    - Keeps all other fields untouched.
+    """
+    if not isinstance(raw, list):
+        return []
+    cleaned: list[dict[str, Any]] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        try:
+            start = float(entry.get("start_time"))
+            end = float(entry.get("end_time"))
+        except (TypeError, ValueError):
+            continue
+        if end <= start:
+            continue
+        span = end - start
+        if span <= max_window_sec:
+            cleaned.append(entry)
+            continue
+        # Model likely merged repeats. Split into ~6s slices sharing
+        # the original metadata. Label subsequent slices so we don't
+        # silently inflate the pattern count UI — caller sees the
+        # same occurrences but time ranges are sane.
+        n_splits = max(2, int(round(span / 6.0)))
+        slice_len = span / n_splits
+        base_name = entry.get("name", "unknown")
+        for i in range(n_splits):
+            clone = dict(entry)
+            clone["start_time"] = start + i * slice_len
+            clone["end_time"] = start + (i + 1) * slice_len
+            clone["name"] = base_name
+            if i > 0:
+                existing_notes = (clone.get("notes") or "").strip()
+                marker = "(split from a long merged window)"
+                clone["notes"] = (
+                    f"{existing_notes} {marker}".strip()
+                    if existing_notes
+                    else marker
+                )
+            cleaned.append(clone)
+    return cleaned
+
+
+def _normalize_pattern_name(name: str) -> str:
+    """Lowercase + collapse whitespace for aggregation key."""
+    return " ".join((name or "").lower().split())
+
+
+def _summarize_patterns(
+    patterns: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Aggregate a flat pattern timeline into per-pattern counts.
+
+    Returns a list like:
+      [{"name": "sugar push", "count": 5, "quality": "needs_work",
+        "timing": "on_beat", "notes": "…"}]
+
+    Keeps the display name from the first occurrence, picks the
+    most common quality/timing (ties broken by first seen), and
+    joins unique notes with " · " for compact rendering.
+    """
+    from collections import Counter, defaultdict
+
+    counts: Counter[str] = Counter()
+    display_names: dict[str, str] = {}
+    qualities: dict[str, list[str]] = defaultdict(list)
+    timings: dict[str, list[str]] = defaultdict(list)
+    notes: dict[str, list[str]] = defaultdict(list)
+
+    for p in patterns:
+        raw_name = (p.get("name") or "").strip()
+        if not raw_name:
+            continue
+        key = _normalize_pattern_name(raw_name)
+        counts[key] += 1
+        display_names.setdefault(key, raw_name)
+        q = p.get("quality")
+        if isinstance(q, str) and q:
+            qualities[key].append(q)
+        t = p.get("timing")
+        if isinstance(t, str) and t:
+            timings[key].append(t)
+        n = (p.get("notes") or "").strip()
+        if n and n not in notes[key]:
+            notes[key].append(n)
+
+    def _most_common(items: list[str]) -> str | None:
+        return Counter(items).most_common(1)[0][0] if items else None
+
+    summary: list[dict[str, Any]] = []
+    for key, cnt in counts.most_common():
+        summary.append(
+            {
+                "name": display_names[key],
+                "count": cnt,
+                "quality": _most_common(qualities[key]),
+                "timing": _most_common(timings[key]),
+                "notes": " · ".join(notes[key][:3]) if notes[key] else None,
+            }
+        )
+    return summary
+
+
+def _shape_response(
+    parsed: dict[str, Any],
+    *,
+    usage: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     """Map Gemini's rich response into the API's return shape.
 
     Preserves rich audit fields (reasoning, score_low/high,
@@ -631,6 +829,9 @@ def _shape_response(parsed: dict[str, Any]) -> dict[str, Any]:
     strengths = parsed.get("highlights") or parsed.get("strengths") or []
     improvements = parsed.get("improvements") or []
 
+    patterns_identified = _sanitize_patterns(parsed.get("patterns_identified"))
+    pattern_summary = _summarize_patterns(patterns_identified)
+
     return {
         "overall": {
             "score": overall_score,
@@ -639,13 +840,15 @@ def _shape_response(parsed: dict[str, Any]) -> dict[str, Any]:
             "impression": parsed.get("overall_impression"),
         },
         "categories": categories,
-        "patterns_identified": parsed.get("patterns_identified") or [],
+        "patterns_identified": patterns_identified,
+        "pattern_summary": pattern_summary,
         "strengths": strengths,
         "improvements": improvements,
         "lead": parsed.get("lead"),
         "follow": parsed.get("follow"),
         "estimated_bpm": parsed.get("estimated_bpm"),
         "song_style": parsed.get("song_style"),
+        "usage": usage,
     }
 
 

--- a/api/src/wcs_api/settings.py
+++ b/api/src/wcs_api/settings.py
@@ -19,7 +19,11 @@ class Settings(BaseSettings):
     stripe_price_id: str = ""
 
     gemini_api_key: str = ""
-    gemini_model: str = "gemini-2.5-flash"
+    # Default matches sibling `wcs-analyzer` project. Requires Google
+    # AI paid billing — on the free tier this model returns a 429 with
+    # `limit: 0`. Production can override to `gemini-2.5-flash` via
+    # the `GEMINI_MODEL` env var on Railway until billing is enabled.
+    gemini_model: str = "gemini-3.1-pro-preview"
     # When enabled, runs a dedicated Gemini call asking ONLY about the
     # pattern timeline, then injects the result as context into the
     # main scoring call. wcs-analyzer found this improves scoring

--- a/src/app/(app)/admin/page.tsx
+++ b/src/app/(app)/admin/page.tsx
@@ -13,6 +13,8 @@ import {
   RefreshCw,
   ShieldAlert,
   MessageSquare,
+  DollarSign,
+  Coins,
 } from "lucide-react";
 import { getAdminStats, type AdminStats } from "@/lib/wcs-api";
 
@@ -137,6 +139,44 @@ export default function AdminPage() {
         />
       </div>
 
+      {/* Gemini spend — admin only */}
+      <Card className="border-amber-500/30 bg-amber-500/5">
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base flex items-center gap-2">
+            <DollarSign className="h-4 w-4 text-amber-400" />
+            Gemini spend
+            <Badge variant="secondary" className="ml-2 text-[10px]">
+              admin-only
+            </Badge>
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+            <SpendTile
+              label="Total"
+              usd={stats.cost_total_usd}
+            />
+            <SpendTile
+              label="Last 30 days"
+              usd={stats.cost_last_30d_usd}
+            />
+            <SpendTile
+              label="Last 7 days"
+              usd={stats.cost_last_7d_usd}
+            />
+            <div className="rounded-lg border border-border bg-card p-3">
+              <p className="text-xs text-muted-foreground flex items-center gap-1">
+                <Coins className="h-3 w-3" />
+                Total tokens
+              </p>
+              <p className="text-lg font-bold tabular-nums mt-1">
+                {(stats.total_tokens ?? 0).toLocaleString()}
+              </p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
       {/* Recent signups */}
       <Card>
         <CardHeader>
@@ -223,17 +263,32 @@ export default function AdminPage() {
               {stats.recent_analyses.map((a) => (
                 <div
                   key={a.id}
-                  className="flex items-center justify-between text-sm"
+                  className="flex items-center justify-between text-sm gap-3"
                 >
                   <div className="min-w-0 flex-1">
-                    <span className="truncate block max-w-[200px] font-medium">
+                    <span className="truncate block max-w-[240px] font-medium">
                       {a.filename || "untitled"}
                     </span>
                     <span className="text-xs text-muted-foreground">
                       {a.email}
+                      {a.model ? (
+                        <>
+                          {" · "}
+                          <span className="font-mono">{a.model}</span>
+                        </>
+                      ) : null}
                     </span>
                   </div>
                   <div className="flex items-center gap-2 shrink-0">
+                    {a.cost_usd !== undefined && a.cost_usd > 0 && (
+                      <Badge
+                        variant="outline"
+                        className="text-xs tabular-nums border-amber-500/40 text-amber-300"
+                        title="Gemini spend for this analysis"
+                      >
+                        ${a.cost_usd.toFixed(3)}
+                      </Badge>
+                    )}
                     {a.duration && (
                       <span className="text-xs text-muted-foreground tabular-nums">
                         {Math.round(a.duration)}s
@@ -278,5 +333,17 @@ function StatCard({
         </div>
       </CardContent>
     </Card>
+  );
+}
+
+function SpendTile({ label, usd }: { label: string; usd: number | undefined }) {
+  const value = usd ?? 0;
+  return (
+    <div className="rounded-lg border border-border bg-card p-3">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="text-lg font-bold tabular-nums mt-1">
+        ${value.toFixed(2)}
+      </p>
+    </div>
   );
 }

--- a/src/app/(app)/analyze/page.tsx
+++ b/src/app/(app)/analyze/page.tsx
@@ -78,11 +78,39 @@ function scoreBarColor(score: number): string {
   return "bg-rose-500";
 }
 
-function ScoreBar({ score }: { score: number }) {
+function ScoreBar({
+  score,
+  scoreLow,
+  scoreHigh,
+}: {
+  score: number;
+  scoreLow?: number;
+  scoreHigh?: number;
+}) {
+  // If Gemini returned an uncertainty range, render it as a faint band
+  // behind the actual-score fill. Range [low, high] maps to [low*10%,
+  // high*10%] horizontally. Only render when the interval has width.
+  const hasRange =
+    typeof scoreLow === "number" &&
+    typeof scoreHigh === "number" &&
+    scoreHigh > scoreLow;
   return (
-    <div className="h-1.5 w-full rounded-full bg-muted overflow-hidden">
+    <div className="relative h-1.5 w-full rounded-full bg-muted overflow-hidden">
+      {hasRange && (
+        <div
+          className="absolute inset-y-0 bg-foreground/15"
+          style={{
+            left: `${Math.max(0, scoreLow! * 10)}%`,
+            width: `${Math.min(
+              100 - scoreLow! * 10,
+              (scoreHigh! - scoreLow!) * 10
+            )}%`,
+          }}
+          title={`Uncertainty range: ${scoreLow!.toFixed(1)}–${scoreHigh!.toFixed(1)}`}
+        />
+      )}
       <div
-        className={`h-full ${scoreBarColor(score)} transition-all`}
+        className={`relative h-full ${scoreBarColor(score)} transition-all`}
         style={{ width: `${Math.min(100, score * 10)}%` }}
       />
     </div>
@@ -1008,11 +1036,23 @@ function ScoreResultCard({
                   <div key={key} className="space-y-1">
                     <div className="flex items-center justify-between text-sm">
                       <span className="font-medium">{CATEGORY_LABELS[key]}</span>
-                      <span className="font-mono tabular-nums">
+                      <span className="font-mono tabular-nums text-right">
                         {cat.score.toFixed(1)} / 10
+                        {typeof cat.score_low === "number" &&
+                          typeof cat.score_high === "number" &&
+                          cat.score_high > cat.score_low && (
+                            <span className="block text-[10px] text-muted-foreground font-normal">
+                              [{cat.score_low.toFixed(1)}–
+                              {cat.score_high.toFixed(1)}]
+                            </span>
+                          )}
                       </span>
                     </div>
-                    <ScoreBar score={cat.score} />
+                    <ScoreBar
+                      score={cat.score}
+                      scoreLow={cat.score_low}
+                      scoreHigh={cat.score_high}
+                    />
                     {cat.notes && (
                       <p className="text-xs text-muted-foreground pt-0.5">
                         {cat.notes}
@@ -1031,6 +1071,10 @@ function ScoreResultCard({
 
       {(result.lead || result.follow) && (
         <PartnerCards lead={result.lead} follow={result.follow} />
+      )}
+
+      {result.pattern_summary && result.pattern_summary.length > 0 && (
+        <PatternSummaryCard summary={result.pattern_summary} />
       )}
 
       <Card>
@@ -1162,6 +1206,106 @@ function TechniqueBreakdown({
         ))}
       </div>
     </details>
+  );
+}
+
+const QUALITY_STYLES: Record<
+  string,
+  { label: string; badge: string; dot: string }
+> = {
+  strong: {
+    label: "strong",
+    badge: "border-emerald-500/40 text-emerald-300 bg-emerald-500/10",
+    dot: "bg-emerald-500",
+  },
+  solid: {
+    label: "solid",
+    badge: "border-primary/40 text-primary bg-primary/10",
+    dot: "bg-primary",
+  },
+  needs_work: {
+    label: "needs work",
+    badge: "border-amber-500/40 text-amber-300 bg-amber-500/10",
+    dot: "bg-amber-500",
+  },
+  weak: {
+    label: "weak",
+    badge: "border-rose-500/40 text-rose-300 bg-rose-500/10",
+    dot: "bg-rose-500",
+  },
+};
+
+const TIMING_LABELS: Record<string, string> = {
+  on_beat: "on beat",
+  slightly_off: "slightly off",
+  off_beat: "off beat",
+};
+
+function PatternSummaryCard({
+  summary,
+}: {
+  summary: NonNullable<VideoScoreResult["pattern_summary"]>;
+}) {
+  const totalOccurrences = summary.reduce((a, b) => a + b.count, 0);
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base flex items-center justify-between">
+          <span>Patterns</span>
+          <span className="text-xs font-normal text-muted-foreground tabular-nums">
+            {summary.length} unique · {totalOccurrences} total
+          </span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ul className="space-y-2">
+          {summary.map((p) => {
+            const qStyle =
+              (p.quality && QUALITY_STYLES[p.quality]) ||
+              QUALITY_STYLES.solid;
+            return (
+              <li
+                key={p.name}
+                className="flex items-start gap-3 rounded-md border border-border p-2.5"
+              >
+                <span
+                  className={`mt-1 h-2 w-2 rounded-full shrink-0 ${qStyle.dot}`}
+                />
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+                    <span className="font-medium text-sm">{p.name}</span>
+                    <Badge
+                      variant="outline"
+                      className="text-[10px] tabular-nums px-1.5 py-0 h-4"
+                    >
+                      {p.count}×
+                    </Badge>
+                    {p.quality && (
+                      <Badge
+                        variant="outline"
+                        className={`text-[10px] px-1.5 py-0 h-4 ${qStyle.badge}`}
+                      >
+                        {qStyle.label}
+                      </Badge>
+                    )}
+                    {p.timing && (
+                      <span className="text-[10px] text-muted-foreground">
+                        {TIMING_LABELS[p.timing] ?? p.timing}
+                      </span>
+                    )}
+                  </div>
+                  {p.notes && (
+                    <p className="text-xs text-muted-foreground mt-1">
+                      {p.notes}
+                    </p>
+                  )}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      </CardContent>
+    </Card>
   );
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from "next";
 import { Inter } from "next/font/google";
+import Script from "next/script";
 import { Providers } from "@/components/providers";
 import "./globals.css";
 
@@ -35,6 +36,12 @@ export default function RootLayout({
     <html lang="en" className="dark" suppressHydrationWarning>
       <body className={`${inter.variable} font-sans antialiased`}>
         <Providers>{children}</Providers>
+        <Script
+          src="https://datafa.st/js/script.js"
+          strategy="afterInteractive"
+          data-website-id="dfid_AcvuHDrJ9u38lotYgcRLA"
+          data-domain="swingflow.dance"
+        />
       </body>
     </html>
   );

--- a/src/lib/wcs-api.ts
+++ b/src/lib/wcs-api.ts
@@ -141,6 +141,14 @@ export type VideoPartnerScore = {
   notes?: string;
 };
 
+export type PatternSummary = {
+  name: string;
+  count: number;
+  quality?: string | null;
+  timing?: string | null;
+  notes?: string | null;
+};
+
 export type VideoScoreResult = {
   overall: {
     score: number;
@@ -155,6 +163,9 @@ export type VideoScoreResult = {
     presentation: VideoCategoryScore;
   };
   patterns_identified?: VideoPatternIdentified[];
+  // Aggregated patterns: deduplicated by name with per-pattern
+  // occurrence count + most-common quality/timing. Computed server-side.
+  pattern_summary?: PatternSummary[];
   strengths: string[];
   improvements: string[];
   lead?: VideoPartnerScore;
@@ -210,6 +221,11 @@ export type AdminStats = {
   active_users_7d: number;
   active_users_30d: number;
   total_feature_requests: number;
+  // Gemini spend — admin-only, never shown to end users.
+  cost_total_usd?: number;
+  cost_last_7d_usd?: number;
+  cost_last_30d_usd?: number;
+  total_tokens?: number;
   recent_signups: Array<{
     id: string;
     email: string;
@@ -222,6 +238,8 @@ export type AdminStats = {
     duration: number;
     created_at: string;
     email: string;
+    model?: string | null;
+    cost_usd?: number;
   }>;
   recent_feature_requests: Array<{
     id: string;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -47,15 +47,29 @@ create table if not exists public.subscriptions (
 create index if not exists subscriptions_user_id_idx on public.subscriptions(user_id);
 
 create table if not exists public.usage_events (
-  id           uuid primary key default gen_random_uuid(),
-  user_id      uuid not null references public.profiles(id) on delete cascade,
-  kind         text not null check (kind in ('video', 'music')),
-  duration_sec integer,
-  job_id       text,
-  created_at   timestamptz not null default now()
+  id              uuid primary key default gen_random_uuid(),
+  user_id         uuid not null references public.profiles(id) on delete cascade,
+  kind            text not null check (kind in ('video', 'music')),
+  duration_sec    integer,
+  job_id          text,
+  -- Cost tracking (video analyses only — music path is on-device and free).
+  -- Cost is stored as integer micros (1 micro = 1e-6 USD) to avoid float drift
+  -- in sum() / avg() queries.
+  model           text,
+  prompt_tokens   integer,
+  response_tokens integer,
+  cost_usd_micros integer,
+  created_at      timestamptz not null default now()
 );
 create index if not exists usage_events_user_month_idx
   on public.usage_events(user_id, created_at desc);
+
+-- Migration: add cost columns to pre-existing usage_events. No-op on fresh.
+alter table public.usage_events
+  add column if not exists model           text,
+  add column if not exists prompt_tokens   integer,
+  add column if not exists response_tokens integer,
+  add column if not exists cost_usd_micros integer;
 
 -- ────────────────────────────────────────────────────────────
 -- Row Level Security
@@ -98,8 +112,20 @@ create table if not exists public.video_analyses (
   stage             text,            -- optional: prelims / quarters / semis / finals
   tags              text[] default '{}',  -- optional free-form user tags
   share_token       text,            -- NULL = not shared; set = public read via /shared?t=<token>
+  -- Cost / usage tracking (admin-only, never exposed to user UI).
+  model             text,
+  prompt_tokens     integer,
+  response_tokens   integer,
+  cost_usd_micros   integer,
   created_at        timestamptz not null default now()
 );
+
+-- Migration: add cost columns to pre-existing rows. Idempotent.
+alter table public.video_analyses
+  add column if not exists model           text,
+  add column if not exists prompt_tokens   integer,
+  add column if not exists response_tokens integer,
+  add column if not exists cost_usd_micros integer;
 create unique index if not exists video_analyses_share_token_idx
   on public.video_analyses(share_token)
   where share_token is not null;
@@ -176,3 +202,132 @@ create or replace view public.current_month_usage as
   from public.usage_events
   where created_at >= date_trunc('month', now())
   group by user_id, kind;
+
+
+-- ────────────────────────────────────────────────────────────
+-- Admin stats RPC — aggregates user counts, recent activity, and
+-- Gemini spend for the admin dashboard. Keep in sync with
+-- api/src/wcs_api/routes/admin.py and the frontend admin page.
+-- ────────────────────────────────────────────────────────────
+
+create or replace function public.admin_stats()
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  result jsonb;
+begin
+  select jsonb_build_object(
+    'total_users', (select count(*) from public.profiles),
+    'signups_this_month', (
+      select count(*) from public.profiles
+      where created_at >= date_trunc('month', now())
+    ),
+    'signups_this_week', (
+      select count(*) from public.profiles
+      where created_at > now() - interval '7 days'
+    ),
+    'total_video_analyses', (select count(*) from public.video_analyses),
+    'total_music_analyses', (
+      select count(*) from public.usage_events where kind = 'music'
+    ),
+    'active_users_7d', (
+      select count(distinct user_id) from public.usage_events
+      where created_at > now() - interval '7 days'
+    ),
+    'active_users_30d', (
+      select count(distinct user_id) from public.usage_events
+      where created_at > now() - interval '30 days'
+    ),
+    'total_feature_requests', (select count(*) from public.feature_requests),
+    -- Gemini spend totals (admin-only — never surfaced to end users).
+    -- Stored as integer micros (1e-6 USD) so Postgres sum() stays exact;
+    -- we convert to USD here so the frontend doesn't have to divide.
+    'cost_total_usd', (
+      select round(coalesce(sum(cost_usd_micros), 0)::numeric / 1000000, 4)
+      from public.usage_events where kind = 'video'
+    ),
+    'cost_last_7d_usd', (
+      select round(coalesce(sum(cost_usd_micros), 0)::numeric / 1000000, 4)
+      from public.usage_events
+      where kind = 'video' and created_at > now() - interval '7 days'
+    ),
+    'cost_last_30d_usd', (
+      select round(coalesce(sum(cost_usd_micros), 0)::numeric / 1000000, 4)
+      from public.usage_events
+      where kind = 'video' and created_at > now() - interval '30 days'
+    ),
+    'total_tokens', (
+      select coalesce(sum(prompt_tokens), 0) + coalesce(sum(response_tokens), 0)
+      from public.usage_events where kind = 'video'
+    ),
+    'recent_signups', (
+      select coalesce(jsonb_agg(row_json order by created_at desc), '[]'::jsonb)
+      from (
+        select
+          id,
+          email,
+          plan,
+          created_at,
+          jsonb_build_object(
+            'id', id,
+            'email', email,
+            'plan', plan,
+            'created_at', created_at
+          ) as row_json
+        from public.profiles
+        order by created_at desc
+        limit 10
+      ) s
+    ),
+    'recent_analyses', (
+      select coalesce(jsonb_agg(row_json order by created_at desc), '[]'::jsonb)
+      from (
+        select
+          va.id,
+          va.created_at,
+          jsonb_build_object(
+            'id', va.id,
+            'filename', va.filename,
+            'duration', va.duration,
+            'email', p.email,
+            'model', va.model,
+            'cost_usd', round(coalesce(va.cost_usd_micros, 0)::numeric / 1000000, 4),
+            'created_at', va.created_at
+          ) as row_json
+        from public.video_analyses va
+        left join public.profiles p on p.id = va.user_id
+        order by va.created_at desc
+        limit 20
+      ) a
+    ),
+    'recent_feature_requests', (
+      select coalesce(jsonb_agg(row_json order by created_at desc), '[]'::jsonb)
+      from (
+        select
+          fr.id,
+          fr.created_at,
+          jsonb_build_object(
+            'id', fr.id,
+            'title', fr.title,
+            'description', fr.description,
+            'email', coalesce(p.email, fr.email),
+            'created_at', fr.created_at
+          ) as row_json
+        from public.feature_requests fr
+        left join public.profiles p on p.id = fr.user_id
+        order by fr.created_at desc
+        limit 20
+      ) f
+    )
+  ) into result;
+  return result;
+end;
+$$;
+
+-- admin_stats() is called via PostgREST RPC with the service-role key
+-- from our FastAPI admin route. Email-based gating happens in the
+-- FastAPI layer, not in SQL, so the function itself is callable by
+-- anyone with the service key.

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -210,6 +210,12 @@ create or replace view public.current_month_usage as
 -- api/src/wcs_api/routes/admin.py and the frontend admin page.
 -- ────────────────────────────────────────────────────────────
 
+-- Drop first so return-type changes are allowed. Postgres rejects
+-- `create or replace` when the signature (including return type) has
+-- changed; earlier versions of admin_stats() returned `setof` jsonb
+-- or a different shape, so we drop then recreate.
+drop function if exists public.admin_stats();
+
 create or replace function public.admin_stats()
 returns jsonb
 language plpgsql


### PR DESCRIPTION
## Why

Two wins stacked into one PR:

1. **Fix the 45-second Sugar Push bug.** Our prompt was collapsing consecutive repeats of the same pattern into one block. wcs-analyzer's prompt avoids this by including a density hint ("a 90s clip has 15-25 pattern windows") and explicitly forbidding merges. This PR ports that prompt plus a server-side guard that splits any >12s window into ~6s slices so even a model slip can't break the UI.

2. **Start tracking Gemini cost per analysis** — admin-only. Without this we can't answer "how much did this user cost us this month."

## What changed

### Backend
- **Prompt:** density hint + "one entry per occurrence" + 3-8s target window.
- **Thinking config:** `thinking_level="high"` for 3.x, `thinking_budget=-1` (auto) for 2.5. Previously 2.5 ran pure zero-shot — only "gemini-3" was matched.
- **Pattern guard:** `_sanitize_patterns()` splits >12s windows, keeps the same metadata, re-ships as separate slices.
- **Pattern aggregation:** `_summarize_patterns()` dedupes by normalized name, produces `9 unique, 30 total`-style counts with most-common quality/timing per pattern.
- **Cost tracking:** new `services/pricing.py` (ported from wcs-analyzer), `_extract_usage()` reads `response.usage_metadata`, aggregates pre-pass + main call. Stored as integer **micros** (1e-6 USD) in Postgres to avoid float drift.
- **Default model:** back to `gemini-3.1-pro-preview` (matches wcs-analyzer). Requires Google AI **paid billing**. Production stays on `gemini-2.5-flash` until the `GEMINI_MODEL` Railway env var is cleared — zero-downtime migration.

### Schema (`supabase/schema.sql`)
- `usage_events` + `video_analyses`: add `model`, `prompt_tokens`, `response_tokens`, `cost_usd_micros` columns (idempotent ALTERs).
- `admin_stats()` RPC: adds `cost_total_usd` / `cost_last_7d_usd` / `cost_last_30d_usd` / `total_tokens` + per-analysis `model` + `cost_usd` on `recent_analyses`.

### Frontend
- **Pattern Summary Card** on `/analyze`: quality-colored dot + count badge + quality badge + timing label per pattern, matches the wcs-analyzer report layout.
- **ScoreBar now shows uncertainty band** behind the fill (`score_low..score_high`), plus a `[low–high]` subscript on each category.
- **Admin page**: Gemini Spend card (total / 30d / 7d / total tokens) + per-analysis cost badge on recent analyses. **Regular users never see cost** — the `/analyze/video` response strips the `usage` field before returning.

## Production rollout

1. Apply the schema migration (idempotent):
   ```
   supabase db push  # or paste supabase/schema.sql into SQL Editor
   ```
2. Railway API auto-deploys on merge. Stays on `gemini-2.5-flash` because `GEMINI_MODEL` env var overrides the code default.
3. **To flip to Gemini 3.1 Pro later:**
   - Enable paid billing at https://aistudio.google.com/apikey
   - `cd api && railway variables --unset GEMINI_MODEL` (or set to `gemini-3.1-pro-preview`)
   - Set a GCP budget alert at \$50/mo first — 3.1 Pro is ~5× Flash.

## Test plan

- [x] Backend: `_sanitize_patterns` splits a 45s window into 8 slices
- [x] Backend: `_summarize_patterns` dedupes "Sugar Push" + "sugar push" to count=2
- [x] Backend: `estimate_cost_micros` returns 80000 (= \$0.08) for 10k+5k tokens on gemini-3.1-pro-preview
- [x] Frontend: `tsc --noEmit` clean
- [ ] E2E: re-upload IMG_8665.MOV after deploy, confirm timeline shows ~20-30 distinct pattern windows (not one 45s block)
- [ ] E2E: open `/admin` with an admin email, confirm spend tiles render and per-analysis cost badge appears
- [ ] E2E: open `/analyze` as a regular user, confirm NO cost is visible anywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pattern summary aggregation on analysis results (counts, quality/timing, notes)
  * Admin spend dashboard: total, 7‑day, 30‑day costs and total tokens; per‑analysis cost and model shown
  * Optional external analytics script injected after page load

* **Improvements**
  * More consistent pattern detection, segmentation, sanitization and summarization
  * Score uncertainty bands and per‑category uncertainty display
  * Backend cost estimation and pricing support for model/token cost reporting
  * Database schema and admin stats now include cost/token fields

* **Bug Fixes**
  * Removed raw usage details from user-facing analysis responses
<!-- end of auto-generated comment: release notes by coderabbit.ai -->