### PR TITLE
Coerce Gemini response + guard score renders (#73)

### DIFF
--- a/api/src/wcs_api/services/video_analyzer.py
+++ b/api/src/wcs_api/services/video_analyzer.py
@@ -2294,6 +2294,83 @@ def _sanitize_follower_initiative(
     return cleaned
 
 
+def _coerce_score(v: Any, default: float = 0.0) -> float:
+    """Coerce a numeric field to a float clamped to [0, 10].
+
+    Gemini sometimes returns scores as strings ("8.5"), lists ([8, 9]),
+    or the occasional free-text qualifier ("high 8"). The frontend
+    calls `.toFixed(1)` directly on these fields, so any non-number
+    white-screens the analysis page. Clamp to the valid WCS range so
+    an outlier like 42 or -3 can't skew downstream computations either.
+    """
+    try:
+        f = float(v)
+    except (TypeError, ValueError):
+        return default
+    if f != f:  # NaN check
+        return default
+    if f < 0:
+        return 0.0
+    if f > 10:
+        return 10.0
+    return round(f, 2)
+
+
+def _coerce_str_list(
+    raw: Any, *, max_items: int = 20, max_len: int = 500
+) -> list[str]:
+    """Coerce a field expected to be a list-of-strings into a safe
+    list. Gemini occasionally returns a single string, a dict, or null
+    where we asked for an array — the frontend `.map()`s over these
+    and crashes if the value isn't iterable. Anything non-stringy is
+    dropped rather than stringified blindly."""
+    if raw is None:
+        return []
+    items: list[Any]
+    if isinstance(raw, list):
+        items = raw
+    elif isinstance(raw, str):
+        # Single string where we asked for an array — wrap it so we
+        # at least don't lose the content.
+        items = [raw]
+    else:
+        return []
+    cleaned: list[str] = []
+    for item in items[:max_items]:
+        if not isinstance(item, str):
+            continue
+        trimmed = item.strip()
+        if not trimmed:
+            continue
+        cleaned.append(trimmed[:max_len])
+    return cleaned
+
+
+def _coerce_category(cat: Any) -> dict[str, Any]:
+    """Coerce a single category dict into a shape the frontend can
+    safely render. Missing or malformed `score` becomes 0.0 (never
+    a crash). Nested sub-scores (posture, extension, footwork, slot)
+    get the same treatment. All other fields pass through so reasoning
+    / notes / off_beat_moments survive the round trip unchanged."""
+    if not isinstance(cat, dict):
+        return {"score": 0.0}
+    out: dict[str, Any] = dict(cat)
+    out["score"] = _coerce_score(cat.get("score"))
+    if "score_low" in cat:
+        out["score_low"] = _coerce_score(cat.get("score_low"), default=out["score"])
+    if "score_high" in cat:
+        out["score_high"] = _coerce_score(cat.get("score_high"), default=out["score"])
+    # Nested sub-scores on technique; shape is {score, notes}.
+    for sub_key in ("posture", "extension", "footwork", "slot"):
+        sub = cat.get(sub_key)
+        if isinstance(sub, dict) and "score" in sub:
+            out[sub_key] = {
+                **sub,
+                "score": _coerce_score(sub.get("score")),
+            }
+    return out
+
+
 def _shape_response(
     parsed: dict[str, Any],
     *,
@@ -2308,9 +2385,13 @@ def _shape_response(
     Preserves rich audit fields (reasoning, score_low/high,
     off_beat_moments, sub-scores, patterns) while also providing the
     simplified fields the current frontend renders.
+
+    All score and list fields are coerced through the `_coerce_*`
+    helpers so one malformed Gemini response cannot poison a DB row
+    or crash the analysis page on `.toFixed()` / `.map()`.
     """
     categories = {
-        key: (parsed.get(key) or {}) if isinstance(parsed.get(key), dict) else {}
+        key: _coerce_category(parsed.get(key))
         for key in ("timing", "technique", "teamwork", "presentation")
     }
     overall_score = _compute_overall(categories)
@@ -2320,8 +2401,10 @@ def _shape_response(
     # than 2 points — matches wcs-analyzer's scoring.py heuristic.
     confidence = "low" if max_interval > 2.0 else "high"
 
-    strengths = parsed.get("highlights") or parsed.get("strengths") or []
-    improvements = parsed.get("improvements") or []
+    strengths = _coerce_str_list(
+        parsed.get("highlights") or parsed.get("strengths")
+    )
+    improvements = _coerce_str_list(parsed.get("improvements"))
 
     patterns_identified = _sanitize_patterns(
         parsed.get("patterns_identified"),

--- a/src/app/shared/page.tsx
+++ b/src/app/shared/page.tsx
@@ -21,6 +21,7 @@ import {
   derivePatternSummary,
 } from "@/components/analyze/pattern-summary";
 import { Analytics } from "@/lib/analytics";
+import { fmtScore } from "@/lib/utils";
 
 function scoreBarColor(score: number): string {
   if (score >= 8) return "bg-emerald-500";
@@ -170,7 +171,7 @@ function SharedAnalysisContent() {
             <div className="flex flex-col items-center gap-3 py-2">
               <div className="flex items-baseline gap-2">
                 <span className="text-7xl font-bold tabular-nums leading-none">
-                  {overall.score.toFixed(1)}
+                  {fmtScore(overall?.score)}
                 </span>
                 <span className="text-2xl text-muted-foreground">/10</span>
               </div>
@@ -199,10 +200,10 @@ function SharedAnalysisContent() {
                       <div className="flex items-center justify-between text-sm">
                         <span className="font-medium">{label}</span>
                         <span className="font-mono tabular-nums">
-                          {cat.score.toFixed(1)} / 10
+                          {fmtScore(cat?.score)} / 10
                         </span>
                       </div>
-                      <ScoreBar score={cat.score} />
+                      <ScoreBar score={cat?.score ?? 0} />
                       {cat.notes && (
                         <p className="text-xs text-muted-foreground pt-0.5">
                           {cat.notes}
@@ -239,7 +240,7 @@ function SharedAnalysisContent() {
         })()}
 
         {/* Strengths */}
-        {result.strengths?.length > 0 && (
+        {Array.isArray(result.strengths) && result.strengths.length > 0 && (
           <Card>
             <CardHeader className="pb-3">
               <CardTitle className="text-base flex items-center gap-2">
@@ -261,7 +262,7 @@ function SharedAnalysisContent() {
         )}
 
         {/* Improvements */}
-        {result.improvements?.length > 0 && (
+        {Array.isArray(result.improvements) && result.improvements.length > 0 && (
           <Card>
             <CardHeader className="pb-3">
               <CardTitle className="text-base flex items-center gap-2">

--- a/src/components/analyze/score-result-card.tsx
+++ b/src/components/analyze/score-result-card.tsx
@@ -13,6 +13,7 @@ import {
 } from "lucide-react";
 import type { FollowerInitiative, VideoScoreResult } from "@/lib/wcs-api";
 import { getLevelContext } from "@/lib/level-context";
+import { fmtScore } from "@/lib/utils";
 import {
   PatternSummaryCard,
   derivePatternSummary,
@@ -219,7 +220,7 @@ export function ScoreResultCard({
           <div className="flex flex-col items-center gap-3 py-4">
             <div className="flex items-baseline gap-2">
               <span className="text-5xl sm:text-7xl font-bold tabular-nums leading-none">
-                {result.overall.score.toFixed(1)}
+                {fmtScore(result.overall?.score)}
               </span>
               <span className="text-xl sm:text-2xl text-muted-foreground">
                 /10
@@ -372,7 +373,7 @@ export function ScoreResultCard({
                       {CATEGORY_LABELS[key]}
                     </span>
                     <span className="font-mono tabular-nums text-right">
-                      {cat.score.toFixed(1)} / 10
+                      {fmtScore(cat?.score)} / 10
                       {typeof cat.score_low === "number" &&
                         typeof cat.score_high === "number" &&
                         cat.score_high > cat.score_low && (
@@ -430,7 +431,7 @@ export function ScoreResultCard({
         </CardHeader>
         <CardContent>
           <ul className="space-y-2.5 text-sm">
-            {result.strengths.map((s, i) => (
+            {(Array.isArray(result.strengths) ? result.strengths : []).map((s, i) => (
               <li key={i} className="flex items-start gap-2.5">
                 <CheckCircle2 className="h-4 w-4 text-emerald-400 mt-0.5 shrink-0" />
                 <span className="text-muted-foreground">{s}</span>
@@ -449,7 +450,7 @@ export function ScoreResultCard({
         </CardHeader>
         <CardContent>
           <ul className="space-y-2.5 text-sm">
-            {result.improvements.map((s, i) => (
+            {(Array.isArray(result.improvements) ? result.improvements : []).map((s, i) => (
               <li key={i} className="flex items-start gap-2.5">
                 <Target className="h-4 w-4 text-amber-400 mt-0.5 shrink-0" />
                 <span className="text-muted-foreground">{s}</span>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,18 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+/**
+ * Safe .toFixed for values that may not be numbers. Guards against
+ * old DB rows persisted before server-side response coercion shipped
+ * — those rows can contain strings, nulls, or NaNs where a number is
+ * expected. Returns the fallback (default "—") on anything non-finite.
+ */
+export function fmtScore(
+  v: unknown,
+  digits: number = 1,
+  fallback: string = "—"
+): string {
+  if (typeof v !== "number" || !Number.isFinite(v)) return fallback;
+  return v.toFixed(digits);
+}


### PR DESCRIPTION
## Summary

Two-layer defense against malformed Gemini responses:

1. **Server-side**: `_coerce_score`, `_coerce_str_list`, `_coerce_category` helpers run over every category, `strengths`, and `improvements` before `_shape_response` returns. A response with `timing.score = "8"` now persists and returns as `8.0`; `strengths = null` becomes `[]`; a category with junk scores falls back to `0.0` rather than crashing the UI.

2. **Frontend (belt-and-suspenders)**: `fmtScore()` utility handles anything non-finite, applied to the two hero scores and each category render. `.strengths` / `.improvements` iteration wrapped in `Array.isArray()` guards. Protects OLD DB rows persisted before the backend coercion shipped.

## Why both layers

The backend fix protects all *new* analyses, but rows already in the DB with bad shapes remain unsafe. The frontend guard keeps those rows from white-screening the analysis / shared page until they age out.

## Test plan

- [x] Smoke-tested all coercion helpers against malformed inputs (strings, nulls, NaN, out-of-range, non-dicts, non-arrays) — all pass.
- [ ] Check an existing good analysis still renders identically.
- [ ] Delete a fresh analysis, manually poke the DB to set `result.categories.timing.score = "bad"`, reload — should show `—` instead of crashing.
- [ ] No TypeScript errors (`tsc --noEmit` passes locally).

Closes #73.