### PR TITLE
Fix signup verification redirect (was pointing to localhost)

### DIFF
--- a/src/hooks/use-user.ts
+++ b/src/hooks/use-user.ts
@@ -49,7 +49,22 @@ export function useUser() {
   const signUpWithPassword = useCallback(
     async (email: string, password: string) => {
       const sb = getSupabase();
-      const { error } = await sb.auth.signUp({ email, password });
+      // Explicit emailRedirectTo so the verification link resolves
+      // back to production, not whatever Site URL is currently
+      // configured in the Supabase dashboard (which defaults to
+      // localhost:3000 on a fresh project). Falls back to the
+      // current origin on staging/dev so local signups still work.
+      const origin =
+        typeof window !== "undefined" && window.location?.origin
+          ? window.location.origin
+          : "https://swingflow.dance";
+      const { error } = await sb.auth.signUp({
+        email,
+        password,
+        options: {
+          emailRedirectTo: `${origin}/`,
+        },
+      });
       if (error) throw error;
     },
     []


### PR DESCRIPTION
Supabase defaulted Site URL to `http://localhost:3000` on project creation, so verification emails sent users to localhost.

Fix: pass explicit `emailRedirectTo` on signUp using `window.location.origin`. Production emails now go to `swingflow.dance`, local dev stays on localhost, no dashboard toggle needed per environment.

**Requires one-time Supabase dashboard fix too** (documented in the PR body below).

## Dashboard steps (also needed)

1. Open https://supabase.com/dashboard/project/uoqfdmkpdqbtcocqnwis/auth/url-configuration
2. **Site URL**: change from `http://localhost:3000` to `https://swingflow.dance`
3. **Redirect URLs**: add `https://swingflow.dance` (and optionally `https://swingflow.dance/*` for wildcard)

Supabase validates `emailRedirectTo` against the allowlist — if production URL isn't whitelisted, it silently falls back to Site URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)