### PR TITLE
Set Gemini media resolution to HIGH

### DIFF
--- a/api/src/wcs_api/services/video_analyzer.py
+++ b/api/src/wcs_api/services/video_analyzer.py
@@ -480,6 +480,15 @@ def _build_gen_config(model: str) -> genai_types.GenerateContentConfig:
         "max_output_tokens": 32768,
         "temperature": 0.0,
         "response_mime_type": "application/json",
+        # HIGH media resolution (~768 tokens/frame) vs the default
+        # MEDIUM (~256). For dance analysis this is the difference
+        # between "I can see there are dancers" and "I can see heel-
+        # toe rolling and a collapsed anchor." wcs-analyzer uses
+        # HIGH by default and it's critical for technique scoring.
+        # Cost: ~3x the per-frame token billing, but Gemini samples
+        # only ~1 frame per second of video anyway, so total spend
+        # per clip stays bounded.
+        "media_resolution": genai_types.MediaResolution.MEDIA_RESOLUTION_HIGH,
     }
     # Extended thinking. The SDK accepts a ThinkingConfig on both
     # Gemini 3.x and 2.5 models, but the fields differ:


### PR DESCRIPTION
Default was MEDIUM (~256 tokens per frame); for dance technique scoring (footwork rolling, anchor settle, posture line) we need HIGH (~768 tokens per frame). wcs-analyzer defaults to HIGH for exactly this reason.

Per-frame token cost ~3x, but Gemini samples ~1 FPS of video so total spend stays bounded. Admin cost-tracking dashboard will show the real impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)