### PR TITLE
Break-even pricing framing (drop fake discount)

### DIFF
--- a/src/app/(app)/billing/page.tsx
+++ b/src/app/(app)/billing/page.tsx
@@ -145,10 +145,7 @@ export default function BillingPage() {
                 <Sparkles className="h-5 w-5 text-primary shrink-0" />
                 Upgrade to Basic
               </span>
-              <div className="flex items-baseline gap-1.5 shrink-0">
-                <span className="text-base font-normal text-muted-foreground line-through">
-                  $20
-                </span>
+              <div className="flex items-baseline gap-1 shrink-0">
                 <span className="text-2xl font-bold">$10</span>
                 <span className="text-sm font-normal text-muted-foreground">
                   /mo
@@ -157,13 +154,12 @@ export default function BillingPage() {
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
-            <Badge
-              variant="secondary"
-              className="bg-amber-500/20 text-amber-200 border-amber-500/40"
-            >
-              <Sparkles className="h-3 w-3 mr-1" />
-              Launch pricing — 50% off
-            </Badge>
+            <p className="text-xs text-muted-foreground leading-relaxed">
+              Each analysis costs us about{" "}
+              <span className="font-medium text-foreground">$1</span> to run
+              on a frontier AI model. 10 analyses per month at $10 is
+              break-even — no margin, just sustainable scoring.
+            </p>
             <ul className="space-y-2 text-sm">
               {BASIC_BENEFITS.map((benefit) => (
                 <li key={benefit} className="flex items-start gap-2">
@@ -184,9 +180,6 @@ export default function BillingPage() {
                 <Sparkles className="mr-2 h-4 w-4" />
               )}
               <span className="truncate">Upgrade to Basic — $10/mo</span>
-              <span className="ml-2 text-xs opacity-70 line-through hidden sm:inline">
-                $20
-              </span>
             </Button>
           </CardContent>
         </Card>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -402,20 +402,11 @@ export default function HomePage() {
                     <Sparkles className="h-3 w-3 mr-1" />
                     Most popular
                   </Badge>
-                  <Badge
-                    variant="secondary"
-                    className="px-2 bg-amber-500/20 text-amber-200 border-amber-500/40"
-                  >
-                    Save 50%
-                  </Badge>
                 </div>
                 <CardContent className="p-6 space-y-4 pt-8">
                   <div className="flex items-baseline justify-between">
                     <h3 className="text-xl font-bold">Basic</h3>
-                    <div className="flex items-baseline gap-1.5">
-                      <span className="text-base text-muted-foreground line-through">
-                        $20
-                      </span>
+                    <div className="flex items-baseline gap-1">
                       <span className="text-2xl font-bold">$10</span>
                       <span className="text-sm text-muted-foreground">
                         /mo
@@ -424,9 +415,11 @@ export default function HomePage() {
                   </div>
                   <p className="text-sm text-muted-foreground">
                     Serious practice. More videos, longer clips.{" "}
-                    <span className="text-amber-200">
-                      Launch pricing — $10/mo while it lasts.
-                    </span>
+                    <span className="text-foreground font-medium">
+                      Break-even pricing
+                    </span>{" "}
+                    — each analysis costs ~$1 to run on a frontier AI
+                    model; 10 at $10/mo is cost-recovery, not profit.
                   </p>
                   <ul className="space-y-2 text-sm pt-2">
                     <li className="flex items-start gap-2">


### PR DESCRIPTION
Dance community is small and informed — fake-urgency "50% off launch pricing" framing undermines trust. Honest cost-transparency framing is more persuasive.

Changes:
- **Billing page**: just shows $10/mo; replaced the "50% off" badge with "Each analysis costs us about $1 to run on a frontier AI model. 10 analyses per month at $10 is break-even — no margin, just sustainable scoring."
- **Landing pricing card**: removed the "Save 50%" badge and $20 strikethrough. Replaced "Launch pricing while it lasts" with "Break-even pricing — each analysis costs ~$1 to run on a frontier AI model; 10 at $10/mo is cost-recovery, not profit."

🤖 Generated with [Claude Code](https://claude.com/claude-code)