### PR TITLE
Count share-link views (bot-filtered)

### DIFF
--- a/api/src/wcs_api/routes/shared.py
+++ b/api/src/wcs_api/routes/shared.py
@@ -1,17 +1,75 @@
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, Header, HTTPException, status
 
 from ..services import supabase_admin
 
 router = APIRouter(prefix="/shared", tags=["shared"])
 
 
+def _is_real_browser_navigation(
+    sec_fetch_mode: str | None,
+    sec_fetch_dest: str | None,
+    user_agent: str | None,
+) -> bool:
+    """Detect real browser page loads vs. link-preview bots.
+
+    Slack / iMessage / Twitter / Discord / Facebook all fire GETs
+    against shared URLs to unfurl an OpenGraph preview. They don't
+    send `Sec-Fetch-Mode: navigate` (the header browsers attach to
+    real page loads) and many have telltale user agents.
+
+    Frontend fetches from our own SPA also send Sec-Fetch-Mode=cors
+    (not navigate), so we actually count a view when the *frontend*
+    page successfully loads the analysis — which we proxy via a
+    custom header the frontend sends, `X-Swingflow-View: 1`. See
+    `src/app/shared/page.tsx`.
+
+    Kept intentionally loose: false negatives (undercounting) are
+    preferable to false positives (inflated numbers from every Slack
+    channel the owner posted in).
+    """
+    ua = (user_agent or "").lower()
+    bot_markers = (
+        "bot",
+        "crawler",
+        "spider",
+        "slackbot",
+        "twitterbot",
+        "facebookexternalhit",
+        "discordbot",
+        "whatsapp",
+        "telegrambot",
+        "linkedinbot",
+        "preview",
+    )
+    if any(m in ua for m in bot_markers):
+        return False
+    # Browsers set `Sec-Fetch-Mode: navigate` on top-level page loads
+    # and `cors` on fetch() calls. We accept either, since our frontend
+    # fetches this endpoint via fetch() after the page mounts.
+    mode = (sec_fetch_mode or "").lower()
+    return mode in ("navigate", "cors", "")
+
+
 @router.get("/{token}")
-async def get_shared(token: str) -> dict:
+async def get_shared(
+    token: str,
+    sec_fetch_mode: str | None = Header(default=None, alias="Sec-Fetch-Mode"),
+    sec_fetch_dest: str | None = Header(default=None, alias="Sec-Fetch-Dest"),
+    user_agent: str | None = Header(default=None, alias="User-Agent"),
+    swingflow_view: str | None = Header(default=None, alias="X-Swingflow-View"),
+) -> dict:
     """Public endpoint — no JWT required. Returns a video analysis row
     keyed by its share_token, restricted to the public-safe field set
     (no user_id, no object_key). The client generates a random token
     when the user clicks Share, so the 'knowledge of the token' acts
-    as the access control."""
+    as the access control.
+
+    Side effect: when called with the frontend's `X-Swingflow-View: 1`
+    header (or a real navigate fetch that isn't a known bot), the
+    share_view_count on the row is atomically incremented and
+    share_last_viewed_at is updated. Bot / link-preview requests
+    don't count.
+    """
     if not token or len(token) < 16:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -23,4 +81,19 @@ async def get_shared(token: str) -> dict:
             status_code=status.HTTP_404_NOT_FOUND,
             detail="shared analysis not found or no longer shared",
         )
+
+    # Count as a view when the frontend explicitly opts in or the
+    # request looks like a real browser. Failures are swallowed
+    # inside `increment_share_view` so the public page never fails
+    # because the counter hiccuped.
+    is_frontend_view = swingflow_view == "1"
+    if is_frontend_view or _is_real_browser_navigation(
+        sec_fetch_mode, sec_fetch_dest, user_agent
+    ):
+        new_count = await supabase_admin.increment_share_view(token)
+        # Reflect the new count back in the response so the owner
+        # (if they're the one viewing) doesn't see stale data.
+        if new_count > 0:
+            analysis["share_view_count"] = new_count
+
     return analysis

--- a/api/src/wcs_api/services/supabase_admin.py
+++ b/api/src/wcs_api/services/supabase_admin.py
@@ -159,19 +159,48 @@ async def insert_usage_event(
 async def get_shared_analysis(token: str) -> dict[str, Any] | None:
     """Unauthenticated read of a video analysis by its share token.
     Intentionally returns only the public-safe subset of fields (no
-    user_id, object_key, or stripe_customer_id)."""
+    user_id, object_key, or stripe_customer_id). Also returns the
+    view counter columns so the owner sees them update in realtime."""
     async with httpx.AsyncClient(timeout=10) as client:
         r = await client.get(
             _rest(
                 f"video_analyses?share_token=eq.{token}"
                 "&select=id,filename,duration,result,role,"
-                "competition_level,event_name,stage,tags,created_at"
+                "competition_level,event_name,stage,tags,created_at,"
+                "share_view_count,share_last_viewed_at"
             ),
             headers=_headers(),
         )
         r.raise_for_status()
         rows = r.json()
         return rows[0] if rows else None
+
+
+async def increment_share_view(token: str) -> int:
+    """Atomically +1 the view count on the row matching the given
+    share token; also stamps share_last_viewed_at = now(). Returns
+    the new count. Safe to call concurrently — the RPC wraps the
+    UPDATE, so two simultaneous views don't race on read-then-write.
+
+    Best-effort: any HTTP error is swallowed and 0 returned so a
+    flaky counter never breaks the public /shared/{token} page.
+    """
+    try:
+        async with httpx.AsyncClient(timeout=5) as client:
+            r = await client.post(
+                f"{settings.supabase_url}/rest/v1/rpc/increment_share_view",
+                headers={**_headers(), "Prefer": "return=representation"},
+                json={"p_token": token},
+            )
+            r.raise_for_status()
+            data = r.json()
+            if isinstance(data, int):
+                return data
+            if isinstance(data, list) and data and isinstance(data[0], int):
+                return data[0]
+            return 0
+    except Exception:
+        return 0
 
 
 async def clear_video_analysis_object_key(

--- a/src/app/(app)/analyze/page.tsx
+++ b/src/app/(app)/analyze/page.tsx
@@ -22,6 +22,7 @@ import {
   Share2,
   Link2Off,
   Copy,
+  Eye,
 } from "lucide-react";
 import { useVideoAnalysis } from "@/hooks/use-video-analysis";
 import { useAnalysisHistory, type AnalysisRecord } from "@/hooks/use-analysis-history";
@@ -937,6 +938,24 @@ function HistoryRow({
                   <span className="hidden sm:inline">Delete video</span>
                 </Button>
               </>
+            )}
+
+            {shareUrl && (record.share_view_count ?? 0) > 0 && (
+              <span
+                className="inline-flex items-center gap-1 text-xs text-muted-foreground tabular-nums"
+                title={
+                  record.share_last_viewed_at
+                    ? `Last viewed ${new Date(record.share_last_viewed_at).toLocaleString()}`
+                    : undefined
+                }
+              >
+                <Eye className="h-3 w-3" />
+                {record.share_view_count}
+                <span className="hidden sm:inline">
+                  {" "}
+                  view{record.share_view_count === 1 ? "" : "s"}
+                </span>
+              </span>
             )}
 
             {shareUrl ? (

--- a/src/hooks/use-analysis-history.ts
+++ b/src/hooks/use-analysis-history.ts
@@ -18,6 +18,8 @@ export type AnalysisRecord = {
   stage: string | null;
   tags: string[] | null;
   share_token: string | null;
+  share_view_count: number | null;
+  share_last_viewed_at: string | null;
   deleted_at: string | null;
   created_at: string;
 };
@@ -62,7 +64,7 @@ export function useAnalysisHistory() {
     const activePromise = sb
       .from("video_analyses")
       .select(
-        "id, filename, duration, result, object_key, role, competition_level, event_name, event_date, stage, tags, share_token, deleted_at, created_at"
+        "id, filename, duration, result, object_key, role, competition_level, event_name, event_date, stage, tags, share_token, share_view_count, share_last_viewed_at, deleted_at, created_at"
       )
       .is("deleted_at", null)
       .order("created_at", { ascending: false })

--- a/src/lib/wcs-api.ts
+++ b/src/lib/wcs-api.ts
@@ -382,14 +382,23 @@ export type SharedAnalysis = {
   stage?: string | null;
   tags?: string[] | null;
   created_at: string;
+  // Populated server-side on real browser views — link-preview
+  // bots don't count.
+  share_view_count?: number;
+  share_last_viewed_at?: string | null;
 };
 
 export async function fetchSharedAnalysis(
   token: string
 ): Promise<SharedAnalysis> {
   if (!API_URL) throw new Error("NEXT_PUBLIC_WCS_API_URL is not set");
+  // The custom header tells the backend this is a real frontend
+  // navigation (not a Slack/Twitter unfurl), so the view counter
+  // increments. Bots can't forge custom request headers via the
+  // standard OpenGraph scrape path — they just do a plain GET.
   const res = await fetch(
-    `${API_URL}/shared/${encodeURIComponent(token)}`
+    `${API_URL}/shared/${encodeURIComponent(token)}`,
+    { headers: { "X-Swingflow-View": "1" } }
   );
   if (!res.ok) {
     let detail = res.statusText;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -120,19 +120,28 @@ create table if not exists public.video_analyses (
   -- Soft-delete: analyze list filters these out; dashboard score
   -- trend chart still shows them for historical progress.
   deleted_at        timestamptz,
+  -- Share-link view counter — see migration block below for details.
+  share_view_count      integer not null default 0,
+  share_last_viewed_at  timestamptz,
   created_at        timestamptz not null default now()
 );
 
 -- Migration: add cost columns to pre-existing rows. Idempotent.
 alter table public.video_analyses
-  add column if not exists model           text,
-  add column if not exists prompt_tokens   integer,
-  add column if not exists response_tokens integer,
-  add column if not exists cost_usd_micros integer,
+  add column if not exists model                 text,
+  add column if not exists prompt_tokens         integer,
+  add column if not exists response_tokens       integer,
+  add column if not exists cost_usd_micros       integer,
   -- Soft-delete: the analyze list filters these out, but the
   -- dashboard score trend chart still shows them so users can see
   -- their historical progress even after cleaning up old clips.
-  add column if not exists deleted_at      timestamptz;
+  add column if not exists deleted_at            timestamptz,
+  -- Share-link view tracking: incremented by the /shared/{token}
+  -- backend route on real browser navigations (Sec-Fetch-Mode:
+  -- navigate) so Slack/iMessage/Twitter link-preview unfurls don't
+  -- inflate the count.
+  add column if not exists share_view_count      integer not null default 0,
+  add column if not exists share_last_viewed_at  timestamptz;
 
 create index if not exists video_analyses_user_active_idx
   on public.video_analyses(user_id, created_at desc)
@@ -348,3 +357,29 @@ $$;
 -- from our FastAPI admin route. Email-based gating happens in the
 -- FastAPI layer, not in SQL, so the function itself is callable by
 -- anyone with the service key.
+
+
+-- ────────────────────────────────────────────────────────────
+-- Share-link view counter RPC — atomic increment.
+-- Called by the FastAPI /shared/{token} route on real browser
+-- navigations (filtered by Sec-Fetch-Mode upstream). Returns the
+-- new count so the route can include it in observability logs.
+-- ────────────────────────────────────────────────────────────
+
+create or replace function public.increment_share_view(p_token text)
+returns integer
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  new_count integer;
+begin
+  update public.video_analyses
+    set share_view_count     = coalesce(share_view_count, 0) + 1,
+        share_last_viewed_at = now()
+    where share_token = p_token
+    returning share_view_count into new_count;
+  return coalesce(new_count, 0);
+end;
+$$;


### PR DESCRIPTION
## What

Track how many real browser visits each shared analysis link gets. Owner sees a small "eye-icon · N views" indicator next to the Copy / Stop-sharing buttons on their history row; hovering reveals the exact last-viewed timestamp. The public share page itself never displays the count.

## Bot filtering

Slack/iMessage/Twitter/Discord auto-unfurl will GET every shared URL to build a link preview. Those fire-and-forget hits would otherwise inflate the count with no real human interest. Two layers:

1. **Primary signal — custom header.** The official frontend sends `X-Swingflow-View: 1` on its fetch. Bots that scrape OpenGraph previews can't forge arbitrary request headers, so they're excluded.
2. **Fallback — Sec-Fetch-Mode + UA.** If the request looks like a real browser navigation (`Sec-Fetch-Mode: navigate` or `cors`) and the UA doesn't match a bot list (Slackbot, Twitterbot, facebookexternalhit, Discordbot, WhatsApp, TelegramBot, LinkedInBot, generic `bot|crawler|spider|preview`), we still count it.

False-negative friendly by design — undercounting is better than inflated numbers from every Slack channel the owner posted in.

## Atomicity

New RPC `public.increment_share_view(p_token text) returns int` wraps the UPDATE+RETURNING in one server-side statement, so two simultaneous views can't race on read-then-write. The helper is `security definer` so it works under the service-role key we already use for backend DB calls.

Call is best-effort — any HTTP error is swallowed inside `increment_share_view`, so a flaky counter never breaks the public `/shared` page.

## Files

- `supabase/schema.sql` — new columns + RPC (idempotent)
- `api/src/wcs_api/services/supabase_admin.py` — `increment_share_view()` client + view count fields on `get_shared_analysis`
- `api/src/wcs_api/routes/shared.py` — header parsing, bot detection, increment call
- `src/lib/wcs-api.ts` — `fetchSharedAnalysis` sends the view header + type exposes the two new fields
- `src/hooks/use-analysis-history.ts` — projects the new columns
- `src/app/(app)/analyze/page.tsx` — eye-icon view count badge on shared history rows

## Test plan

- [x] Backend: `_is_real_browser_navigation` returns false for Slackbot/Twitterbot UAs, true for Chrome `navigate`, true for fetch `cors`
- [x] Backend: `increment_share_view` import path clean
- [x] Frontend: `tsc --noEmit` clean
- [ ] E2E: open a share link in your browser, confirm the badge bumps to `1 view` on the owner's history row
- [ ] E2E: paste the link in Slack, confirm Slackbot preview doesn't inflate the count

## Schema migration

Idempotent — paste `supabase/schema.sql` or just this block:

```sql
alter table public.video_analyses
  add column if not exists share_view_count      integer not null default 0,
  add column if not exists share_last_viewed_at  timestamptz;

create or replace function public.increment_share_view(p_token text)
returns integer language plpgsql security definer set search_path = public
as $$
declare new_count integer;
begin
  update public.video_analyses
    set share_view_count = coalesce(share_view_count, 0) + 1,
        share_last_viewed_at = now()
    where share_token = p_token
    returning share_view_count into new_count;
  return coalesce(new_count, 0);
end;
$$;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)