### PR TITLE
Chart uses event_date, monthly avg is prominent, free plan = 2 videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Includes WCS pattern presets, tempo ramp for progressive difficulty, timing accu
 Guided warm-up routines in 5, 15, or 30-minute sessions. Covers joint mobility, body isolation, walking practice, triple step drills, anchor variations, and pattern work.
 
 ### Accounts & Plan Tiers
-- **Free** — 1 video analysis / month, 2-minute clips, unlimited music analysis
+- **Free** — 2 video analyses / month, 2-minute clips, unlimited music analysis
 - **Basic ($10/mo)** — 10 video analyses / month, 5-minute clips, unlimited music analysis
 - Per-user quota overrides on the `profiles` table for beta testers and refunds
 - Google-auth-free: email + password via Supabase Auth

--- a/api/src/wcs_api/settings.py
+++ b/api/src/wcs_api/settings.py
@@ -38,7 +38,7 @@ class Settings(BaseSettings):
     r2_secret_access_key: str = ""
     r2_bucket: str = "swingflow-uploads"
     r2_upload_ttl_seconds: int = 3600
-    free_monthly_video: int = 1
+    free_monthly_video: int = 2
     free_max_video_seconds: int = 120
     basic_monthly_video: int = 10
     basic_max_video_seconds: int = 300

--- a/src/app/(app)/billing/page.tsx
+++ b/src/app/(app)/billing/page.tsx
@@ -24,7 +24,7 @@ const BASIC_BENEFITS = [
 ];
 
 const FREE_FEATURES = [
-  "1 dance video analysis per month, up to 2 minutes",
+  "2 dance video analyses per month, up to 2 minutes each",
   "Precise cloud music analysis — unlimited songs",
 ];
 

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -115,7 +115,7 @@ export default function LoginPage() {
             </TabsContent>
             <TabsContent value="signup" className="pt-2">
               <p className="text-center text-xs text-muted-foreground">
-                Free tier: 1 video analysis / month. Music analysis is
+                Free tier: 2 video analyses / month. Music analysis is
                 unlimited.
               </p>
             </TabsContent>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -74,7 +74,7 @@ export default function HomePage() {
                 </Button>
               </div>
               <p className="text-xs text-muted-foreground pt-2">
-                No credit card required · 1 video analysis / month free ·
+                No credit card required · 2 video analyses / month free ·
                 Unlimited music analysis
               </p>
             </div>
@@ -382,7 +382,7 @@ export default function HomePage() {
                     </li>
                     <li className="flex items-start gap-2">
                       <Check className="h-4 w-4 text-primary mt-0.5 shrink-0" />
-                      <span>1 dance video analysis / month (up to 2 min)</span>
+                      <span>2 dance video analyses / month (up to 2 min each)</span>
                     </li>
                     <li className="flex items-start gap-2">
                       <Check className="h-4 w-4 text-primary mt-0.5 shrink-0" />

--- a/src/components/analyze/score-trend.tsx
+++ b/src/components/analyze/score-trend.tsx
@@ -14,6 +14,10 @@ type Point = {
   stage: string | null;
   competition_level: string | null;
   tags: string[] | null;
+  // True when the bucket date came from the upload's `event_date`
+  // rather than `created_at` — useful for the hover tooltip so
+  // viewers understand why a clip sits where it does.
+  from_event_date: boolean;
   deleted: boolean;
 };
 
@@ -52,15 +56,35 @@ function buildBuckets(records: ChartRecord[]): MonthBucket[] {
   const points: Point[] = [];
   for (const r of records) {
     if (typeof r.score !== "number" || Number.isNaN(r.score)) continue;
+    // Prefer the user-entered event_date so footage from a 2024
+    // event clusters in 2024, even if uploaded later. Falls back to
+    // created_at when no event date was supplied.
+    let date: Date;
+    let fromEvent = false;
+    if (r.event_date) {
+      // Postgres stores as 'YYYY-MM-DD'. Append midnight UTC to
+      // avoid the constructor interpreting a bare date as UTC and
+      // then shifting it into the previous day in western timezones.
+      const parsed = new Date(`${r.event_date}T00:00:00`);
+      if (!Number.isNaN(parsed.getTime())) {
+        date = parsed;
+        fromEvent = true;
+      } else {
+        date = new Date(r.created_at);
+      }
+    } else {
+      date = new Date(r.created_at);
+    }
     points.push({
       id: r.id,
-      date: new Date(r.created_at),
+      date,
       score: r.score,
       filename: r.filename,
       event_name: r.event_name,
       stage: r.stage,
       competition_level: r.competition_level,
       tags: r.tags,
+      from_event_date: fromEvent,
       deleted: Boolean(r.deleted_at),
     });
   }
@@ -317,7 +341,8 @@ function TrendSVG({
           </g>
         ))}
 
-        {/* Average polyline */}
+        {/* Average polyline connecting months with data. Sits behind
+            the per-month markers so the markers read as anchors. */}
         {pathD && (
           <path
             d={pathD}
@@ -327,20 +352,67 @@ function TrendSVG({
             strokeWidth={2}
             strokeLinecap="round"
             strokeLinejoin="round"
-            opacity={0.7}
+            opacity={0.5}
           />
         )}
 
-        {/* Average-per-month markers */}
-        {avgPath.map((p, i) => (
-          <circle
-            key={`avg-${i}`}
-            cx={p.x}
-            cy={p.y}
-            r={3}
-            className="fill-primary"
-          />
-        ))}
+        {/* Per-month monthly-average visual:
+            - thick primary range bar covering min → max (so a
+              dancer with a wide spread sees that spread at a glance)
+            - large primary circle at the monthly avg, labelled
+              with the numeric avg so a single-month chart still
+              communicates meaningfully */}
+        {buckets.map((b, i) => {
+          if (b.points.length === 0) return null;
+          const scores = b.points.map((p) => p.score);
+          const minS = Math.min(...scores);
+          const maxS = Math.max(...scores);
+          const x = xFor(i);
+          const avgY = yFor(b.avg);
+          return (
+            <g key={`avg-${i}`}>
+              {maxS > minS && (
+                <line
+                  x1={x}
+                  x2={x}
+                  y1={yFor(maxS)}
+                  y2={yFor(minS)}
+                  stroke="currentColor"
+                  className="text-primary"
+                  strokeWidth={6}
+                  strokeOpacity={0.18}
+                  strokeLinecap="round"
+                />
+              )}
+              <circle
+                cx={x}
+                cy={avgY}
+                r={5.5}
+                className="fill-primary"
+                stroke="white"
+                strokeOpacity={0.35}
+                strokeWidth={1.5}
+              >
+                <title>
+                  {b.label} {b.year}: avg {b.avg.toFixed(1)} across{" "}
+                  {b.points.length} analys{b.points.length === 1 ? "is" : "es"}
+                  {maxS > minS
+                    ? ` · range ${minS.toFixed(1)}–${maxS.toFixed(1)}`
+                    : ""}
+                </title>
+              </circle>
+              <text
+                x={x + 9}
+                y={avgY + 3}
+                className="fill-foreground"
+                fontSize={10}
+                fontWeight={600}
+              >
+                {b.avg.toFixed(1)}
+              </text>
+            </g>
+          );
+        })}
 
         {/* Individual analysis dots. Soft-deleted rows render as
             hollow outlines so the user can tell them apart from

--- a/src/hooks/use-analysis-history.ts
+++ b/src/hooks/use-analysis-history.ts
@@ -39,6 +39,11 @@ export type ChartRecord = {
   stage: string | null;
   competition_level: string | null;
   tags: string[] | null;
+  // When the user entered an event date on the upload form (the
+  // month the video was actually recorded), the chart buckets by
+  // that instead of created_at — so a clip from a 2024 competition
+  // uploaded today lands in 2024, not today.
+  event_date: string | null;
   deleted_at: string | null;
   created_at: string;
 };
@@ -78,7 +83,7 @@ export function useAnalysisHistory() {
     const chartPromise = sb
       .from("video_analyses")
       .select(
-        "id, filename, created_at, deleted_at, event_name, stage, competition_level, tags, result"
+        "id, filename, created_at, event_date, deleted_at, event_name, stage, competition_level, tags, result"
       )
       .order("created_at", { ascending: true })
       .limit(1000);
@@ -93,6 +98,7 @@ export function useAnalysisHistory() {
       id: string;
       filename: string | null;
       created_at: string;
+      event_date: string | null;
       deleted_at: string | null;
       event_name: string | null;
       stage: string | null;
@@ -107,6 +113,7 @@ export function useAnalysisHistory() {
       stage: r.stage,
       competition_level: r.competition_level,
       tags: r.tags,
+      event_date: r.event_date,
       deleted_at: r.deleted_at,
       created_at: r.created_at,
     }));


### PR DESCRIPTION
## Three changes

### 1. Score trend bucket by event_date (not upload date)
Uploading a 2024 competition video today previously put it in April 2026. Now the chart prefers `event_date` (the month the user entered on the upload form) and falls back to `created_at` when no event date was supplied. A clip from Sept 2024 lands in Sept 2024, which is what the dancer actually cares about.

Also fixed a timezone bug: parsing `YYYY-MM-DD` as a bare date was shifting into the previous day in western timezones. Now parsed with an explicit `T00:00:00`.

### 2. Monthly average is visually obvious
Previously the monthly avg was the same r=3 primary dot as the scatter — invisible in the screenshot you sent. Now:
- **Larger primary circle** (r=5.5, white outline) at the avg
- **Numeric avg label** beside the dot (`5.5`)
- **Thick semi-transparent range bar** behind the dot spanning min→max for the month, so wide spreads read at a glance

Single-month charts communicate meaningfully now without needing a between-months polyline. The polyline is still there but dimmed to opacity 0.5 so it sits behind the markers.

### 3. Free plan: 2 videos / month
Raised `free_monthly_video` default from 1 → 2. Pricing copy updated everywhere (landing hero, pricing card, login page footer, billing page, README).

## Files

- `src/hooks/use-analysis-history.ts` — projects `event_date` into `ChartRecord`
- `src/components/analyze/score-trend.tsx` — new bucket-date logic + prominent monthly avg
- `api/src/wcs_api/settings.py` — `free_monthly_video: 1 → 2`
- `src/app/page.tsx`, `src/app/(app)/billing/page.tsx`, `src/app/(auth)/login/page.tsx`, `README.md` — copy updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)