### PR TITLE
Keep analytics failures off analyze critical path (#72 partial)

### DIFF
--- a/api/src/wcs_api/routes/video.py
+++ b/api/src/wcs_api/routes/video.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 import httpx
@@ -12,6 +13,8 @@ from ..services.video_analyzer import (
     get_video_duration,
 )
 from ..settings import settings
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/analyze/video", tags=["analyze"])
 
@@ -189,18 +192,27 @@ async def analyze_video_endpoint(
         # admin dashboards can aggregate it.
         usage = result.pop("usage", None)
 
-        await supabase_admin.insert_usage_event(
-            user_id=user_id,
-            kind="video",
-            duration_sec=int(duration),
-            usage=usage,
-        )
+        # Usage logging is analytics — if it fails, we still want to
+        # return the analysis the user paid for. A Supabase hiccup
+        # on the INSERT here should never throw away a completed
+        # Gemini call. Quota enforcement already ran above; the only
+        # downside to a missed usage_event is that the monthly count
+        # is off by one, which is self-healing the next month.
+        try:
+            await supabase_admin.insert_usage_event(
+                user_id=user_id,
+                kind="video",
+                duration_sec=int(duration),
+                usage=usage,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "insert_usage_event failed for user=%s (analysis still returned): %s",
+                user_id,
+                exc,
+            )
         analysis_id: str | None = None
         try:
-            # object_key is intentionally NOT saved — the R2 object is
-            # deleted below, so keeping the key would just lead to 404s
-            # on Watch/Re-analyze. Privacy also: we don't retain dance
-            # videos of real people after the scoring run.
             # Preserve the R2 object_key on the row only when the
             # user opted in to video retention. Otherwise the row
             # stores a null key and the clip is purged below.
@@ -219,8 +231,16 @@ async def analyze_video_endpoint(
                 dancer_description=body.dancer_description,
                 usage=usage,
             )
-        except Exception:
-            pass
+        except Exception as exc:  # noqa: BLE001
+            # Surface the failure in logs so a persistence bug is
+            # observable. Analysis is still returned to the user —
+            # the DB row is a convenience (history list), not the
+            # primary artifact.
+            logger.warning(
+                "insert_video_analysis failed for user=%s (analysis still returned): %s",
+                user_id,
+                exc,
+            )
 
         return {
             "duration": round(duration, 2),


### PR DESCRIPTION
## Summary

Two ways a DB hiccup could nuke a completed Gemini call:

1. \`insert_usage_event\` was awaited unguarded — any Supabase error after Gemini ran would propagate up as a 500 even though the analysis itself succeeded. User paid for the call, got nothing.
2. \`insert_video_analysis\` was wrapped in a bare \`except: pass\` — failure was silent, so we couldn't tell when the history row didn't actually land.

Both paths now log a warning (instead of raising / swallowing) and always fall through to return the analysis. Quota enforcement already ran up-front; a missing \`usage_event\` just means the monthly count is off by one, which self-heals next month.

## What this does NOT fix

The check-then-charge quota race — two concurrent requests can each see \`remaining=1\` and both proceed, spending quota twice. That needs an atomic reserve-and-charge RPC (a schema + backend change), which I'm leaving for a follow-up. Low-severity: bounded by concurrent request count per user, and Gemini cost on overrun is cheap compared to the "dropped analysis" bug this PR fixes.

#72 stays open until the race is addressed.

## Test plan

- [ ] Happy path: fresh analysis returns result + quota unchanged in behavior.
- [ ] Simulate Supabase failure during \`insert_usage_event\` (e.g. kill the service role key) → analysis still returns to the client; Railway log shows a warning.
- [ ] Simulate same during \`insert_video_analysis\` → analysis returns with \`analysis_id: null\`; user sees score but history row is missing; warning logged.