### PR TITLE
Level context + per-category trends + scoring info box

### DIFF
--- a/src/app/(app)/analyze/page.tsx
+++ b/src/app/(app)/analyze/page.tsx
@@ -26,6 +26,7 @@ import {
 } from "lucide-react";
 import { useVideoAnalysis } from "@/hooks/use-video-analysis";
 import { useAnalysisHistory, type AnalysisRecord } from "@/hooks/use-analysis-history";
+import { getLevelContext } from "@/lib/level-context";
 import {
   analyzeVideoFromKey,
   deleteUploadedVideo,
@@ -395,6 +396,11 @@ export default function AnalyzePage() {
         </Card>
       )}
 
+      {/* How scoring works — quietly collapsed by default so it
+          doesn't dominate the page, but always accessible for users
+          wondering what their score is based on. */}
+      {state.status !== "success" && <HowScoringWorksInfo />}
+
       {/* Uploader */}
       {!isPaywalled && state.status !== "success" && (
         <Card>
@@ -610,6 +616,7 @@ export default function AnalyzePage() {
           <ScoreResultCard
             result={state.result.result}
             duration={state.result.duration}
+            competitionLevel={competitionLevel || undefined}
             onClear={handleClear}
           />
           <Card>
@@ -1120,6 +1127,7 @@ function HistoryRow({
               <ScoreResultCard
                 result={currentResult}
                 duration={record.duration ?? 0}
+                competitionLevel={record.competition_level}
                 onClear={() => setExpanded(false)}
               />
             </>
@@ -1133,12 +1141,18 @@ function HistoryRow({
 function ScoreResultCard({
   result,
   duration,
+  competitionLevel,
   onClear,
 }: {
   result: VideoScoreResult;
   duration: number;
+  competitionLevel?: string | null;
   onClear: () => void;
 }) {
+  const levelContext = getLevelContext(
+    result.overall.score,
+    competitionLevel
+  );
   return (
     <div className="space-y-4">
       <Card className="bg-gradient-to-b from-card to-muted/20">
@@ -1161,6 +1175,20 @@ function ScoreResultCard({
               </span>
               <span className="text-xl sm:text-2xl text-muted-foreground">/10</span>
             </div>
+            {levelContext && (
+              <span
+                className={`text-xs font-medium ${
+                  levelContext.tone === "above"
+                    ? "text-emerald-300"
+                    : levelContext.tone === "below"
+                    ? "text-amber-300"
+                    : "text-muted-foreground"
+                }`}
+                title={`Heuristic tier range for ${levelContext.matchedLevel}. Compares against typical WCS scoring bands, not peer data.`}
+              >
+                {levelContext.label}
+              </span>
+            )}
             <div className="flex items-center gap-2">
               <Badge className="text-sm px-3 py-0.5">
                 {result.overall.grade}
@@ -1289,6 +1317,130 @@ function ScoreResultCard({
         Analyze another video
       </Button>
     </div>
+  );
+}
+
+function HowScoringWorksInfo() {
+  return (
+    <Card className="border-primary/20 bg-primary/5">
+      <CardContent className="p-0">
+        <details className="group">
+          <summary className="flex items-center justify-between cursor-pointer list-none p-4 text-sm font-medium">
+            <span className="flex items-center gap-2">
+              <Sparkles className="h-4 w-4 text-primary" />
+              How scoring works
+            </span>
+            <span className="text-xs text-muted-foreground group-open:hidden">
+              Show details ▾
+            </span>
+            <span className="text-xs text-muted-foreground hidden group-open:inline">
+              Hide ▴
+            </span>
+          </summary>
+          <div className="px-4 pb-4 space-y-4 text-xs text-muted-foreground">
+            <div>
+              <p className="font-medium text-foreground mb-1.5">
+                WSDC-style scoring · 4 weighted categories
+              </p>
+              <ul className="space-y-1">
+                <li>
+                  <span className="font-mono text-foreground">30%</span>{" "}
+                  <span className="font-medium text-foreground">
+                    Timing & Rhythm
+                  </span>{" "}
+                  — on-beat dancing, triple-step precision, anchor-step
+                  placement, musical breaks
+                </li>
+                <li>
+                  <span className="font-mono text-foreground">30%</span>{" "}
+                  <span className="font-medium text-foreground">
+                    Technique
+                  </span>{" "}
+                  — posture, extension, footwork (heel-toe rolling), slot
+                  discipline, frame
+                </li>
+                <li>
+                  <span className="font-mono text-foreground">20%</span>{" "}
+                  <span className="font-medium text-foreground">Teamwork</span>{" "}
+                  — connection quality, shared weight, responsiveness,
+                  matched energy
+                </li>
+                <li>
+                  <span className="font-mono text-foreground">20%</span>{" "}
+                  <span className="font-medium text-foreground">
+                    Presentation
+                  </span>{" "}
+                  — musicality, styling, stage presence, creative movement
+                </li>
+              </ul>
+            </div>
+
+            <div>
+              <p className="font-medium text-foreground mb-1.5">
+                What affects your score
+              </p>
+              <ul className="space-y-1">
+                <li>
+                  <span className="font-medium text-foreground">Level</span>{" "}
+                  — calibrates the rubric. A Novice at 6.5 and a Champion
+                  at 6.5 are judged against different expectations in the
+                  written feedback.
+                </li>
+                <li>
+                  <span className="font-medium text-foreground">
+                    Focus on (who)
+                  </span>{" "}
+                  — when multiple dancers are in frame, this restricts
+                  scoring to the identified dancer(s) only.
+                </li>
+                <li>
+                  <span className="font-medium text-foreground">
+                    Role / Event / Stage / Tags
+                  </span>{" "}
+                  — context for the reasoning. Doesn&apos;t change the
+                  rubric; helps you filter and compare later.
+                </li>
+                <li>
+                  <span className="font-medium text-foreground">
+                    Audio quality
+                  </span>{" "}
+                  — the model listens to the music to judge on-beat
+                  dancing. Phone-mic clips are fine; completely silent
+                  video hurts Timing scoring.
+                </li>
+              </ul>
+            </div>
+
+            <div>
+              <p className="font-medium text-foreground mb-1.5">
+                What doesn&apos;t affect it
+              </p>
+              <ul className="space-y-1">
+                <li>
+                  Video quality and camera angle (within reason) — the
+                  model is tolerant of handheld phone footage
+                </li>
+                <li>
+                  Filename or tags — stored for your reference, not shown
+                  to the model
+                </li>
+                <li>
+                  Other analyses in your history — each clip is scored
+                  independently
+                </li>
+              </ul>
+            </div>
+
+            <p className="italic">
+              Scoring is a tool for reflection — use it to spot patterns
+              over time rather than as a definitive judgment on any one
+              run. The uncertainty band next to each score is the model&apos;s
+              honest confidence interval.
+            </p>
+          </div>
+        </details>
+      </CardContent>
+    </Card>
   );
 }
 

--- a/src/components/analyze/score-trend.tsx
+++ b/src/components/analyze/score-trend.tsx
@@ -4,7 +4,31 @@ import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { TrendingUp, Trash2, ExternalLink } from "lucide-react";
-import type { ChartRecord } from "@/hooks/use-analysis-history";
+import type { ChartMetric, ChartRecord } from "@/hooks/use-analysis-history";
+
+const METRIC_TABS: Array<{ key: ChartMetric; label: string }> = [
+  { key: "overall", label: "Overall" },
+  { key: "timing", label: "Timing" },
+  { key: "technique", label: "Technique" },
+  { key: "teamwork", label: "Teamwork" },
+  { key: "presentation", label: "Presentation" },
+];
+
+function scoreFor(r: ChartRecord, metric: ChartMetric): number | null {
+  switch (metric) {
+    case "timing":
+      return r.timing;
+    case "technique":
+      return r.technique;
+    case "teamwork":
+      return r.teamwork;
+    case "presentation":
+      return r.presentation;
+    case "overall":
+    default:
+      return r.score;
+  }
+}
 
 type Point = {
   id: string;
@@ -53,10 +77,14 @@ function addMonths(d: Date, n: number): Date {
 }
 
 /** Build per-month buckets covering [earliest - 3mo, max(now, latest) + 3mo]. */
-function buildBuckets(records: ChartRecord[]): MonthBucket[] {
+function buildBuckets(
+  records: ChartRecord[],
+  metric: ChartMetric = "overall"
+): MonthBucket[] {
   const points: Point[] = [];
   for (const r of records) {
-    if (typeof r.score !== "number" || Number.isNaN(r.score)) continue;
+    const s = scoreFor(r, metric);
+    if (typeof s !== "number" || Number.isNaN(s)) continue;
     // Prefer the user-entered event_date so footage from a 2024
     // event clusters in 2024, even if uploaded later. Falls back to
     // created_at when no event date was supplied.
@@ -79,7 +107,7 @@ function buildBuckets(records: ChartRecord[]): MonthBucket[] {
     points.push({
       id: r.id,
       date,
-      score: r.score,
+      score: s,
       filename: r.filename,
       event_name: r.event_name,
       stage: r.stage,
@@ -168,7 +196,11 @@ export function ScoreTrendChart({
   loading?: boolean;
 }) {
   const router = useRouter();
-  const buckets = useMemo(() => buildBuckets(records), [records]);
+  const [metric, setMetric] = useState<ChartMetric>("overall");
+  const buckets = useMemo(
+    () => buildBuckets(records, metric),
+    [records, metric]
+  );
   const [hovered, setHovered] = useState<Point | null>(null);
 
   // Clicking a dot or the detail card deep-links into the analyze
@@ -228,7 +260,7 @@ export function ScoreTrendChart({
 
   return (
     <Card>
-      <CardHeader className="pb-3">
+      <CardHeader className="pb-3 space-y-3">
         <CardTitle className="text-base flex items-center justify-between flex-wrap gap-2">
           <span className="flex items-center gap-2">
             <TrendingUp className="h-4 w-4 text-primary" />
@@ -245,6 +277,25 @@ export function ScoreTrendChart({
             )}
           </span>
         </CardTitle>
+        <div className="flex flex-wrap gap-1">
+          {METRIC_TABS.map((t) => (
+            <button
+              key={t.key}
+              type="button"
+              onClick={() => {
+                setMetric(t.key);
+                setHovered(null);
+              }}
+              className={`text-[11px] px-2 py-0.5 rounded-md border transition-colors ${
+                metric === t.key
+                  ? "border-primary bg-primary/15 text-foreground"
+                  : "border-border text-muted-foreground hover:text-foreground hover:border-primary/40"
+              }`}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
       </CardHeader>
       <CardContent>
         <TrendSVG

--- a/src/hooks/use-analysis-history.ts
+++ b/src/hooks/use-analysis-history.ts
@@ -31,10 +31,26 @@ export type AnalysisRecord = {
  * history (including soft-deleted rows) without paying for the big
  * result JSON per row.
  */
+export type ChartMetric =
+  | "overall"
+  | "timing"
+  | "technique"
+  | "teamwork"
+  | "presentation";
+
 export type ChartRecord = {
   id: string;
   filename: string | null;
   score: number | null;
+  // Per-category scores so the dashboard trend chart can slice by
+  // Timing / Technique / Teamwork / Presentation in addition to
+  // the overall score. Null when the stored result lacks that
+  // category (shouldn't happen for any post-MVP analyses, but
+  // we defend against it).
+  timing: number | null;
+  technique: number | null;
+  teamwork: number | null;
+  presentation: number | null;
   event_name: string | null;
   stage: string | null;
   competition_level: string | null;
@@ -105,18 +121,25 @@ export function useAnalysisHistory() {
       competition_level: string | null;
       tags: string[] | null;
       result: VideoScoreResult | null;
-    }): ChartRecord => ({
-      id: r.id,
-      filename: r.filename,
-      score: r.result?.overall?.score ?? null,
-      event_name: r.event_name,
-      stage: r.stage,
-      competition_level: r.competition_level,
-      tags: r.tags,
-      event_date: r.event_date,
-      deleted_at: r.deleted_at,
-      created_at: r.created_at,
-    }));
+    }): ChartRecord => {
+      const cats = r.result?.categories;
+      return {
+        id: r.id,
+        filename: r.filename,
+        score: r.result?.overall?.score ?? null,
+        timing: cats?.timing?.score ?? null,
+        technique: cats?.technique?.score ?? null,
+        teamwork: cats?.teamwork?.score ?? null,
+        presentation: cats?.presentation?.score ?? null,
+        event_name: r.event_name,
+        stage: r.stage,
+        competition_level: r.competition_level,
+        tags: r.tags,
+        event_date: r.event_date,
+        deleted_at: r.deleted_at,
+        created_at: r.created_at,
+      };
+    });
     setChartRecords(chartData);
 
     setLoading(false);

--- a/src/lib/level-context.ts
+++ b/src/lib/level-context.ts
@@ -1,0 +1,134 @@
+/**
+ * Map a score (0-10) + self-reported level to a short contextual
+ * label. Purpose: answer "is this score good for my level?" without
+ * needing a peer data flywheel. The level→range mapping is a
+ * judgment call anchored to wcs-analyzer's calibration examples
+ * (Novice ~3-5, Intermediate ~5-7, Champion ~9).
+ *
+ * Heuristic, not data — deliberately conservative ranges so most
+ * real scores fall cleanly into one tier.
+ */
+
+export type LevelRange = {
+  level: string;
+  aliases: string[]; // normalized tokens that map to this tier
+  min: number;
+  max: number;
+  // Anchor = the "typical" score for this level — used to phrase
+  // the contextual label ("above typical X", "mid Y", etc.).
+  anchor: number;
+};
+
+const LEVEL_RANGES: LevelRange[] = [
+  {
+    level: "Newcomer",
+    aliases: ["newcomer", "beginner", "first-timer"],
+    min: 2.0,
+    max: 4.0,
+    anchor: 3.0,
+  },
+  {
+    level: "Novice",
+    aliases: ["novice"],
+    min: 3.0,
+    max: 5.5,
+    anchor: 4.2,
+  },
+  {
+    level: "Intermediate",
+    aliases: ["intermediate"],
+    min: 4.5,
+    max: 7.0,
+    anchor: 5.8,
+  },
+  {
+    level: "Advanced",
+    aliases: ["advanced", "rising star", "open"],
+    min: 6.0,
+    max: 8.0,
+    anchor: 7.0,
+  },
+  {
+    level: "All-Star",
+    aliases: ["all-star", "allstar", "all star"],
+    min: 7.0,
+    max: 8.8,
+    anchor: 7.9,
+  },
+  {
+    level: "Champion",
+    aliases: ["champion", "invitational", "pro"],
+    min: 8.0,
+    max: 10.0,
+    anchor: 9.0,
+  },
+];
+
+function matchLevel(level: string): LevelRange | null {
+  const normalized = level.toLowerCase().trim();
+  for (const range of LEVEL_RANGES) {
+    if (range.aliases.some((a) => normalized.includes(a))) {
+      return range;
+    }
+  }
+  return null;
+}
+
+export type LevelContext = {
+  label: string;
+  tone: "above" | "in-range" | "below";
+  matchedLevel: string;
+};
+
+/**
+ * Returns a short contextual label ("upper Novice", "above
+ * Intermediate range", "below expected All-Star") for a given
+ * score + self-reported level. Returns null when the level
+ * string doesn't match any known tier, so callers can hide
+ * the label cleanly.
+ */
+export function getLevelContext(
+  score: number,
+  level: string | null | undefined
+): LevelContext | null {
+  if (typeof score !== "number" || Number.isNaN(score)) return null;
+  if (!level) return null;
+  const range = matchLevel(level);
+  if (!range) return null;
+
+  if (score < range.min) {
+    return {
+      label: `Below typical ${range.level} range`,
+      tone: "below",
+      matchedLevel: range.level,
+    };
+  }
+  if (score > range.max) {
+    return {
+      label: `Above typical ${range.level} range`,
+      tone: "above",
+      matchedLevel: range.level,
+    };
+  }
+
+  // In range: describe where in the band.
+  const nearAnchor = Math.abs(score - range.anchor) <= 0.3;
+  if (nearAnchor) {
+    return {
+      label: `Typical ${range.level} score`,
+      tone: "in-range",
+      matchedLevel: range.level,
+    };
+  }
+
+  const third = (range.max - range.min) / 3;
+  let position = "Mid";
+  if (score < range.min + third) position = "Lower";
+  else if (score > range.max - third) position = "Upper";
+
+  return {
+    label: `${position} ${range.level} range`,
+    tone: "in-range",
+    matchedLevel: range.level,
+  };
+}


### PR DESCRIPTION
## Three things that help users interpret their scores

### 1. Level-contextual label on the score hero
Below the big score number, a short label puts the number in tier context:
- *Upper Novice range* / *Typical Champion score* / *Above typical All-Star range*

Color-coded: emerald = above expected, amber = below, muted = within range. Hidden when no level is set or the level string doesn't match a known tier (free-text custom levels still work).

Heuristic (not peer data) — answers "is this score good for my level?" without needing a data flywheel. Real percentile comparison is deferred until we have enough samples per level.

### 2. Per-category chart tabs on dashboard
Tabs in the score trend card header: **Overall · Timing · Technique · Teamwork · Presentation**.

Switching recomputes the chart from that category's scores, so you can see exactly which dimension is improving (or slipping) over time. `ChartRecord` now projects all four category scores alongside the overall.

### 3. "How scoring works" info box on `/analyze`
Collapsible panel at the top of the upload flow (collapsed by default so it doesn't dominate). Explains:
- 4 WSDC categories + weights (30/30/20/20)
- What affects scoring (level, focus-on, audio quality, other context fields)
- What doesn't (video quality within reason, filename, other analyses in history)
- Note on using the uncertainty band as honest confidence

## Files

- `src/lib/level-context.ts` — new helper, ~110 LOC, with per-tier ranges + anchors
- `src/hooks/use-analysis-history.ts` — `ChartRecord` gains timing/technique/teamwork/presentation fields + `ChartMetric` type
- `src/components/analyze/score-trend.tsx` — metric tabs + metric-aware bucket builder
- `src/app/(app)/analyze/page.tsx` — level label on score hero + `HowScoringWorksInfo` component

🤖 Generated with [Claude Code](https://claude.com/claude-code)