### PR TITLE
Log silent failures + derive dance_window from patterns

### DIFF
--- a/api/src/wcs_api/services/video_analysis/analyzer.py
+++ b/api/src/wcs_api/services/video_analysis/analyzer.py
@@ -14,12 +14,15 @@ to ensure scoring consistency with the canonical research tool.
 
 from __future__ import annotations
 
+import logging
 import os
 import tempfile
 import time
 from typing import Any
 
 from google import genai
+
+logger = logging.getLogger(__name__)
 
 from ...settings import settings
 from .gemini_client import (
@@ -96,10 +99,15 @@ def _run_pattern_pre_pass(
             thinking_level_override="high",
             seed=seed,
         )
-    except VideoAnalysisError:
+    except VideoAnalysisError as exc:
+        logger.warning("video_analysis.pre_pass_failed error=%r", exc)
         return None, None, None, None
     data = _safe_parse_json(raw)
     if not data:
+        logger.warning(
+            "video_analysis.pre_pass_unparseable raw_prefix=%r",
+            raw[:200] if raw else None,
+        )
         return None, usage, None, None
 
     dance_start = _safe_float(data.get("dance_start_sec"))
@@ -335,6 +343,72 @@ def analyze_video_path(
             dance_start_sec = motion_floor_sec
         if duration_sec is not None and dance_end_sec is not None:
             dance_end_sec = min(dance_end_sec, duration_sec)
+
+        # Fallback: if neither the pre-pass nor the main call emitted
+        # a dance window but the main call DID emit patterns with
+        # start_time / end_time, derive the window from those. Without
+        # this, a main call that silently drops dance_start_sec/
+        # dance_end_sec (empirically common on the large schema we
+        # send today) ships to the user with `dance_window=null`,
+        # which breaks the timeline UI's window-clamping and the
+        # sanitizer's pre-dance-pattern trimming.
+        if dance_start_sec is None or dance_end_sec is None:
+            pattern_times: list[tuple[float, float]] = []
+            for p in parsed.get("patterns_identified") or []:
+                if not isinstance(p, dict):
+                    continue
+                ps = _safe_float(p.get("start_time"))
+                pe = _safe_float(p.get("end_time"))
+                if ps is not None and pe is not None and pe > ps:
+                    pattern_times.append((ps, pe))
+            if pattern_times:
+                if dance_start_sec is None:
+                    dance_start_sec = min(s for s, _ in pattern_times)
+                    logger.info(
+                        "video_analysis.dance_start_fallback derived=%s",
+                        dance_start_sec,
+                    )
+                if dance_end_sec is None:
+                    dance_end_sec = max(e for _, e in pattern_times)
+                    logger.info(
+                        "video_analysis.dance_end_fallback derived=%s",
+                        dance_end_sec,
+                    )
+            # Re-apply floors after the fallback.
+            if (
+                first_downbeat_sec is not None
+                and dance_start_sec is not None
+                and dance_start_sec + 0.25 < first_downbeat_sec
+            ):
+                dance_start_sec = first_downbeat_sec
+            if (
+                motion_floor_sec is not None
+                and motion_floor_sec > 0.5
+                and dance_start_sec is not None
+                and dance_start_sec + 0.25 < motion_floor_sec
+            ):
+                dance_start_sec = motion_floor_sec
+            if duration_sec is not None and dance_end_sec is not None:
+                dance_end_sec = min(dance_end_sec, duration_sec)
+
+        # Log load-bearing fields that the main call silently dropped.
+        # These are the four lenses the UX advertises; missing them
+        # in prod is how Sarah's feedback arrived as "horoscope".
+        missing_fields = [
+            f
+            for f in (
+                "dance_start_sec",
+                "dance_end_sec",
+                "musical_moments",
+                "follower_initiative",
+            )
+            if parsed.get(f) in (None, [], {})
+        ]
+        if missing_fields:
+            logger.warning(
+                "video_analysis.main_call_missing_fields fields=%s",
+                missing_fields,
+            )
 
         # Sanity check: if the response has obvious implausibilities
         # (e.g. "intro lasted 60s" or only 2 patterns for a 2-minute

--- a/api/src/wcs_api/services/video_analysis/media_context.py
+++ b/api/src/wcs_api/services/video_analysis/media_context.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import subprocess
 import tempfile
@@ -9,6 +10,8 @@ from typing import Any
 from google.genai import types as genai_types
 
 from .gemini_client import VideoAnalysisError
+
+logger = logging.getLogger(__name__)
 
 
 def _detect_motion_floor(video_path: str) -> float | None:
@@ -307,7 +310,17 @@ def _extract_beat_context(
                 os.unlink(wav_path)
             except OSError:
                 pass
-    except Exception:
+    except Exception as exc:  # noqa: BLE001
+        # Silent failure here cascades into an empty `beat_grid` and a
+        # missing `first_downbeat_sec` floor on the analyzer, which
+        # then lets pre-dance hallucinations through. Log loud enough
+        # that Railway logs show why the beat context is absent when
+        # a real analysis ships with beat_grid={}.
+        logger.warning(
+            "video_analysis.beat_context_failed video=%s error=%r",
+            video_path,
+            exc,
+        )
         return None, None, None
 
 


### PR DESCRIPTION
Part of #91.

Fetched three recent shared analyses via browser-harness and confirmed every one landed with `dance_start_sec=null`, `dance_end_sec=null`, `musical_moments=[]`, `follower_initiative=[]`, and `beat_grid={}`. The pipeline had three silent-fail points (`_extract_beat_context`, `_run_pattern_pre_pass` exception, `_run_pattern_pre_pass` unparseable JSON) and no fallback when the main Gemini call omits the dance-window keys — which it empirically does on the large schema we ship today.

## Changes

- Log at every silent-fail site so Railway logs surface which path actually failed.
- Derive `dance_start_sec` / `dance_end_sec` from the main call's `patterns_identified` timestamps when neither pre-pass nor main emitted a window. Re-apply first-downbeat / motion-floor / duration clamps after the derivation.
- Warn when the main call drops any of the four load-bearing fields so we can measure the rate in prod.

## Verification

- Module imports still work (`from wcs_api.services.video_analysis import analyzer, media_context`).
- No behavior change when everything succeeds — fallback branch only runs when `dance_start_sec is None or dance_end_sec is None`.

## Follow-ups (tracked separately)

- #92 evidence-grounded improvements (strip "horoscope" coaching)
- #93 per-pattern confidence gate + visual_cue enforcement
- #94 Novice-default bias fix
- #95 "Which dancer did we analyze?" panel + multi-couple warning
- #96 Song-style classifier

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video analysis handling for cases with missing dance timing by deriving timing from identified patterns.
  * Enhanced error logging and reporting for analysis failures and beat context extraction issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->