### PR TITLE
Fix Failed-to-fetch on shared links (CORS header)

### DIFF
--- a/api/src/wcs_api/main.py
+++ b/api/src/wcs_api/main.py
@@ -11,7 +11,11 @@ app.add_middleware(
     allow_origins=settings.allowed_origins_list,
     allow_credentials=True,
     allow_methods=["GET", "POST", "OPTIONS"],
-    allow_headers=["Authorization", "Content-Type"],
+    # X-Swingflow-View is sent by fetchSharedAnalysis so the backend
+    # knows it's a real frontend load (not a Slackbot unfurl). Custom
+    # request headers require explicit CORS allow-list entries or the
+    # preflight fails and the browser reports "Failed to fetch".
+    allow_headers=["Authorization", "Content-Type", "X-Swingflow-View"],
 )
 
 app.include_router(health.router)


### PR DESCRIPTION
PR #36 added `X-Swingflow-View: 1` to `fetchSharedAnalysis` so the backend could distinguish real frontend loads from Slack/Twitter bot unfurls. I forgot to add it to the `allow_headers` list on CORSMiddleware — the browser's CORS preflight was therefore rejecting the request before it reached the backend.

Symptoms:
- `/shared?t=<token>` shows "Link unavailable · Failed to fetch"
- `curl` directly against the backend works fine (confirmed the token resolves)
- Browser DevTools would have shown a preflight 400 + a console CORS error

Fix: add `X-Swingflow-View` to `allow_headers`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)