### PR TITLE
Track pattern variants explicitly (basket whip, reverse whip, etc.)

### DIFF
--- a/api/src/wcs_api/services/video_analyzer.py
+++ b/api/src/wcs_api/services/video_analyzer.py
@@ -328,36 +328,67 @@ DO NOT default every ambiguous move to "sugar push" or "basic". Many WCS \
 patterns share silhouettes but differ in rotation, entry, exit, and travel. \
 Look for these specific cues:
 
-**6-count patterns** (2 walks + 2 triples + anchor; ~3-5 seconds at typical tempo):
-- **Sugar push** — follower walks TOWARD lead (beats 1-2), compression on
-  3&4 triple in place, follower walks back to anchor (5-6). NO travel,
-  NO rotation, stays in the slot. Hands stay connected in a V.
-- **Left side pass** — lead catches follower across to lead's LEFT side on
-  beats 3-4. Follower passes through the slot, anchors on the opposite end.
-  Lead rotates roughly 180° total. Clear travel.
-- **Right side pass** — mirror of left side pass; follower crosses to
-  lead's RIGHT side. Often includes a lead-side step-through.
-- **Tuck turn** — lead leads a compact 1-turn on follower during beats 3-4,
-  then catches. Turn is tight and in-place; follower's shoulder often
-  drops briefly into the lead.
-- **Underarm pass / inside turn** — follower spins under a raised hand
-  DURING the pass (not at the catch). Bigger arc than tuck, follower
-  travels while turning.
-- **Starter step / basic** — no travel, no rotation. Weight changes in
-  place to find the music. Usually at the start of a dance.
+**6-count pattern FAMILIES** (2 walks + 2 triples + anchor; ~3-5s):
 
-**8-count patterns** (3 walks + 3 triples + anchor; ~5-7 seconds):
-- **Whip** — extended rotational flow. Lead traverses the slot twice,
-  follower rotates around. Compression 1-2, stretch 3-4, rotation 5-6,
-  anchor 7-8. Travels. Follower rotates at least 360° cumulative.
-- **Basket whip** — whip with follower's hand held behind their back
-  creating a "basket" shape. Tighter arm frame than a regular whip.
-- **Reverse whip** — whip where rotation goes the opposite direction;
-  follower is led backwards through the pattern.
-- **Apache whip** — whip with lead's arm cradling follower's head or
-  shoulder during the rotation.
-- **Whip with inside turn** — whip with an additional follower inside-
-  turn during the rotation. Visible extra turn at beats 5-6.
+- **Sugar push** (family) — follower walks TOWARD lead (beats 1-2),
+  compression on 3&4 in place, follower walks back to anchor (5-6).
+  NO travel, NO rotation, stays in the slot. Hands stay connected in a V.
+  Variants to identify explicitly when present:
+  - *basic* — plain execution, no styling or added turns
+  - *with inside turn* — follower adds an inside turn on 3-4
+  - *with tuck* / *sugar tuck* — compression into a tuck before push-off
+  - *with hand change* — lead transfers from one hand to the other
+- **Left side pass** / **Right side pass** — follower crosses to lead's
+  respective side on 3-4, anchors at the opposite end of the slot.
+  Variants:
+  - *basic* — straight pass, no turn added
+  - *with inside turn* — follower adds an inside turn during the pass
+  - *with outside turn* — follower adds an outside (CCW) turn
+- **Tuck turn** (family) — compact 1-turn on follower during 3-4.
+  Variants: *basic*, *double tuck* (two spins), *open tuck* (catch with
+  both hands open).
+- **Underarm turn / Inside turn** — follower turns UNDER a raised hand
+  during the pass (not at the catch).
+- **Starter step / basic** — no travel, no rotation. Weight changes in
+  place.
+
+**8-count pattern FAMILIES** (3 walks + 3 triples + anchor; ~5-7s):
+
+- **Whip** (family — has MANY variants, identify the specific one):
+  - *basic* — standard 8-count whip, no modifications
+  - *basket* — follower's hand held behind their back creating a
+    "basket" shape; tighter frame
+  - *reverse* — rotation goes the OPPOSITE direction; follower led
+    backwards through the pattern
+  - *apache* — lead's arm cradles follower's head/shoulder during
+    rotation
+  - *with inside turn* — whip + additional follower inside-turn during
+    rotation (beats 5-6)
+  - *with outside turn* — whip + follower outside-turn during rotation
+  - *tandem* — lead and follower travel side-by-side through rotation
+  - *cuddle* / *continuous* — follower stays close in a cuddle position
+    through the whip
+  - *shadow* — follower dances behind lead, same direction facing
+  - *pretzel* — follower's arms wrap into a pretzel shape during
+    rotation
+- **Basic in closed / promenade** — closed-position walk variation.
+
+=== VARIANT IDENTIFICATION ===
+
+For each pattern, return BOTH:
+1. `name` — the pattern family (e.g. "whip", "sugar push", "side pass")
+2. `variant` — the specific sub-type (e.g. "basket", "reverse",
+   "with inside turn"). Use "basic" when it's a plain execution of
+   the family, or null if you can't commit to a specific variant.
+
+Example: a clear basket whip → `{name: "whip", variant: "basket"}`.
+A plain whip → `{name: "whip", variant: "basic"}`. A whip where you
+see rotation but can't tell which kind → `{name: "whip", variant: null}`.
+
+Prefer committing to a specific variant when distinguishing features
+are visible. "basic" is valid when the family is clear but nothing
+sets it apart. `null` is for genuine uncertainty — don't use it to
+avoid thinking.
 
 === DISTINGUISHING RULES (when in doubt) ===
 
@@ -392,15 +423,17 @@ no markdown, no prose:
 
 {
   "patterns": [
-    {"start_time": 0.00, "end_time": 2.67, "name": "starter step", "count": 6, "confidence": 0.9},
-    {"start_time": 2.67, "end_time": 5.33, "name": "sugar push", "count": 6, "confidence": 0.8},
-    {"start_time": 5.33, "end_time": 8.89, "name": "whip", "count": 8, "confidence": 0.7}
+    {"start_time": 0.00, "end_time": 2.67, "name": "starter step", "variant": "basic", "count": 6, "confidence": 0.9},
+    {"start_time": 2.67, "end_time": 5.33, "name": "sugar push", "variant": "with inside turn", "count": 6, "confidence": 0.8},
+    {"start_time": 5.33, "end_time": 8.89, "name": "whip", "variant": "basket", "count": 8, "confidence": 0.7}
   ]
 }
 
 Fields:
 - start_time / end_time: decimal seconds, snapped to beat grid
-- name: specific pattern from the list above, or "unknown" when unclear
+- name: pattern family (e.g. "whip", "sugar push"), or "unknown"
+- variant: specific sub-type (e.g. "basket", "reverse", "with inside
+  turn"), "basic" for plain execution, or null for genuine uncertainty
 - count: 6 or 8 (the WCS count structure)
 - confidence: 0.0-1.0 (1.0 = certain, 0.5 = narrowed to family,
   <0.3 = unclear — use with "unknown")\
@@ -473,7 +506,8 @@ Respond in this exact JSON format. Fill `reasoning` BEFORE `score` in each categ
   },
   "patterns_identified": [
     {
-      "name": "<e.g., sugar push, left side pass, whip>",
+      "name": "<pattern family — e.g. sugar push, left side pass, whip, tuck turn>",
+      "variant": "<specific sub-type — e.g. 'basket', 'reverse', 'apache', 'with inside turn', 'with outside turn', 'sugar tuck'. Use 'basic' for plain execution. Use null only when you genuinely can't commit to a variant.>",
       "start_time": <seconds from video start, float>,
       "end_time": <seconds from video start, float>,
       "quality": "<strong|solid|needs_work|weak>",
@@ -1196,6 +1230,7 @@ def _summarize_patterns(
 
     counts: Counter[str] = Counter()
     display_names: dict[str, str] = {}
+    variants_per_key: dict[str, str | None] = {}
     qualities: dict[str, list[str]] = defaultdict(list)
     timings: dict[str, list[str]] = defaultdict(list)
     notes: dict[str, list[str]] = defaultdict(list)
@@ -1209,9 +1244,21 @@ def _summarize_patterns(
         raw_name = (p.get("name") or "").strip()
         if not raw_name:
             continue
-        key = _normalize_pattern_name(raw_name)
+        # Key on (family + variant) so "basket whip" and "reverse whip"
+        # count as distinct patterns even though they share the "whip"
+        # family. "basic" variant groups with null — both mean
+        # "plain execution of the family".
+        raw_variant = (p.get("variant") or "").strip().lower()
+        variant_key_part = "" if raw_variant in ("", "basic") else raw_variant
+        key = _normalize_pattern_name(raw_name) + (
+            f"|{variant_key_part}" if variant_key_part else ""
+        )
         counts[key] += 1
         display_names.setdefault(key, raw_name)
+        # Store the first non-"basic" variant we see for this key
+        # so the UI can show it as a distinct label.
+        if variant_key_part and key not in variants_per_key:
+            variants_per_key[key] = raw_variant
         q = p.get("quality")
         if isinstance(q, str) and q:
             qualities[key].append(q)
@@ -1236,6 +1283,7 @@ def _summarize_patterns(
         summary.append(
             {
                 "name": display_names[key],
+                "variant": variants_per_key.get(key),
                 "count": cnt,
                 "quality": _most_common(qualities[key]),
                 "timing": _most_common(timings[key]),

--- a/src/components/analyze/pattern-summary.tsx
+++ b/src/components/analyze/pattern-summary.tsx
@@ -48,6 +48,7 @@ export function derivePatternSummary(
   if (!patterns || patterns.length === 0) return [];
   const counts = new Map<string, number>();
   const displayNames = new Map<string, string>();
+  const variants = new Map<string, string | null>();
   const qualities = new Map<string, string[]>();
   const timings = new Map<string, string[]>();
   const notes = new Map<string, string[]>();
@@ -57,9 +58,19 @@ export function derivePatternSummary(
   for (const p of patterns) {
     const raw = (p.name || "").trim();
     if (!raw) continue;
-    const key = raw.toLowerCase().replace(/\s+/g, " ");
+    const rawVariant = (p.variant || "").trim().toLowerCase();
+    // Group "basic" and null together — both mean "plain execution
+    // of the family". Distinct non-basic variants get their own
+    // bucket ("whip basket" ≠ "whip reverse").
+    const variantKeyPart =
+      rawVariant === "" || rawVariant === "basic" ? "" : rawVariant;
+    const base = raw.toLowerCase().replace(/\s+/g, " ");
+    const key = variantKeyPart ? `${base}|${variantKeyPart}` : base;
     counts.set(key, (counts.get(key) ?? 0) + 1);
     if (!displayNames.has(key)) displayNames.set(key, raw);
+    if (variantKeyPart && !variants.has(key)) {
+      variants.set(key, p.variant ?? variantKeyPart);
+    }
     if (p.quality) {
       const list = qualities.get(key) ?? [];
       list.push(p.quality);
@@ -101,6 +112,7 @@ export function derivePatternSummary(
     .sort((a, b) => b[1] - a[1])
     .map(([key, count]) => ({
       name: displayNames.get(key)!,
+      variant: variants.get(key) ?? null,
       count,
       quality: mostCommon(qualities.get(key)),
       timing: mostCommon(timings.get(key)),
@@ -150,7 +162,15 @@ export function PatternSummaryCard({
                 />
                 <div className="min-w-0 flex-1">
                   <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
-                    <span className="font-medium text-sm">{p.name}</span>
+                    <span className="font-medium text-sm">
+                      {p.name}
+                      {p.variant && p.variant.toLowerCase() !== "basic" && (
+                        <span className="text-muted-foreground font-normal">
+                          {" · "}
+                          <span className="text-foreground">{p.variant}</span>
+                        </span>
+                      )}
+                    </span>
                     <Badge
                       variant="outline"
                       className="text-[10px] tabular-nums px-1.5 py-0 h-4"

--- a/src/components/analyze/timeline-view.tsx
+++ b/src/components/analyze/timeline-view.tsx
@@ -381,6 +381,15 @@ export function TimelineView({
             <div className="flex items-baseline justify-between gap-2 flex-wrap">
               <span className="font-semibold text-foreground">
                 {autoDetail.name}
+                {autoDetail.variant &&
+                  autoDetail.variant.toLowerCase() !== "basic" && (
+                    <span className="text-muted-foreground font-normal">
+                      {" · "}
+                      <span className="text-foreground">
+                        {autoDetail.variant}
+                      </span>
+                    </span>
+                  )}
               </span>
               <span className="text-muted-foreground font-mono tabular-nums">
                 {formatTime(autoDetail.start_time ?? 0)} →{" "}

--- a/src/lib/wcs-api.ts
+++ b/src/lib/wcs-api.ts
@@ -128,6 +128,11 @@ export type VideoCategoryScore = {
 
 export type VideoPatternIdentified = {
   name: string;
+  // Specific sub-type within the pattern family (e.g. "basket",
+  // "reverse", "apache", "with inside turn"). "basic" means plain
+  // execution of the family; null means the model couldn't commit
+  // to a specific variant.
+  variant?: string | null;
   start_time?: number;
   end_time?: number;
   quality?: "strong" | "solid" | "needs_work" | "weak" | string;
@@ -151,6 +156,10 @@ export type VideoPartnerScore = {
 
 export type PatternSummary = {
   name: string;
+  // When the aggregate has a specific non-basic variant (e.g.
+  // "basket", "reverse"), it's surfaced here so the UI can
+  // display "Whip · basket" alongside the count.
+  variant?: string | null;
   count: number;
   quality?: string | null;
   timing?: string | null;


### PR DESCRIPTION
Whips were all collapsing to "whip" even when they were clearly a specific variant. Same issue with sugar pushes ("with inside turn" got lost), side passes, etc.

### Schema
New `variant` field on every pattern. Values:
- Specific variant string: `"basket"`, `"reverse"`, `"apache"`, `"with inside turn"`, `"sugar tuck"`, etc.
- `"basic"` for plain execution of the family
- `null` for genuine uncertainty

Prompt expanded: whip family now lists **9 variants** (basic, basket, reverse, apache, with inside turn, with outside turn, tandem, cuddle, shadow, pretzel). Sugar push / side pass / tuck families also get explicit variant lists.

### Aggregation
`_summarize_patterns` keys on (family + variant), so basket and reverse whips count as separate entries. `basic` and `null` both group as plain-execution. Verified:

```
whip            variant='basket'                  count=2
whip            variant=None                      count=2
whip            variant='reverse'                 count=1
sugar push      variant='with inside turn'        count=1
sugar push      variant=None                      count=1
```

### UI
Timeline hover + pattern summary card render "Whip · basket" with the variant in a muted middle-dot separator. Plain / basic patterns render as before ("Whip"). Backward-compatible with analyses that don't have variant data yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)