### PR TITLE
Emit subject_description + detect subject drift across patterns

### DIFF
--- a/api/src/wcs_api/services/video_analysis/prompts.py
+++ b/api/src/wcs_api/services/video_analysis/prompts.py
@@ -644,7 +644,8 @@ Respond in this exact JSON format. Fill `reasoning` BEFORE `score` in each categ
       "timing": "<on_beat|slightly_off|off_beat>",
       "notes": "<what was good or needs improvement in this pattern>",
       "styling": "<brief description of styling observed during this pattern — body rolls, arm styling, footwork flourishes, musical hits, syncopations. Use null when nothing notable. DO NOT invent styling that wasn't there.>",
-      "coaching_tip": "<one concrete, actionable suggestion specific to THIS pattern (e.g. 'stretch the anchor 2 extra beats to match the blues pocket', 'less arm on the entry — drive from the core'). Address whichever partner the tip applies to (or both). Use null for patterns that execute cleanly and don't need targeted work.>"
+      "coaching_tip": "<one concrete, actionable suggestion specific to THIS pattern (e.g. 'stretch the anchor 2 extra beats to match the blues pocket', 'less arm on the entry — drive from the core'). Address whichever partner the tip applies to (or both). Use null for patterns that execute cleanly and don't need targeted work.>",
+      "subject_location": "<SHORT phrase describing WHERE in the frame the analyzed couple was for this pattern — e.g. 'center', 'center-left', 'left foreground', 'far right'. Used to detect whether you drifted to tracking a different couple mid-analysis. If the couple traveled across the slot during the pattern (which is normal), describe where they STARTED the pattern. Use the SAME language across patterns so consistency can be checked — don't say 'middle' once and 'center' next time.>"
     }
   ],
   "musical_moments": [
@@ -690,6 +691,8 @@ Respond in this exact JSON format. Fill `reasoning` BEFORE `score` in each categ
   },
   "overall_impression": "<1-2 sentence overall assessment>",
   "observed_level": "<REQUIRED — must be one of: Newcomer|Novice|Intermediate|Advanced|All-Star|Champion. The tier the dancing actually lands at, regardless of what was declared. If you default to Novice because the user didn't declare a level, that's a bug — commit to what you actually see. Do NOT return null. If truly uncertain between two tiers, pick the higher one and note the uncertainty in overall_impression.>",
+  "subject_description": "<REQUIRED — short phrase describing WHO you analyzed in the frame. Include lane / frame position AND one distinguishing visual (clothing color, height, frame position). e.g. 'lead in red shirt, couple in the center-left lane', 'follower in blue dress, center frame throughout'. If the video has multiple couples, pick the one matching the user's dancer_description — or, if no description was given, pick the most visually prominent couple and explicitly say so. Do NOT return null; commit to a specific couple.>",
+  "other_couples_visible": <true/false — were other dance couples visible in the frame at any point during the dance window? (Spectators / judges standing on the sidelines don't count.) Used to flag multi-couple videos where subject drift is a risk.>,
   "estimated_bpm": <estimated BPM from the music>,
   "song_style": "<e.g., blues, contemporary, lyrical>"
 }

--- a/api/src/wcs_api/services/video_analysis/response_sanitizer.py
+++ b/api/src/wcs_api/services/video_analysis/response_sanitizer.py
@@ -118,6 +118,62 @@ _CONFIDENCE_UNGROUNDED_VARIANT = 0.4
 _CONFIDENCE_UNSET = 0.6
 
 
+def _detect_subject_drift(patterns: list[dict[str, Any]]) -> int:
+    """Count likely subject-drift transitions across a pattern timeline.
+
+    Gemini is prompted to emit a short `subject_location` phrase per
+    pattern using consistent language (e.g. 'center-left' across all
+    patterns for one couple). When consecutive patterns disagree on
+    which frame region the couple is in — and the disagreement is
+    farther than one 'adjacent' step (center → center-left is fine;
+    center-left → far right is not) — we suspect the model switched
+    to tracking a different couple mid-analysis.
+
+    Returns the number of suspected drift transitions. Downstream
+    surfaces a warning when the count is non-zero.
+    """
+    # Rough horizontal bands: a drift is worth flagging when a pattern
+    # jumps more than ~1 band. Map each location phrase to a band
+    # index; unrecognized phrases get -1 and are ignored.
+    BAND_MAP = {
+        "far left": 0,
+        "left": 1,
+        "left foreground": 1,
+        "left background": 1,
+        "center-left": 2,
+        "center left": 2,
+        "middle-left": 2,
+        "center": 3,
+        "middle": 3,
+        "center foreground": 3,
+        "center background": 3,
+        "center-right": 4,
+        "center right": 4,
+        "middle-right": 4,
+        "right": 5,
+        "right foreground": 5,
+        "right background": 5,
+        "far right": 6,
+    }
+    drift_count = 0
+    prev_band: int | None = None
+    for p in patterns:
+        if not isinstance(p, dict):
+            continue
+        loc_raw = p.get("subject_location")
+        if not isinstance(loc_raw, str):
+            continue
+        key = loc_raw.strip().lower()
+        band = BAND_MAP.get(key, -1)
+        if band < 0:
+            prev_band = None  # unknown phrase — don't chain against it
+            continue
+        if prev_band is not None and abs(band - prev_band) > 2:
+            drift_count += 1
+        prev_band = band
+    return drift_count
+
+
 def _detect_repeating_cycle(names: list[str]) -> int | None:
     """Detect a repeating cycle in the pattern-name sequence.
 
@@ -1006,6 +1062,37 @@ def _shape_response(
             "pattern from the video. Treat the pattern labels as "
             "low-confidence."
         )
+
+    # Subject tracking + multi-couple drift detection. On crowded
+    # floors the model sometimes slides its focus from the intended
+    # couple to an adjacent one mid-analysis — Jon's Discord
+    # complaint ("maybe it's locking onto the couple next to me").
+    # We don't prevent the drift, but we detect it and warn the user
+    # so they can flag the wrong-subject failure.
+    subject_description_raw = parsed.get("subject_description")
+    subject_description = (
+        subject_description_raw.strip()
+        if isinstance(subject_description_raw, str)
+        and subject_description_raw.strip()
+        else None
+    )
+    other_couples_visible = bool(parsed.get("other_couples_visible"))
+    subject_drift_count = _detect_subject_drift(patterns_identified)
+    if subject_drift_count >= 2:
+        extra_warnings.append(
+            f"Subject location jumped sharply {subject_drift_count} "
+            "times between patterns — we may have switched to tracking "
+            "a different couple mid-analysis. If the feedback doesn't "
+            "match your dance, add a 'dancer_description' on re-upload "
+            "(e.g. 'lead in blue shirt, center-left of frame')."
+        )
+    elif other_couples_visible and not subject_description:
+        extra_warnings.append(
+            "Other couples were visible in the frame and no subject "
+            "description was provided — the analysis may have tracked "
+            "the wrong couple. Add a 'dancer_description' on re-upload "
+            "to anchor the analysis."
+        )
     musical_moments = _sanitize_musical_moments(
         parsed.get("musical_moments"),
         dance_start_sec=dance_start_sec,
@@ -1053,6 +1140,9 @@ def _shape_response(
             else ("detector" if detected_style else "gemini")
         ),
         "observed_level": parsed.get("observed_level"),
+        "subject_description": subject_description,
+        "other_couples_visible": other_couples_visible,
+        "subject_drift_count": subject_drift_count,
         "timeline_locked": timeline_locked,
         "sanity_warnings": (sanity_warnings or []) + extra_warnings,
         "usage": usage,


### PR DESCRIPTION
Closes #95 (backend portion).

## Why

Jon's Discord note (2026-04-17): *"maybe it's locking onto the couple next to me which the leader was leading a whip"*. Today's output gives zero signal about which couple was tracked, so wrong-subject failures look authoritative.

## Prompt-first approach

Skip CV (motion clustering, pose tracking) for v1 — too much surface for the first cut. Lean on Gemini's scene understanding, but make the answer visible:

- Top-level `subject_description` (required, no nulls): lane + distinguishing visual. "Lead in red shirt, center-left lane".
- Top-level `other_couples_visible` (bool): elevated wrong-subject risk when true.
- Per-pattern `subject_location` with a small controlled vocabulary (`center`, `center-left`, `far right`, etc.).

## Drift detection

`_detect_subject_drift` maps each `subject_location` to a horizontal-band index (0..6). When consecutive patterns jump more than 2 bands, we count that as a drift transition. ≥2 drift transitions → sanity warning. Also warn when `other_couples_visible=true` and no `dancer_description` was supplied — the fix is to re-upload with an anchor description.

## Verification

Unit tests cover:
- No drift (same band or adjacent bands)
- Sharp jump (center-left → far right)
- Unknown phrases ignored
- Pass-through of `subject_description` / `other_couples_visible`
- Multi-couple + missing description fires warning
- `subject_drift_count ≥ 2` fires drift warning

## Follow-ups

- Frontend: upload-form chip prompting the user to add a dancer description on crowded-floor uploads.
- Frontend: show `subject_description` next to the first-frame thumbnail with a "Wrong dancer?" flag button.
- When drift is flagged, offer a one-click re-analyze with a placeholder for `dancer_description`.