### PR TITLE
Upload retries + classified errors

### DIFF
--- a/src/app/(app)/analyze/page.tsx
+++ b/src/app/(app)/analyze/page.tsx
@@ -533,7 +533,7 @@ export default function AnalyzePage() {
                   </Label>
                   <Input
                     id="dancer-focus"
-                    placeholder="e.g. couple in the red dress, lead on the right"
+                    placeholder="e.g. lead with floral jacket and bib number 433"
                     value={dancerDescription}
                     onChange={(e) =>
                       setDancerDescription(e.target.value.slice(0, 200))

--- a/src/hooks/use-video-analysis.ts
+++ b/src/hooks/use-video-analysis.ts
@@ -7,6 +7,7 @@ import {
   getVideoQuota,
   isWcsApiConfigured,
   uploadToPresignedUrl,
+  UploadError,
   type VideoAnalysisResponse,
   type VideoAnalyzeOptions,
   type VideoQuota,
@@ -79,13 +80,47 @@ export function useVideoAnalysis() {
         content_type: file.type || "application/octet-stream",
       });
       try {
-        const { uploadUrl, objectKey } = await getPresignedUploadUrl(
-          file.name,
-          file.type || "application/octet-stream"
-        );
-        await uploadToPresignedUrl(uploadUrl, file, (percent) => {
-          setState((s) => ({ ...s, uploadProgress: percent }));
-        });
+        // Retry the upload up to 3 times. Re-request a fresh
+        // presigned URL on each attempt so we don't retry against a
+        // stale/expired link. Only retry on transient failures —
+        // genuine config issues (storage 4xx other than 403) fail
+        // fast with a useful message instead of hammering R2.
+        const MAX_ATTEMPTS = 3;
+        const BACKOFF_MS = [0, 1500, 4000];
+        let objectKey = "";
+        let lastError: unknown = null;
+        for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+          if (BACKOFF_MS[attempt] > 0) {
+            await new Promise((r) => setTimeout(r, BACKOFF_MS[attempt]));
+          }
+          try {
+            const presign = await getPresignedUploadUrl(
+              file.name,
+              file.type || "application/octet-stream"
+            );
+            objectKey = presign.objectKey;
+            await uploadToPresignedUrl(
+              presign.uploadUrl,
+              file,
+              (percent) => {
+                setState((s) => ({ ...s, uploadProgress: percent }));
+              }
+            );
+            lastError = null;
+            break;
+          } catch (e) {
+            lastError = e;
+            const shouldRetry =
+              e instanceof UploadError &&
+              e.retryable &&
+              attempt < MAX_ATTEMPTS - 1;
+            if (!shouldRetry) break;
+            // Reset progress for the retry so the UI doesn't look
+            // stuck at the failed attempt's last frame.
+            setState((s) => ({ ...s, uploadProgress: 0 }));
+          }
+        }
+        if (lastError) throw lastError;
         Analytics.videoUploadSucceeded({ size_mb: +sizeMb.toFixed(1) });
         setState((s) => ({ ...s, status: "analyzing", uploadProgress: 100 }));
         Analytics.videoAnalysisStarted();
@@ -110,7 +145,37 @@ export function useVideoAnalysis() {
         });
         refreshQuota();
       } catch (e) {
-        const message = e instanceof Error ? e.message : "Analysis failed";
+        // Surface user-actionable copy per error kind. Keeps the
+        // "check the R2 CORS policy" troubleshooting note OFF the
+        // screen — that's an ops concern, not something users can do.
+        let message: string;
+        if (e instanceof UploadError) {
+          switch (e.kind) {
+            case "offline":
+              message =
+                "You appear to be offline. Reconnect and try again.";
+              break;
+            case "timeout":
+              message =
+                "Upload timed out. Try again on a stronger connection, or use a shorter clip.";
+              break;
+            case "network":
+              message =
+                "Connection dropped during upload. We retried but it kept failing — check your internet and try again.";
+              break;
+            case "expired":
+              message =
+                "Upload link expired. Refresh the page and try again.";
+              break;
+            case "storage":
+              message = `Storage returned an error (${e.status}). If this keeps happening, let us know.`;
+              break;
+            default:
+              message = e.message || "Upload failed.";
+          }
+        } else {
+          message = e instanceof Error ? e.message : "Analysis failed";
+        }
         Analytics.videoAnalysisFailed({ message });
         setState({ ...INITIAL, status: "error", error: message });
       }

--- a/src/lib/wcs-api.ts
+++ b/src/lib/wcs-api.ts
@@ -295,9 +295,40 @@ export async function getPresignedUploadUrl(
   });
 }
 
+export type UploadErrorKind =
+  | "network"
+  | "timeout"
+  | "offline"
+  | "expired"
+  | "storage"
+  | "aborted"
+  | "unknown";
+
+export class UploadError extends Error {
+  kind: UploadErrorKind;
+  status: number;
+  constructor(kind: UploadErrorKind, message: string, status = 0) {
+    super(message);
+    this.name = "UploadError";
+    this.kind = kind;
+    this.status = status;
+  }
+  /** True when retrying is likely to help (as opposed to a config bug). */
+  get retryable(): boolean {
+    return (
+      this.kind === "network" ||
+      this.kind === "timeout" ||
+      this.kind === "expired" ||
+      (this.kind === "storage" && this.status >= 500)
+    );
+  }
+}
+
 /**
  * PUT a file directly to the presigned URL. Uses XHR (not fetch) because
- * only XHR exposes upload progress events.
+ * only XHR exposes upload progress events. Throws a classified
+ * `UploadError` so callers can retry the transient failures and
+ * surface useful messages for the rest.
  */
 export function uploadToPresignedUrl(
   url: string,
@@ -305,12 +336,27 @@ export function uploadToPresignedUrl(
   onProgress?: (percent: number) => void
 ): Promise<void> {
   return new Promise((resolve, reject) => {
+    if (typeof navigator !== "undefined" && navigator.onLine === false) {
+      reject(
+        new UploadError(
+          "offline",
+          "You appear to be offline. Check your internet connection."
+        )
+      );
+      return;
+    }
+
     const xhr = new XMLHttpRequest();
     xhr.open("PUT", url);
     xhr.setRequestHeader(
       "Content-Type",
       file.type || "application/octet-stream"
     );
+    // 10-minute hard ceiling — stops a dead connection from hanging
+    // the UI indefinitely on large clips. Most uploads complete in
+    // under 2 minutes even on modest wifi.
+    xhr.timeout = 10 * 60 * 1000;
+
     xhr.upload.onprogress = (e) => {
       if (e.lengthComputable && onProgress) {
         onProgress(Math.round((e.loaded / e.total) * 100));
@@ -319,21 +365,51 @@ export function uploadToPresignedUrl(
     xhr.onload = () => {
       if (xhr.status >= 200 && xhr.status < 300) {
         resolve();
-      } else {
+        return;
+      }
+      // R2 returns 403 when the presigned URL has expired or been
+      // tampered with. We classify that separately so callers can
+      // request a fresh URL on retry.
+      if (xhr.status === 403) {
         reject(
-          new Error(
-            `Upload failed (${xhr.status}). Your R2 bucket may be missing CORS — verify the policy allows PUT from this origin.`
+          new UploadError(
+            "expired",
+            "Upload link expired — retrying with a fresh link.",
+            403
           )
         );
+        return;
       }
-    };
-    xhr.onerror = () =>
       reject(
-        new Error(
-          "Upload failed (network error). If this persists, check the R2 bucket's CORS policy."
+        new UploadError(
+          "storage",
+          `Storage rejected the upload (${xhr.status}).`,
+          xhr.status
         )
       );
-    xhr.onabort = () => reject(new Error("Upload aborted"));
+    };
+    xhr.onerror = () => {
+      // Status 0 means the browser blocked the response reading —
+      // either a real network drop or a CORS preflight denied.
+      // We can't distinguish reliably, so report as network and let
+      // the caller retry; a persistent failure will surface with
+      // our follow-up diagnostic copy below.
+      reject(
+        new UploadError(
+          "network",
+          "Connection dropped during upload. Retrying…"
+        )
+      );
+    };
+    xhr.ontimeout = () =>
+      reject(
+        new UploadError(
+          "timeout",
+          "Upload timed out. Try again on a stronger connection."
+        )
+      );
+    xhr.onabort = () =>
+      reject(new UploadError("aborted", "Upload was cancelled."));
     xhr.send(file);
   });
 }


### PR DESCRIPTION
Addresses the "Upload failed (network error)" red banner users were hitting on large files.

### 1. Classified upload errors
`UploadError` subclass with a `kind` (`network | timeout | offline | expired | storage | aborted | unknown`) and a `retryable` flag. 10-minute XHR timeout. Pre-check navigator.onLine.

### 2. Automatic retry with fresh presigned URL
Up to 3 attempts, backoff 0 / 1.5s / 4s. Each retry fetches a fresh presigned URL so expired links self-heal. Non-retryable failures (4xx other than 403) fail fast.

### 3. Cleaner user-facing error copy
No more exposing "check the R2 bucket's CORS policy" to end users — that was an ops note. Replaced with per-kind messages users can actually act on.

### 4. Placeholder update
Dancer-focus field placeholder → "e.g. lead with floral jacket and bib number 433" (more representative of how dancers actually describe each other in WSDC footage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)