### PR TITLE
Show observed vs declared level on score hero

### DIFF
--- a/api/src/wcs_api/services/video_analyzer.py
+++ b/api/src/wcs_api/services/video_analyzer.py
@@ -387,6 +387,7 @@ Respond in this exact JSON format. Fill `reasoning` BEFORE `score` in each categ
     "notes": "<follow-specific observations>"
   },
   "overall_impression": "<1-2 sentence overall assessment>",
+  "observed_level": "<one of: Newcomer|Novice|Intermediate|Advanced|All-Star|Champion — the tier the dancing actually lands at, regardless of what was declared. Fill this even when it matches the declared level; leave null only if truly uncertain.>",
   "estimated_bpm": <estimated BPM from the music>,
   "song_style": "<e.g., blues, contemporary, lyrical>"
 }
@@ -1221,6 +1222,7 @@ def _shape_response(
         "follow": parsed.get("follow"),
         "estimated_bpm": parsed.get("estimated_bpm"),
         "song_style": parsed.get("song_style"),
+        "observed_level": parsed.get("observed_level"),
         "sanity_warnings": sanity_warnings or [],
         "usage": usage,
     }

--- a/src/app/(app)/analyze/page.tsx
+++ b/src/app/(app)/analyze/page.tsx
@@ -1189,6 +1189,39 @@ function ScoreResultCard({
                 {levelContext.label}
               </span>
             )}
+            {(() => {
+              // When Gemini's observed tier differs from the user's
+              // declared level, make the mismatch explicit instead of
+              // letting the impression text contradict the label.
+              const declared = (competitionLevel || "").trim().toLowerCase();
+              const observed = (result.observed_level || "").trim();
+              if (!observed) return null;
+              if (
+                declared &&
+                observed.toLowerCase() === declared
+              )
+                return null;
+              if (!declared) {
+                return (
+                  <span className="text-xs text-muted-foreground">
+                    Scored as{" "}
+                    <span className="font-medium text-foreground">
+                      {observed}
+                    </span>
+                  </span>
+                );
+              }
+              return (
+                <span className="text-xs text-muted-foreground">
+                  Scored as{" "}
+                  <span className="font-medium text-emerald-300">
+                    {observed}
+                  </span>
+                  {" · Declared "}
+                  <span className="font-medium">{competitionLevel}</span>
+                </span>
+              );
+            })()}
             <div className="flex items-center gap-2">
               <Badge className="text-sm px-3 py-0.5">
                 {result.overall.grade}

--- a/src/lib/wcs-api.ts
+++ b/src/lib/wcs-api.ts
@@ -172,6 +172,12 @@ export type VideoScoreResult = {
   follow?: VideoPartnerScore;
   estimated_bpm?: number;
   song_style?: string;
+  // The tier Gemini actually observed (Newcomer / Novice /
+  // Intermediate / Advanced / All-Star / Champion), independent
+  // of the user's self-declared level. When the two disagree we
+  // render an explicit "Scored as X · Declared Y" note on the
+  // score hero so the mismatch doesn't look like a contradiction.
+  observed_level?: string;
   // Non-empty when the server sanity check flagged implausible
   // results (e.g. "intro lasted 60s") that even one retry couldn't
   // fully fix. Surfaced as a low-confidence hint in the UI.


### PR DESCRIPTION
When Gemini observes a different tier than the user declared, make that mismatch explicit instead of hiding it in the impression paragraph.

New field `observed_level` in the response (one of Newcomer / Novice / Intermediate / Advanced / All-Star / Champion). When it differs from the declared `competition_level`, the score hero renders:

**Scored as Intermediate · Declared Novice**

Hidden when observed matches declared. When nothing was declared, shows just "Scored as X".

Fixes the "why does it say intermediate when I put Novice" UX confusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)