### PR TITLE
Quick wins from codex review (#71 #77 #78 #80 #81)

### DIFF
--- a/api/src/wcs_api/services/supabase_admin.py
+++ b/api/src/wcs_api/services/supabase_admin.py
@@ -175,6 +175,7 @@ async def get_shared_analysis(token: str) -> dict[str, Any] | None:
         r = await client.get(
             _rest(
                 f"video_analyses?share_token=eq.{token}"
+                "&deleted_at=is.null"
                 "&select=id,filename,duration,result,role,"
                 "competition_level,event_name,stage,tags,created_at,"
                 "share_view_count,share_last_viewed_at"

--- a/api/src/wcs_api/services/video_analyzer.py
+++ b/api/src/wcs_api/services/video_analyzer.py
@@ -1581,9 +1581,15 @@ def _build_sanity_retry_prompt(
         "on, counting beats, and the first real pattern are "
         "different entries. Every pattern window should be 3-8 "
         "seconds — if yours is longer, it's a merge of repeats. "
-        "Cover the full video with no gaps larger than ~8 seconds. "
-        "Return the complete revised JSON in the same format as "
-        "before.\n\n"
+        "Cover the full DANCE WINDOW (dance_start_sec → "
+        "dance_end_sec) with no gaps larger than ~8 seconds. "
+        "DO NOT add patterns before dance_start_sec or after "
+        "dance_end_sec — walk-on, setup, bow, and walk-off are "
+        "explicitly excluded, not patterns. Preserve the "
+        "dance_start_sec / dance_end_sec values from your previous "
+        "response unless one of the issues above is directly about "
+        "them. Return the complete revised JSON in the same format "
+        "as before.\n\n"
         f"YOUR PREVIOUS RESPONSE (for reference, do not copy blindly):\n"
         f"{previous_raw[:6000]}\n"
     )
@@ -1789,7 +1795,7 @@ def analyze_video_path(
                 retry_raw, retry_usage = _call_gemini(
                     client,
                     settings.gemini_model,
-                    contents=[uploaded, retry_prompt],
+                    contents=[video_part, retry_prompt],
                     seed=seed,
                 )
                 total_prompt_tokens += int(retry_usage.get("prompt_tokens", 0))

--- a/api/src/wcs_api/services/video_analyzer.py
+++ b/api/src/wcs_api/services/video_analyzer.py
@@ -1563,17 +1563,39 @@ def _build_user_context(context: dict[str, Any] | None) -> str:
 
 
 def _build_sanity_retry_prompt(
-    issues: list[str], previous_raw: str
+    issues: list[str],
+    previous_raw: str,
+    *,
+    dance_start_sec: float | None = None,
+    dance_end_sec: float | None = None,
 ) -> str:
     """Construct a correction prompt for a second Gemini pass when
     the first response tripped sanity checks. We include the prior
     response so the model can patch it rather than start over.
+
+    `dance_start_sec` / `dance_end_sec` are the EFFECTIVE bounds
+    `analyze_video_path` computed after applying downbeat, motion
+    floor, and duration clamps. Gemini's raw previous response may
+    have un-clamped bounds, so we explicitly hand over the effective
+    values here — otherwise the retry would preserve stale numbers
+    while `_sanity_check` validates against the effective ones.
     """
     issue_lines = "\n".join(f"- {i}" for i in issues)
+    window_block = ""
+    if dance_start_sec is not None and dance_end_sec is not None:
+        window_block = (
+            f"\nEFFECTIVE DANCE WINDOW (use these exact values in the "
+            f"revised JSON): dance_start_sec = {dance_start_sec:.2f}, "
+            f"dance_end_sec = {dance_end_sec:.2f}. These already "
+            "incorporate downbeat + motion-floor + duration clamps "
+            "— do not recompute them, and do not emit any patterns "
+            "outside this window.\n"
+        )
     return (
         "SANITY CHECK FAILED on your previous response. "
         "The following issues were detected:\n"
-        f"{issue_lines}\n\n"
+        f"{issue_lines}\n"
+        f"{window_block}\n"
         "Revise your response to fix these specific issues. "
         "Non-dance labels like 'intro', 'waiting', 'starter step', "
         "or 'unknown' should be 1-8 seconds — if one of yours is "
@@ -1585,11 +1607,8 @@ def _build_sanity_retry_prompt(
         "dance_end_sec) with no gaps larger than ~8 seconds. "
         "DO NOT add patterns before dance_start_sec or after "
         "dance_end_sec — walk-on, setup, bow, and walk-off are "
-        "explicitly excluded, not patterns. Preserve the "
-        "dance_start_sec / dance_end_sec values from your previous "
-        "response unless one of the issues above is directly about "
-        "them. Return the complete revised JSON in the same format "
-        "as before.\n\n"
+        "explicitly excluded, not patterns. Return the complete "
+        "revised JSON in the same format as before.\n\n"
         f"YOUR PREVIOUS RESPONSE (for reference, do not copy blindly):\n"
         f"{previous_raw[:6000]}\n"
     )
@@ -1790,7 +1809,12 @@ def analyze_video_path(
             dance_end_sec=dance_end_sec,
         )
         if issues:
-            retry_prompt = _build_sanity_retry_prompt(issues, raw)
+            retry_prompt = _build_sanity_retry_prompt(
+                issues,
+                raw,
+                dance_start_sec=dance_start_sec,
+                dance_end_sec=dance_end_sec,
+            )
             try:
                 retry_raw, retry_usage = _call_gemini(
                     client,

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -164,8 +164,12 @@ export default function DashboardPage() {
       </div>
 
       {/* ─── Score trend ─── */}
+      {/* Include soft-deleted rows so the chart shows the user's full
+          historical progress, matching the delete copy ("stays on
+          the score trend"). `use-analysis-history` already fetches
+          them in chartRecords for this purpose. */}
       <ScoreTrendChart
-        records={history.chartRecords.filter((r) => !r.deleted_at)}
+        records={history.chartRecords}
         loading={history.loading}
       />
 

--- a/src/components/analyze/pattern-summary.tsx
+++ b/src/components/analyze/pattern-summary.tsx
@@ -154,7 +154,7 @@ export function PatternSummaryCard({
               QUALITY_STYLES.solid;
             return (
               <li
-                key={p.name}
+                key={`${p.name}|${p.variant ?? ""}`}
                 className="flex items-start gap-3 rounded-md border border-border p-2.5"
               >
                 <span

--- a/src/hooks/use-analysis-history.ts
+++ b/src/hooks/use-analysis-history.ts
@@ -157,14 +157,21 @@ export function useAnalysisHistory() {
       // chart can still plot it as history, but it disappears from
       // the analyze-page list. User-intent here is "clean up my
       // list", not "erase all evidence this ever happened".
+      //
+      // We also null share_token so any public link the user
+      // previously generated stops working — deleting should revoke
+      // sharing. Backend /shared/{token} also filters deleted rows
+      // as defense in depth.
       const now = new Date().toISOString();
       await sb
         .from("video_analyses")
-        .update({ deleted_at: now })
+        .update({ deleted_at: now, share_token: null })
         .eq("id", id);
       setRecords((rs) => rs.filter((r) => r.id !== id));
       setChartRecords((rs) =>
-        rs.map((r) => (r.id === id ? { ...r, deleted_at: now } : r))
+        rs.map((r) =>
+          r.id === id ? { ...r, deleted_at: now, share_token: null } : r
+        )
       );
     },
     []

--- a/src/hooks/use-analysis-history.ts
+++ b/src/hooks/use-analysis-history.ts
@@ -162,11 +162,19 @@ export function useAnalysisHistory() {
       // previously generated stops working — deleting should revoke
       // sharing. Backend /shared/{token} also filters deleted rows
       // as defense in depth.
+      //
+      // Await the response and bail on error so we don't lie to the
+      // user: if the DB write fails, the row is still visible and
+      // the share link is still live — mutating local state would
+      // make it look like the delete succeeded.
       const now = new Date().toISOString();
-      await sb
+      const { error } = await sb
         .from("video_analyses")
         .update({ deleted_at: now, share_token: null })
         .eq("id", id);
+      if (error) {
+        throw new Error(`Failed to delete analysis: ${error.message}`);
+      }
       setRecords((rs) => rs.filter((r) => r.id !== id));
       setChartRecords((rs) =>
         rs.map((r) =>

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -291,6 +291,7 @@ begin
     set share_view_count     = coalesce(share_view_count, 0) + 1,
         share_last_viewed_at = now()
     where share_token = p_token
+      and deleted_at is null
     returning share_view_count into new_count;
   return coalesce(new_count, 0);
 end;


### PR DESCRIPTION
## Summary

Batched four small fixes surfaced by the codex codebase review.

## Included

- **#77 + #78 — Retry pass: fps=2 + dance-window rule** (`video_analyzer.py`)
  The corrective retry dropped the fps=2 sampling hint by using `uploaded` instead of `video_part`, and its prompt said "cover the full video" which contradicted the main prompt's dance-window rule. Both fixed; likely helps #70.

- **#80 — Pattern-summary duplicate keys** (`pattern-summary.tsx`)
  Rows were grouped by `name+variant` but keyed by `name` only. Now keyed by `\${p.name}|\${p.variant ?? ""}`.

- **#71 — Revoke share link on soft delete** (frontend + backend + schema)
  Delete now clears `share_token` alongside `deleted_at`, `get_shared_analysis` filters `deleted_at=is.null`, and the `increment_share_view` RPC adds the same guard.

  **Backfill required after merge** (one-off SQL on Supabase):
  \`\`\`sql
  update public.video_analyses
    set share_token = null
    where deleted_at is not null
      and share_token is not null;
  \`\`\`

- **#81 — Dashboard shows deleted rows on trend chart**
  The hook already fetches deleted rows into `chartRecords` for this purpose. The dashboard was filtering them out at render, contradicting the delete-flow copy.

## Test plan

- [ ] Re-analyze a clip with pre-dance setup; confirm `dance_start_sec` is respected through the retry pass and no ghost pattern at 0s.
- [ ] Verify pattern summary with repeating whip variants shows no React key warnings in console.
- [ ] Share an analysis → delete it → confirm `/shared/<token>` returns 404.
- [ ] Run the backfill SQL above on prod Supabase.
- [ ] Dashboard trend chart continues to plot previously-deleted analyses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Soft-deleted analyses no longer appear in shared links or increment share view counts
  * Fixed pattern rendering for patterns sharing the same name with different variants
  * Improved video analysis retry logic to focus on detected dance windows

* **Improvements**
  * Deleting an analysis now automatically revokes its share link
  * Score trend chart displays complete historical data including soft-deleted records

<!-- end of auto-generated comment: release notes by coderabbit.ai -->