### PR TITLE
Opt-in: keep video stored for timeline replay

### DIFF
--- a/api/src/wcs_api/routes/video.py
+++ b/api/src/wcs_api/routes/video.py
@@ -32,6 +32,12 @@ class VideoAnalyzeBody(BaseModel):
     # keep the prompt overhead bounded and prevent prompt injection
     # via a multi-paragraph dump.
     dancer_description: str | None = Field(default=None, max_length=200)
+    # Opt-in video retention. Default False = we delete the R2
+    # object after scoring (privacy-preserving default). True =
+    # keep it so the user can replay the clip later against the
+    # pattern timeline / off-beat markers. User can still click
+    # "Delete video" on the history row to remove it any time.
+    store_video: bool = False
 
 
 def _admin_error_to_http(exc: httpx.HTTPStatusError) -> HTTPException:
@@ -172,12 +178,15 @@ async def analyze_video_endpoint(
             # deleted below, so keeping the key would just lead to 404s
             # on Watch/Re-analyze. Privacy also: we don't retain dance
             # videos of real people after the scoring run.
+            # Preserve the R2 object_key on the row only when the
+            # user opted in to video retention. Otherwise the row
+            # stores a null key and the clip is purged below.
             await supabase_admin.insert_video_analysis(
                 user_id=user_id,
                 filename=body.filename,
                 duration=duration,
                 result=result,
-                object_key=None,
+                object_key=body.object_key if body.store_video else None,
                 role=body.role,
                 competition_level=body.competition_level,
                 event_name=body.event_name,
@@ -205,7 +214,11 @@ async def analyze_video_endpoint(
             os.unlink(tmp_path)
         except OSError:
             pass
-        # Delete from R2 right after analysis — privacy first. Users
-        # who want to re-score must re-upload. The 24h lifecycle rule
-        # on the bucket is the backstop for orphaned uploads.
-        r2.delete_object(body.object_key)
+        # Delete from R2 by default — privacy-preserving. Users who
+        # opted in to `store_video` keep their clip so they can
+        # replay it against the pattern timeline later; they can
+        # still remove it anytime via the Delete-video button on
+        # the history row. The 24h bucket lifecycle rule is the
+        # backstop for orphaned uploads on either path.
+        if not body.store_video:
+            r2.delete_object(body.object_key)

--- a/src/app/(app)/analyze/page.tsx
+++ b/src/app/(app)/analyze/page.tsx
@@ -217,6 +217,10 @@ export default function AnalyzePage() {
   const [eventDate, setEventDate] = useState("");
   const [tagsInput, setTagsInput] = useState("");
   const [dancerDescription, setDancerDescription] = useState("");
+  // Default off — videos get deleted from R2 right after scoring
+  // for privacy. Turning it on keeps the clip so the user can
+  // replay it against the pattern timeline later.
+  const [storeVideo, setStoreVideo] = useState(false);
 
   const role =
     roleSelect === OTHER ? roleCustom.trim() : roleSelect.trim();
@@ -290,6 +294,7 @@ export default function AnalyzePage() {
       stage: stage || undefined,
       tags: tags.length ? tags : undefined,
       dancerDescription: focus || undefined,
+      storeVideo,
     }).then(() => history.refresh());
   }, [
     file,
@@ -302,6 +307,7 @@ export default function AnalyzePage() {
     stage,
     tagsInput,
     dancerDescription,
+    storeVideo,
   ]);
 
   const handleClear = useCallback(() => {
@@ -545,6 +551,30 @@ export default function AnalyzePage() {
                     {dancerDescription.length}/200
                   </p>
                 </div>
+
+                <label
+                  htmlFor="store-video"
+                  className="flex items-start gap-2 cursor-pointer rounded-md border border-border p-2.5 hover:border-primary/40 transition-colors"
+                >
+                  <input
+                    id="store-video"
+                    type="checkbox"
+                    checked={storeVideo}
+                    onChange={(e) => setStoreVideo(e.target.checked)}
+                    className="mt-0.5 h-4 w-4 accent-primary cursor-pointer"
+                  />
+                  <span className="text-xs space-y-0.5">
+                    <span className="block font-medium">
+                      Keep video stored
+                    </span>
+                    <span className="block text-muted-foreground">
+                      Replay the clip later mapped against the pattern
+                      timeline + off-beat markers. Off by default — clips
+                      are deleted right after scoring. You can delete a
+                      stored video any time.
+                    </span>
+                  </span>
+                </label>
               </div>
             )}
 
@@ -1091,11 +1121,22 @@ function HistoryRow({
             <p className="text-xs text-primary">{shareMessage}</p>
           )}
 
+          {canViewOrReanalyze && (
+            <p className="text-xs text-muted-foreground">
+              <span className="font-medium text-foreground">
+                Stored video —
+              </span>{" "}
+              click <span className="font-medium">Watch</span> to map the
+              pattern timeline and off-beat markers against the actual
+              clip.
+            </p>
+          )}
+
           {!canViewOrReanalyze && (
             <p className="text-xs text-muted-foreground">
               {videoDeleted
                 ? "Video deleted from storage. The scoring result above is preserved."
-                : "Source video isn\u2019t available (removed after scoring — scoring result is preserved)."}
+                : "Source video wasn\u2019t kept (delete-after-scoring is the default). Upload again with \u201cKeep video stored\u201d enabled if you want to map the timeline to a clip you can replay."}
             </p>
           )}
 

--- a/src/lib/wcs-api.ts
+++ b/src/lib/wcs-api.ts
@@ -425,6 +425,10 @@ export type VideoAnalyzeOptions = {
   // when multiple people are in frame (e.g. "couple in the red
   // dress and blue shirt", "the lead on the far right").
   dancerDescription?: string;
+  // Opt-in: keep the video in R2 after analysis so the user can
+  // replay it against the pattern timeline. Default off — we
+  // delete the clip right after scoring otherwise.
+  storeVideo?: boolean;
 };
 
 export async function analyzeVideoFromKey(
@@ -442,6 +446,7 @@ export async function analyzeVideoFromKey(
     stage: options.stage || null,
     tags: options.tags && options.tags.length ? options.tags : null,
     dancer_description: options.dancerDescription || null,
+    store_video: Boolean(options.storeVideo),
   });
 }
 


### PR DESCRIPTION
Adds a checkbox on the upload form (**default OFF**) that keeps the R2 clip after scoring instead of deleting it. Users who opt in can click "Watch" on the history row to replay the video against the pattern timeline and off-beat markers.

### Backend
- `VideoAnalyzeBody.store_video: bool = False`
- `/analyze/video` skips `r2.delete_object(...)` when true, and persists the object_key so the frontend can resolve a signed GET URL.

### Frontend
- Checkbox card under the dancer-focus field with clear copy on the tradeoff.
- `VideoAnalyzeOptions.storeVideo` threaded through.
- History row copy updates:
  - **Stored**: "Stored video — click Watch to map the pattern timeline and off-beat markers against the actual clip."
  - **Not stored**: "Source video wasn't kept (delete-after-scoring is the default). Upload again with 'Keep video stored' enabled if you want to map the timeline to a clip you can replay."

Existing Delete-video button still works for removing a stored clip any time.

### Note on R2 bucket lifecycle
If your R2 bucket has a 24h auto-delete lifecycle rule (it does per earlier setup), stored videos will still be GC'd after 24 hours. If you want stored videos to persist longer, loosen the lifecycle rule in the Cloudflare dashboard (R2 → bucket → Settings → Object lifecycle rules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Keep video stored" option during analysis to optionally retain source videos beyond initial processing.
  * Stored videos can now be viewed and re-analyzed without re-uploading.
  * Enhanced messaging to clarify video retention behavior and storage options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->