### PR TITLE
Carry pre-pass variant + visual_cue into main prompt (#76)

### DIFF
--- a/api/src/wcs_api/services/video_analyzer.py
+++ b/api/src/wcs_api/services/video_analyzer.py
@@ -1309,16 +1309,28 @@ def _format_pattern_timeline(
         start = float(seg.get("start_time") or 0.0)
         end = float(seg.get("end_time") or 0.0)
         name = seg.get("name", "unknown")
+        # Surface variant + visual_cue from the pre-pass so the main
+        # prompt doesn't have to re-derive "what KIND of whip" — the
+        # pre-pass already spent a high-thinking pass identifying it.
+        variant = (seg.get("variant") or "").strip()
+        variant_str = f" · {variant}" if variant and variant.lower() != "basic" else ""
+        cue = (seg.get("visual_cue") or "").strip()
+        cue_str = f" [cue: {cue}]" if cue else ""
         conf = seg.get("confidence")
         conf_str = (
             f" (confidence {conf:.1f})"
             if isinstance(conf, (int, float))
             else ""
         )
-        lines.append(f"  {i}. {start:.1f}s - {end:.1f}s: {name}{conf_str}")
+        lines.append(
+            f"  {i}. {start:.1f}s - {end:.1f}s: {name}{variant_str}"
+            f"{cue_str}{conf_str}"
+        )
     lines.append(
         "\nUse this timeline as a strong prior when filling "
-        "`patterns_identified` in your response. You can add patterns the "
+        "`patterns_identified` in your response. The variant and "
+        "visual cue above come from a dedicated pattern-ID pass — "
+        "prefer them over re-guessing. You can add patterns the "
         "pre-pass missed or correct obvious errors, but default to "
         "trusting it. Respect the dance window — no patterns before "
         "dance_start_sec or after dance_end_sec."


### PR DESCRIPTION
## Summary

The pattern pre-pass runs at \`high\` thinking level and produces per-pattern \`variant\` and \`visual_cue\` fields (e.g. \`"whip", variant: "basket", visual_cue: "follower's hand held behind back from 3-5"\`). But \`_format_pattern_timeline\` was flattening that output to \`name + time range\` only, so the main scoring call had to re-derive the variant from scratch despite the pre-pass already having spent the tokens.

This PR surfaces \`variant\` (when not \`"basic"\`) and \`visual_cue\` in the prior, and tells the main prompt to prefer them over re-guessing.

## Changes

- \`_format_pattern_timeline\` now includes \`· variant [cue: ...]\` after the pattern name.
- Trailing "use this timeline as a strong prior" note explains that the variant/cue came from a dedicated ID pass.

## Why minimal

No change to the pre-pass prompt, pre-pass response schema, or the \`patterns_identified\` shape returned to the frontend. This is a pure "don't throw away data you already paid for" fix — the main pass gets a richer prior and is less likely to downgrade a \`basket whip\` to a plain whip.

## Test plan

- [ ] Run a fresh analysis on a clip with several whip variants; confirm the main pass's \`patterns_identified\` agrees with the pre-pass variants more often.
- [ ] Existing analyses remain unaffected (stored result JSON is the same shape).

Closes #76.