### PR TITLE
Harden video_analysis modules against malformed inputs

### DIFF
--- a/api/src/wcs_api/services/video_analysis/__init__.py
+++ b/api/src/wcs_api/services/video_analysis/__init__.py
@@ -3,7 +3,7 @@ from .media_context import get_video_duration
 
 __all__ = [
     "VideoAnalysisError",
-    "analyze_video_path",
     "analyze_video_bytes",
+    "analyze_video_path",
     "get_video_duration",
 ]

--- a/api/src/wcs_api/services/video_analysis/analyzer.py
+++ b/api/src/wcs_api/services/video_analysis/analyzer.py
@@ -192,19 +192,10 @@ def analyze_video_path(
     seed: int | None = _secrets.randbelow(2**31) if fresh else 42
 
     client = genai.Client(api_key=settings.gemini_api_key)
+    # Upload outside the try so `uploaded` is bound before we enter
+    # cleanup territory; if the upload itself raises, there's nothing
+    # to delete.
     uploaded = client.files.upload(file=video_path)
-
-    # Poll until the file is ACTIVE on Gemini's side.
-    deadline = time.time() + 120
-    while uploaded.state and uploaded.state.name == "PROCESSING":
-        if time.time() > deadline:
-            raise VideoAnalysisError("Gemini file processing timed out")
-        time.sleep(1.5)
-        uploaded = client.files.get(name=uploaded.name)
-
-    if not uploaded.state or uploaded.state.name != "ACTIVE":
-        state_name = uploaded.state.name if uploaded.state else "UNKNOWN"
-        raise VideoAnalysisError(f"Gemini file upload state: {state_name}")
 
     # Aggregate token usage across pre-pass + main call so cost
     # tracking reflects the full billed spend for this analysis.
@@ -213,14 +204,28 @@ def analyze_video_path(
 
     sanity_warnings: list[str] = []
 
-    # Wrap the uploaded video with an explicit fps=2 sampling hint.
-    # Default Gemini sampling is ~1 FPS; doubling it catches the
-    # "&" counts between beats (kick-ball-changes, quick anchor
-    # settles) that 1 FPS routinely misses. Video token cost ~2x,
-    # still bounded because we only upload short clips.
-    video_part = _video_part_with_fps(uploaded, fps=2.0)
-
     try:
+        # Poll until the file is ACTIVE on Gemini's side. Inside the
+        # try block so a timeout or non-ACTIVE state still triggers
+        # the cleanup in `finally`.
+        deadline = time.time() + 120
+        while uploaded.state and uploaded.state.name == "PROCESSING":
+            if time.time() > deadline:
+                raise VideoAnalysisError("Gemini file processing timed out")
+            time.sleep(1.5)
+            uploaded = client.files.get(name=uploaded.name)
+
+        if not uploaded.state or uploaded.state.name != "ACTIVE":
+            state_name = uploaded.state.name if uploaded.state else "UNKNOWN"
+            raise VideoAnalysisError(f"Gemini file upload state: {state_name}")
+
+        # Wrap the uploaded video with an explicit fps=2 sampling hint.
+        # Default Gemini sampling is ~1 FPS; doubling it catches the
+        # "&" counts between beats (kick-ball-changes, quick anchor
+        # settles) that 1 FPS routinely misses. Video token cost ~2x,
+        # still bounded because we only upload short clips.
+        video_part = _video_part_with_fps(uploaded, fps=2.0)
+
         prompt = GEMINI_VIDEO_PROMPT
 
         # User-provided metadata (level, role, event, stage, tags)
@@ -421,7 +426,10 @@ def analyze_video_bytes(
 
     try:
         duration = get_video_duration(tmp_path)
-        result = analyze_video_path(tmp_path)
+        # Pass duration through so sanity checks (pattern density,
+        # gap detection) and dance_end_sec clamping work on this
+        # byte-upload path the same way they do on the R2 path.
+        result = analyze_video_path(tmp_path, duration_sec=duration)
         return result, duration
     finally:
         try:

--- a/api/src/wcs_api/services/video_analysis/media_context.py
+++ b/api/src/wcs_api/services/video_analysis/media_context.py
@@ -291,10 +291,14 @@ def _extract_beat_context(
             # Compact grid for the frontend metronome. Round to
             # milliseconds to keep the payload small — sub-ms
             # precision doesn't matter for a visual pulse.
+            # Sort downbeats chronologically — `downbeat_set` is a
+            # plain set, so iterating it yields arbitrary order, and
+            # the frontend metronome does a binary search that assumes
+            # sorted input.
             beat_grid = {
                 "bpm": round(float(bpm), 1),
                 "beats": [round(float(t), 3) for t in all_beats],
-                "downbeats": [round(float(t), 3) for t in downbeat_set],
+                "downbeats": [round(float(t), 3) for t in sorted(downbeat_set)],
                 "source": source,
             }
             return prompt_text, first_downbeat_sec, beat_grid
@@ -337,7 +341,10 @@ def get_video_duration(path: str) -> float:
     except subprocess.TimeoutExpired as exc:
         raise VideoAnalysisError("ffprobe timed out") from exc
 
-    data = json.loads(result.stdout or "{}")
+    try:
+        data = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        raise VideoAnalysisError("could not parse video duration") from exc
     try:
         return float(data["format"]["duration"])
     except (KeyError, TypeError, ValueError) as exc:

--- a/api/src/wcs_api/services/video_analysis/prompts.py
+++ b/api/src/wcs_api/services/video_analysis/prompts.py
@@ -694,15 +694,28 @@ def _format_pattern_timeline(
             "with patterns in your response)."
         )
     for i, seg in enumerate(patterns, 1):
-        start = float(seg.get("start_time") or 0.0)
-        end = float(seg.get("end_time") or 0.0)
+        # Defensive coercion: the pre-pass is usually well-formed, but
+        # if Gemini returns "unknown" or a non-numeric timestamp, we
+        # don't want the whole timeline-rendering call to crash.
+        try:
+            start = float(seg.get("start_time") or 0.0)
+        except (TypeError, ValueError):
+            start = 0.0
+        try:
+            end = float(seg.get("end_time") or 0.0)
+        except (TypeError, ValueError):
+            end = 0.0
         name = seg.get("name", "unknown")
+        if not isinstance(name, str):
+            name = "unknown"
         # Surface variant + visual_cue from the pre-pass so the main
         # prompt doesn't have to re-derive "what KIND of whip" — the
         # pre-pass already spent a high-thinking pass identifying it.
-        variant = (seg.get("variant") or "").strip()
+        variant_raw = seg.get("variant")
+        variant = str(variant_raw).strip() if variant_raw is not None else ""
         variant_str = f" · {variant}" if variant and variant.lower() != "basic" else ""
-        cue = (seg.get("visual_cue") or "").strip()
+        cue_raw = seg.get("visual_cue")
+        cue = str(cue_raw).strip() if cue_raw is not None else ""
         cue_str = f" [cue: {cue}]" if cue else ""
         conf = seg.get("confidence")
         conf_str = (

--- a/api/src/wcs_api/services/video_analysis/response_sanitizer.py
+++ b/api/src/wcs_api/services/video_analysis/response_sanitizer.py
@@ -223,15 +223,21 @@ def _summarize_patterns(
     stylings: dict[str, list[str]] = defaultdict(list)
     tips: dict[str, list[str]] = defaultdict(list)
 
+    def _s(v: Any) -> str:
+        """Coerce any field that should be a string into one safely,
+        so .strip() / .lower() below can't raise on a nested dict or
+        number returned by Gemini."""
+        return str(v).strip() if isinstance(v, str) else ""
+
     for p in patterns:
-        raw_name = (p.get("name") or "").strip()
+        raw_name = _s(p.get("name"))
         if not raw_name:
             continue
         # Key on (family + variant) so "basket whip" and "reverse whip"
         # count as distinct patterns even though they share the "whip"
         # family. "basic" variant groups with null — both mean
         # "plain execution of the family".
-        raw_variant = (p.get("variant") or "").strip().lower()
+        raw_variant = _s(p.get("variant")).lower()
         variant_key_part = "" if raw_variant in ("", "basic") else raw_variant
         key = _normalize_pattern_name(raw_name) + (
             f"|{variant_key_part}" if variant_key_part else ""
@@ -248,13 +254,13 @@ def _summarize_patterns(
         t = p.get("timing")
         if isinstance(t, str) and t:
             timings[key].append(t)
-        n = (p.get("notes") or "").strip()
+        n = _s(p.get("notes"))
         if n and n not in notes[key]:
             notes[key].append(n)
-        styling_val = (p.get("styling") or "").strip()
+        styling_val = _s(p.get("styling"))
         if styling_val and styling_val not in stylings[key]:
             stylings[key].append(styling_val)
-        tip_val = (p.get("coaching_tip") or "").strip()
+        tip_val = _s(p.get("coaching_tip"))
         if tip_val and tip_val not in tips[key]:
             tips[key].append(tip_val)
 
@@ -512,7 +518,7 @@ def _sanitize_musical_moments(
                 "timestamp_sec": ts,
                 "kind": kind,
                 "description": (entry.get("description") or "").strip() or None,
-                "caught": bool(entry.get("caught")),
+                "caught": _coerce_bool(entry.get("caught")),
                 "caught_how": (
                     (entry.get("caught_how") or "").strip() or None
                 ),
@@ -584,6 +590,25 @@ def _coerce_score(v: Any, default: float = 0.0) -> float:
     if f > 10:
         return 10.0
     return round(f, 2)
+
+
+def _coerce_bool(v: Any) -> bool:
+    """Coerce a loosely-typed 'caught' flag into a strict boolean.
+
+    `bool(x)` is too permissive: Gemini occasionally returns the
+    string "false" or "missed" here, both of which bool() would
+    treat as truthy. Parse known true/false tokens explicitly and
+    default to False for anything else — "caught" should be an
+    explicit positive, not a fuzzy fallback.
+    """
+    if isinstance(v, bool):
+        return v
+    if isinstance(v, (int, float)):
+        return v != 0
+    if isinstance(v, str):
+        normalized = v.strip().lower()
+        return normalized in ("true", "1", "yes", "y", "caught", "hit")
+    return False
 
 
 def _coerce_str_list(


### PR DESCRIPTION
## Summary

Addresses the 8 CodeRabbit findings on PR #89. All were **pre-existing** behaviors in \`video_analyzer.py\` that became easier to spot once the modules got smaller — none are regressions from the refactor.

## Fixes

**Real bugs**
- **\`caught\` coercion** (\`response_sanitizer.py\`): \`bool(entry.get("caught"))\` treats \`"false"\` and \`"missed"\` as True. New \`_coerce_bool\` parses known true/false tokens explicitly.
- **Downbeat ordering** (\`media_context.py\`): \`beat_grid.downbeats\` serialized from a \`set\`, which yields arbitrary order. Frontend metronome binary-searches this list assuming sorted input. Now \`sorted(downbeat_set)\`.
- **\`analyze_video_bytes\` dropped duration** (\`analyzer.py\`): probed duration but never passed it to \`analyze_video_path\`, so sanity checks + \`dance_end_sec\` clamping were disabled on the byte-upload path. Threaded through.

**Robustness**
- **\`_summarize_patterns\`** (\`response_sanitizer.py\`): \`.strip()\` on non-string fields. Wrap through a tiny \`_s()\` helper.
- **\`_format_pattern_timeline\`** (\`prompts.py\`): \`float()\` / \`.strip()\` on pre-pass fields that could be \`"unknown"\` or a nested dict. Each coercion wrapped so one weird segment can't crash the whole render.
- **\`get_video_duration\`** (\`media_context.py\`): \`json.JSONDecodeError\` escaped past the \`VideoAnalysisError\` wrapper. Now caught + wrapped.
- **Upload try/finally** (\`analyzer.py\`): polling timeout / non-ACTIVE state raised BEFORE the try block, orphaning the file on Gemini's side. Moved poll + state-check inside the try so cleanup always runs.

**Nitpick**
- \`__all__\` alphabetized per RUF022.

## Test plan

- [x] All 6 modules parse (ast.parse).
- [x] \`_coerce_bool\` smoke tests: \`True/False/"true"/"false"/"missed"/"yes"/1/0/None/dict\` all resolve correctly.
- [x] \`_summarize_patterns\` survives \`{'variant': 42, 'notes': None, 'styling': {'x': 1}}\`.
- [x] Shim still resolves \`analyze_video_path\` identically.
- [ ] Railway build passes post-merge.

Follow-up to #89. Unblocks cleaner future edits on the same modules.