### PR TITLE
Per-pattern styling + coaching tips

### DIFF
--- a/api/src/wcs_api/services/video_analyzer.py
+++ b/api/src/wcs_api/services/video_analyzer.py
@@ -478,7 +478,9 @@ Respond in this exact JSON format. Fill `reasoning` BEFORE `score` in each categ
       "end_time": <seconds from video start, float>,
       "quality": "<strong|solid|needs_work|weak>",
       "timing": "<on_beat|slightly_off|off_beat>",
-      "notes": "<what was good or needs improvement in this pattern>"
+      "notes": "<what was good or needs improvement in this pattern>",
+      "styling": "<brief description of styling observed during this pattern — body rolls, arm styling, footwork flourishes, musical hits, syncopations. Use null when nothing notable. DO NOT invent styling that wasn't there.>",
+      "coaching_tip": "<one concrete, actionable suggestion specific to THIS pattern (e.g. 'stretch the anchor 2 extra beats to match the blues pocket', 'less arm on the lead into this whip — drive from the core'). Use null for patterns that execute cleanly and don't need targeted work.>"
     }
   ],
   "highlights": ["<notable positive moments with approximate timestamps>"],
@@ -507,6 +509,7 @@ Constraints on patterns_identified:
 - If a segment is truly unclear, name it "unknown", keep it short (≤8s), and explain in notes.
 - start_time and end_time are decimal seconds from the video start.
 - Use the beat grid in the context (if provided) to anchor window boundaries near anchor steps (beats 5–6).
+- `styling` and `coaching_tip`: populate when there's something real to say. Return null (not empty string) when a pattern is unremarkable — it's better to say nothing than to invent filler. These should feel like a coach's post-dance notes, not AI-generated text.
 
 Only output valid JSON, no other text. Do not include // comments inside the JSON.\
 """
@@ -1196,6 +1199,11 @@ def _summarize_patterns(
     qualities: dict[str, list[str]] = defaultdict(list)
     timings: dict[str, list[str]] = defaultdict(list)
     notes: dict[str, list[str]] = defaultdict(list)
+    # Keep styling + coaching_tips dedup'd per pattern too — an
+    # expressive dancer may land the same body-roll on multiple
+    # sugar pushes, and we only want to surface that once.
+    stylings: dict[str, list[str]] = defaultdict(list)
+    tips: dict[str, list[str]] = defaultdict(list)
 
     for p in patterns:
         raw_name = (p.get("name") or "").strip()
@@ -1213,6 +1221,12 @@ def _summarize_patterns(
         n = (p.get("notes") or "").strip()
         if n and n not in notes[key]:
             notes[key].append(n)
+        styling_val = (p.get("styling") or "").strip()
+        if styling_val and styling_val not in stylings[key]:
+            stylings[key].append(styling_val)
+        tip_val = (p.get("coaching_tip") or "").strip()
+        if tip_val and tip_val not in tips[key]:
+            tips[key].append(tip_val)
 
     def _most_common(items: list[str]) -> str | None:
         return Counter(items).most_common(1)[0][0] if items else None
@@ -1226,6 +1240,12 @@ def _summarize_patterns(
                 "quality": _most_common(qualities[key]),
                 "timing": _most_common(timings[key]),
                 "notes": " · ".join(notes[key][:3]) if notes[key] else None,
+                "styling": (
+                    " · ".join(stylings[key][:2]) if stylings[key] else None
+                ),
+                "coaching_tip": (
+                    " · ".join(tips[key][:2]) if tips[key] else None
+                ),
             }
         )
     return summary

--- a/src/components/analyze/pattern-summary.tsx
+++ b/src/components/analyze/pattern-summary.tsx
@@ -51,6 +51,8 @@ export function derivePatternSummary(
   const qualities = new Map<string, string[]>();
   const timings = new Map<string, string[]>();
   const notes = new Map<string, string[]>();
+  const stylings = new Map<string, string[]>();
+  const tips = new Map<string, string[]>();
 
   for (const p of patterns) {
     const raw = (p.name || "").trim();
@@ -74,6 +76,18 @@ export function derivePatternSummary(
       if (!list.includes(note)) list.push(note);
       notes.set(key, list);
     }
+    const styling = (p.styling || "").trim();
+    if (styling) {
+      const list = stylings.get(key) ?? [];
+      if (!list.includes(styling)) list.push(styling);
+      stylings.set(key, list);
+    }
+    const tip = (p.coaching_tip || "").trim();
+    if (tip) {
+      const list = tips.get(key) ?? [];
+      if (!list.includes(tip)) list.push(tip);
+      tips.set(key, list);
+    }
   }
 
   const mostCommon = (items?: string[]): string | null => {
@@ -91,6 +105,9 @@ export function derivePatternSummary(
       quality: mostCommon(qualities.get(key)),
       timing: mostCommon(timings.get(key)),
       notes: (notes.get(key) ?? []).slice(0, 3).join(" · ") || null,
+      styling: (stylings.get(key) ?? []).slice(0, 2).join(" · ") || null,
+      coaching_tip:
+        (tips.get(key) ?? []).slice(0, 2).join(" · ") || null,
     }));
 }
 
@@ -157,6 +174,20 @@ export function PatternSummaryCard({
                   {p.notes && (
                     <p className="text-xs text-muted-foreground mt-1">
                       {p.notes}
+                    </p>
+                  )}
+                  {p.styling && (
+                    <p className="text-xs text-muted-foreground mt-1.5">
+                      <span className="font-medium text-foreground">
+                        Styling:
+                      </span>{" "}
+                      {p.styling}
+                    </p>
+                  )}
+                  {p.coaching_tip && (
+                    <p className="text-xs mt-1 text-amber-300">
+                      <span className="font-medium">Tip:</span>{" "}
+                      {p.coaching_tip}
                     </p>
                   )}
                 </div>

--- a/src/components/analyze/timeline-view.tsx
+++ b/src/components/analyze/timeline-view.tsx
@@ -324,6 +324,20 @@ export function TimelineView({
                   {detail.notes}
                 </span>
               )}
+              {detail.styling && (
+                <span className="block mt-1.5 whitespace-pre-wrap break-words">
+                  <span className="font-medium text-foreground">
+                    Styling:
+                  </span>{" "}
+                  {detail.styling}
+                </span>
+              )}
+              {detail.coaching_tip && (
+                <span className="block mt-1 whitespace-pre-wrap break-words text-amber-300">
+                  <span className="font-medium">Tip:</span>{" "}
+                  {detail.coaching_tip}
+                </span>
+              )}
             </div>
           </div>
         )}

--- a/src/lib/wcs-api.ts
+++ b/src/lib/wcs-api.ts
@@ -133,6 +133,14 @@ export type VideoPatternIdentified = {
   quality?: "strong" | "solid" | "needs_work" | "weak" | string;
   timing?: "on_beat" | "slightly_off" | "off_beat" | string;
   notes?: string;
+  // Brief free-text description of styling during this pattern
+  // (body rolls, arm styling, musical hits). Null when nothing
+  // notable — the model is instructed to prefer silence over
+  // invention here.
+  styling?: string | null;
+  // One actionable, pattern-specific suggestion. Null when the
+  // execution was clean enough not to warrant targeted work.
+  coaching_tip?: string | null;
 };
 
 export type VideoPartnerScore = {
@@ -147,6 +155,8 @@ export type PatternSummary = {
   quality?: string | null;
   timing?: string | null;
   notes?: string | null;
+  styling?: string | null;
+  coaching_tip?: string | null;
 };
 
 export type VideoScoreResult = {


### PR DESCRIPTION
Each identified pattern now returns optional `styling` and `coaching_tip` fields.

**Rendering:**
- Timeline hover/tap card shows both as separate lines under the pattern's quality/timing
- Pattern summary card shows stacked styling + tip per pattern
- Coaching tips render in amber to match the improvement-accent color

**Anti-hallucination guardrail:** prompt explicitly instructs model to return null (not empty string, not filler) when nothing notable is happening stylistically or when a pattern was cleanly executed. Framing note in the prompt: "these should feel like a coach's post-dance notes, not AI-generated text."

**Aggregation:** `_summarize_patterns` dedupes per pattern (same body roll on multiple sugar pushes collapses to one entry), joins up to 2 unique values with " · " for compact summary rendering. Client-side `derivePatternSummary` mirrors the logic for historical analyses.

Cost: ~40 extra output tokens per pattern, ~1KB per analysis. Negligible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)