### PR TITLE
Focus scoring on a specific dancer / couple

### DIFF
--- a/api/src/wcs_api/routes/video.py
+++ b/api/src/wcs_api/routes/video.py
@@ -2,7 +2,7 @@ import os
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from ..auth import verify_jwt
 from ..services import quota, r2, supabase_admin
@@ -25,6 +25,13 @@ class VideoAnalyzeBody(BaseModel):
     event_date: str | None = None  # ISO date string (YYYY-MM-DD)
     stage: str | None = None
     tags: list[str] | None = None
+    # Free-text description of which dancer / couple to focus on
+    # when multiple people are in frame (e.g. "couple in the red
+    # dress and blue shirt", "the lead on the far right"). Fed into
+    # Gemini's DANCER IDENTIFICATION block. Capped at 200 chars to
+    # keep the prompt overhead bounded and prevent prompt injection
+    # via a multi-paragraph dump.
+    dancer_description: str | None = Field(default=None, max_length=200)
 
 
 def _admin_error_to_http(exc: httpx.HTTPStatusError) -> HTTPException:
@@ -142,6 +149,7 @@ async def analyze_video_endpoint(
                     "event_date": body.event_date,
                     "stage": body.stage,
                     "tags": body.tags,
+                    "dancer_description": body.dancer_description,
                 },
             )
         except VideoAnalysisError as exc:
@@ -176,6 +184,7 @@ async def analyze_video_endpoint(
                 event_date=body.event_date,
                 stage=body.stage,
                 tags=body.tags,
+                dancer_description=body.dancer_description,
                 usage=usage,
             )
         except Exception:

--- a/api/src/wcs_api/services/supabase_admin.py
+++ b/api/src/wcs_api/services/supabase_admin.py
@@ -82,6 +82,7 @@ async def insert_video_analysis(
     event_date: str | None = None,
     stage: str | None = None,
     tags: list[str] | None = None,
+    dancer_description: str | None = None,
     usage: dict[str, Any] | None = None,
 ) -> None:
     record: dict[str, Any] = {
@@ -103,6 +104,8 @@ async def insert_video_analysis(
         record["stage"] = stage
     if tags:
         record["tags"] = tags
+    if dancer_description:
+        record["dancer_description"] = dancer_description
     if usage:
         record["model"] = usage.get("model")
         record["prompt_tokens"] = usage.get("prompt_tokens")

--- a/api/src/wcs_api/services/video_analyzer.py
+++ b/api/src/wcs_api/services/video_analyzer.py
@@ -614,9 +614,33 @@ def _build_user_context(context: dict[str, Any] | None) -> str:
     upload form into a short context block for Gemini. Keeps the
     model grounded on what the user *says* they are (and is at),
     while still scoring against the objective WSDC rubric.
+
+    Also includes a DANCER IDENTIFICATION paragraph when
+    `dancer_description` is set — critical for practice-floor or
+    social-dance clips where multiple couples share the frame.
     """
     if not context:
         return ""
+
+    # Defensive cap in case the request body bypassed the pydantic
+    # validator (older clients, direct REST hits, etc.). Matches the
+    # max_length on VideoAnalyzeBody.dancer_description.
+    dancer = (context.get("dancer_description") or "").strip()[:200]
+    dancer_block = ""
+    if dancer:
+        dancer_block = (
+            "DANCER IDENTIFICATION: "
+            f"{dancer}\n"
+            "Focus your analysis ONLY on these dancers. There may be "
+            "other people visible in the video (other couples, "
+            "spectators, judges, instructors) — ignore them entirely. "
+            "Every pattern you identify, every score you give, and "
+            "every observation you make must refer exclusively to the "
+            "identified dancer(s). If you can't confidently tell which "
+            "dancer matches the description at any given moment, say so "
+            "in the reasoning rather than guessing.\n\n"
+        )
+
     fields = []
     if context.get("role"):
         fields.append(f"- Role: {context['role']}")
@@ -636,20 +660,27 @@ def _build_user_context(context: dict[str, Any] | None) -> str:
         if isinstance(tags, (list, tuple)) and tags:
             fields.append(f"- Tags: {', '.join(str(t) for t in tags)}")
 
-    if not fields:
+    if not fields and not dancer_block:
         return ""
-    return (
-        "USER-PROVIDED CONTEXT:\n"
-        + "\n".join(fields)
-        + "\n\nCalibrate your scoring against the self-reported level — "
-        "a Novice scoring 6/10 is different from a Champion scoring 6/10, "
-        "and your reasoning should reflect the dancer's stated tier. "
-        "If the video clearly shows a dancer at a different level than "
-        "what they self-report, score based on what you observe and say "
-        "so in the reasoning. Use the event / stage info to decide how "
-        "formal the scoring should feel (Finals on the floor vs. a "
-        "practice social).\n"
-    )
+
+    context_block = ""
+    if fields:
+        context_block = (
+            "USER-PROVIDED CONTEXT:\n"
+            + "\n".join(fields)
+            + "\n\nCalibrate your scoring against the self-reported level — "
+            "a Novice scoring 6/10 is different from a Champion scoring 6/10, "
+            "and your reasoning should reflect the dancer's stated tier. "
+            "If the video clearly shows a dancer at a different level than "
+            "what they self-report, score based on what you observe and say "
+            "so in the reasoning. Use the event / stage info to decide how "
+            "formal the scoring should feel (Finals on the floor vs. a "
+            "practice social).\n"
+        )
+
+    # Dancer identification comes first so the model knows WHO to
+    # score before anything about how to score them.
+    return dancer_block + context_block
 
 
 def _build_sanity_retry_prompt(

--- a/src/app/(app)/analyze/page.tsx
+++ b/src/app/(app)/analyze/page.tsx
@@ -216,6 +216,7 @@ export default function AnalyzePage() {
   const [eventName, setEventName] = useState("");
   const [eventDate, setEventDate] = useState("");
   const [tagsInput, setTagsInput] = useState("");
+  const [dancerDescription, setDancerDescription] = useState("");
 
   const role =
     roleSelect === OTHER ? roleCustom.trim() : roleSelect.trim();
@@ -280,6 +281,7 @@ export default function AnalyzePage() {
     const normalizedDate = eventDate
       ? `${eventDate}-01`
       : undefined;
+    const focus = dancerDescription.trim().slice(0, 200);
     analyze(file, {
       role: role || undefined,
       competitionLevel: competitionLevel || undefined,
@@ -287,6 +289,7 @@ export default function AnalyzePage() {
       eventDate: normalizedDate,
       stage: stage || undefined,
       tags: tags.length ? tags : undefined,
+      dancerDescription: focus || undefined,
     }).then(() => history.refresh());
   }, [
     file,
@@ -298,6 +301,7 @@ export default function AnalyzePage() {
     eventDate,
     stage,
     tagsInput,
+    dancerDescription,
   ]);
 
   const handleClear = useCallback(() => {
@@ -513,6 +517,28 @@ export default function AnalyzePage() {
                     onChange={(e) => setTagsInput(e.target.value)}
                     className="h-8 text-sm"
                   />
+                </div>
+
+                <div className="space-y-1">
+                  <Label htmlFor="dancer-focus" className="text-xs">
+                    Focus on
+                    <span className="ml-1 text-muted-foreground font-normal">
+                      (if multiple people in frame)
+                    </span>
+                  </Label>
+                  <Input
+                    id="dancer-focus"
+                    placeholder="e.g. couple in the red dress, lead on the right"
+                    value={dancerDescription}
+                    onChange={(e) =>
+                      setDancerDescription(e.target.value.slice(0, 200))
+                    }
+                    maxLength={200}
+                    className="h-8 text-sm"
+                  />
+                  <p className="text-[10px] text-muted-foreground tabular-nums text-right">
+                    {dancerDescription.length}/200
+                  </p>
                 </div>
               </div>
             )}
@@ -1019,6 +1045,12 @@ function HistoryRow({
               <span className="hidden sm:inline">Delete analysis</span>
             </Button>
           </div>
+
+          {record.dancer_description && (
+            <p className="text-xs text-muted-foreground italic">
+              Focused on: {record.dancer_description}
+            </p>
+          )}
 
           {shareMessage && (
             <p className="text-xs text-primary">{shareMessage}</p>

--- a/src/hooks/use-analysis-history.ts
+++ b/src/hooks/use-analysis-history.ts
@@ -17,6 +17,7 @@ export type AnalysisRecord = {
   event_date: string | null;
   stage: string | null;
   tags: string[] | null;
+  dancer_description: string | null;
   share_token: string | null;
   share_view_count: number | null;
   share_last_viewed_at: string | null;
@@ -64,7 +65,7 @@ export function useAnalysisHistory() {
     const activePromise = sb
       .from("video_analyses")
       .select(
-        "id, filename, duration, result, object_key, role, competition_level, event_name, event_date, stage, tags, share_token, share_view_count, share_last_viewed_at, deleted_at, created_at"
+        "id, filename, duration, result, object_key, role, competition_level, event_name, event_date, stage, tags, dancer_description, share_token, share_view_count, share_last_viewed_at, deleted_at, created_at"
       )
       .is("deleted_at", null)
       .order("created_at", { ascending: false })

--- a/src/lib/wcs-api.ts
+++ b/src/lib/wcs-api.ts
@@ -339,6 +339,10 @@ export type VideoAnalyzeOptions = {
   eventDate?: string; // YYYY-MM-DD
   stage?: string;
   tags?: string[];
+  // Free-text description of which dancer / couple to focus on
+  // when multiple people are in frame (e.g. "couple in the red
+  // dress and blue shirt", "the lead on the far right").
+  dancerDescription?: string;
 };
 
 export async function analyzeVideoFromKey(
@@ -355,6 +359,7 @@ export async function analyzeVideoFromKey(
     event_date: options.eventDate || null,
     stage: options.stage || null,
     tags: options.tags && options.tags.length ? options.tags : null,
+    dancer_description: options.dancerDescription || null,
   });
 }
 

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -111,6 +111,11 @@ create table if not exists public.video_analyses (
   event_date        date,            -- optional: when the event happened (separate from created_at)
   stage             text,            -- optional: prelims / quarters / semis / finals
   tags              text[] default '{}',  -- optional free-form user tags
+  -- When there's more than one couple in frame, the user can
+  -- describe which dancer(s) we should focus on (e.g. "couple in
+  -- the red dress and blue shirt", "the lead on the far right").
+  -- Prepended to the Gemini prompt as a DANCER IDENTIFICATION block.
+  dancer_description text,
   share_token       text,            -- NULL = not shared; set = public read via /shared?t=<token>
   -- Cost / usage tracking (admin-only, never exposed to user UI).
   model             text,
@@ -141,7 +146,10 @@ alter table public.video_analyses
   -- navigate) so Slack/iMessage/Twitter link-preview unfurls don't
   -- inflate the count.
   add column if not exists share_view_count      integer not null default 0,
-  add column if not exists share_last_viewed_at  timestamptz;
+  add column if not exists share_last_viewed_at  timestamptz,
+  -- Free-text identifier used to focus scoring on a specific
+  -- dancer/couple when the video has multiple people in frame.
+  add column if not exists dancer_description    text;
 
 create index if not exists video_analyses_user_active_idx
   on public.video_analyses(user_id, created_at desc)


### PR DESCRIPTION
## Problem

Practice-floor and social-dance clips usually have multiple couples in frame. Previously Gemini scored "whoever it noticed most" — unreliable feedback if you actually wanted per-couple attention. wcs-analyzer solves this with a `dancer_description` field; this PR ports it end-to-end.

## What ships

### UI
- New **Focus on (if multiple people in frame)** input at the bottom of the optional-tags block on `/analyze`
- Placeholder: `e.g. couple in the red dress, lead on the right`
- Capped at 200 characters with a live `N/200` counter
- Stored value renders as `Focused on: …` below the action buttons on expanded history rows

### Prompt
When set, a `DANCER IDENTIFICATION` paragraph sits at the very top of the prompt:
> Focus your analysis ONLY on these dancers. There may be other people visible in the video (other couples, spectators, judges, instructors) — ignore them entirely. Every pattern you identify, every score you give, and every observation you make must refer exclusively to the identified dancer(s). If you can't confidently tell which dancer matches the description at any given moment, say so in the reasoning rather than guessing.

### Schema + API
- `video_analyses.dancer_description text` (idempotent ALTER)
- `VideoAnalyzeBody.dancer_description: str | None = Field(max_length=200)` — pydantic-validated to bound prompt overhead + prompt-injection surface
- Persisted via `insert_video_analysis`
- Defensive `[:200]` trim inside `_build_user_context` too (belt and suspenders)

## Migration

```sql
alter table public.video_analyses
  add column if not exists dancer_description text;
```

## Test plan

- [x] Prompt builder renders DANCER IDENTIFICATION block when set
- [x] Prompt builder returns `""` when no context at all
- [x] 300-char input gets trimmed to 200 inside the builder
- [x] `tsc --noEmit` clean
- [ ] E2E: upload a social-dance clip with multiple couples, set focus to "couple in red", confirm scoring references that couple only

🤖 Generated with [Claude Code](https://claude.com/claude-code)