### PR TITLE
Surface R2 delete failures (#74)

### DIFF
--- a/api/src/wcs_api/routes/uploads.py
+++ b/api/src/wcs_api/routes/uploads.py
@@ -23,12 +23,23 @@ async def delete_video(
 ) -> dict:
     """User-initiated delete: remove the R2 object and clear the
     reference on any of the user's video_analyses rows so the UI
-    reflects the deletion immediately."""
+    reflects the deletion immediately.
+
+    Uses raise_on_error=True so a failed R2 delete surfaces as a
+    500 to the client instead of the user seeing a silent success
+    on a privacy-critical operation.
+    """
     if not r2.object_key_belongs_to_user(body.object_key, user["sub"]):
         raise HTTPException(
             status_code=403, detail="object does not belong to user"
         )
-    r2.delete_object(body.object_key)
+    try:
+        r2.delete_object(body.object_key, raise_on_error=True)
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"R2 delete failed: {exc}",
+        ) from exc
     try:
         await supabase_admin.clear_video_analysis_object_key(
             object_key=body.object_key, user_id=user["sub"]

--- a/api/src/wcs_api/services/r2.py
+++ b/api/src/wcs_api/services/r2.py
@@ -7,6 +7,7 @@ GETs, and DELETEs objects server-to-server.
 
 from __future__ import annotations
 
+import logging
 import os
 import tempfile
 import uuid
@@ -16,6 +17,8 @@ import boto3
 from botocore.config import Config
 
 from ..settings import settings
+
+logger = logging.getLogger(__name__)
 
 
 def _client():
@@ -68,11 +71,28 @@ def download_to_tempfile(object_key: str, suffix: str = "") -> str:
     return tmp.name
 
 
-def delete_object(object_key: str) -> None:
+def delete_object(object_key: str, *, raise_on_error: bool = False) -> None:
+    """Delete an R2 object.
+
+    By default this is best-effort: exceptions are logged (not
+    swallowed silently) and suppressed so automatic post-scoring
+    cleanup can't take down a successful analysis. The 24h bucket
+    lifecycle rule is the backstop for anything we leaked here.
+
+    Callers that are responding to a user's explicit delete request
+    (e.g. the /uploads/delete endpoint) should pass
+    `raise_on_error=True` so the error surfaces to the UI instead
+    of the user seeing a silent "deleted" that actually left the
+    object behind.
+    """
     try:
         _client().delete_object(Bucket=settings.r2_bucket, Key=object_key)
-    except Exception:
-        pass
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "r2.delete_object failed for key=%s: %s", object_key, exc
+        )
+        if raise_on_error:
+            raise
 
 
 def generate_presigned_get(object_key: str, expires_in: int = 3600) -> str:


### PR DESCRIPTION
## Summary

R2 deletion errors were silently swallowed everywhere — the "delete after scoring" privacy guarantee was best-effort with no signal on failure, and user-initiated deletes returned \`ok: true\` even when the R2 object was left behind.

## Changes

- \`r2.delete_object\` logs failures at warning level via the module logger and accepts \`raise_on_error=True\` for privacy-critical callers.
- \`/uploads/delete\` (user-initiated) passes \`raise_on_error=True\` and maps any failure to a 502 so the UI surfaces \`"couldn't delete"\` instead of a silent success.
- \`/video/analyze\` post-scoring cleanup keeps best-effort semantics — a failed R2 delete must never take down a successful analysis — but now logs instead of swallowing.
- The oversize-upload reject path in \`/video/analyze\` gets the same logging treatment by reusing the updated \`delete_object\`.

## Test plan

- [ ] Upload a video, let it score, confirm R2 object is gone (happy path).
- [ ] Simulate an R2 outage (e.g. break the secret key) then attempt a user-initiated delete → UI should show an error, not a silent success.
- [ ] During the same outage, a fresh analysis should still return scoring results — just with a warning line in Railway logs.

Closes #74.