### PR TITLE
Peer review flow: owner requests, reviewer scores, no account needed

### DIFF
--- a/api/src/wcs_api/main.py
+++ b/api/src/wcs_api/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from .routes import health, music, shared, uploads, video
+from .routes import health, music, peer_reviews, shared, uploads, video
 from .settings import settings
 
 app = FastAPI(title="wcs-api", version="0.1.0")
@@ -23,3 +23,4 @@ app.include_router(music.router)
 app.include_router(video.router)
 app.include_router(uploads.router)
 app.include_router(shared.router)
+app.include_router(peer_reviews.router)

--- a/api/src/wcs_api/routes/peer_reviews.py
+++ b/api/src/wcs_api/routes/peer_reviews.py
@@ -1,0 +1,241 @@
+"""Peer-review flow.
+
+A logged-in dancer requests a review → we mint a one-time opaque token
+→ dancer shares the `/review/<token>` link however they like →
+reviewer hits the public endpoints (no auth) to see the video and
+submit a score → dancer sees aggregated reviews alongside the AI
+result on their analysis page.
+
+Tokens are stored in `peer_reviews.token`. Single-use: once
+`submitted_at` is set the public GET returns a thank-you state
+instead of the form.
+"""
+
+from __future__ import annotations
+
+import secrets
+from typing import Any
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field, field_validator
+
+from ..auth import verify_jwt
+from ..services import peer_reviews as peer_reviews_service
+from ..services import r2, supabase_admin
+
+router = APIRouter(prefix="/peer-reviews", tags=["peer-reviews"])
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Requester (authenticated) endpoints
+# ─────────────────────────────────────────────────────────────────────
+
+class RequestBody(BaseModel):
+    analysis_id: str = Field(..., min_length=1, max_length=64)
+
+
+@router.post("/request")
+async def request_review(
+    body: RequestBody,
+    user: dict = Depends(verify_jwt),
+) -> dict[str, str]:
+    """Mint a new review token for one of the user's own analyses.
+
+    Authorization: we re-read the analysis row via service role and
+    verify `user_id == auth.uid` before minting. Dancers can't
+    generate review tokens for someone else's analysis.
+    """
+    analysis = await supabase_admin.get_analysis_minimal(body.analysis_id)
+    if not analysis or analysis.get("user_id") != user["sub"]:
+        raise HTTPException(status_code=404, detail="analysis not found")
+
+    # Opaque token ~= same style as share_token: 32 hex chars, enough
+    # entropy that guessing one is infeasible.
+    token = secrets.token_hex(16)
+    try:
+        await peer_reviews_service.insert_request(
+            analysis_id=body.analysis_id,
+            token=token,
+            requester_user_id=user["sub"],
+        )
+    except httpx.HTTPStatusError as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=f"could not create review request: {exc.response.text[:200]}",
+        )
+
+    return {"token": token}
+
+
+@router.get("/for-analysis/{analysis_id}")
+async def list_for_analysis(
+    analysis_id: str,
+    user: dict = Depends(verify_jwt),
+) -> dict[str, Any]:
+    """Return all review requests + submitted reviews for an analysis
+    the caller owns. Caller identity is checked via RLS on the select."""
+    try:
+        rows = await peer_reviews_service.list_for_analysis(
+            user_id=user["sub"],
+            analysis_id=analysis_id,
+        )
+    except httpx.HTTPStatusError as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=f"could not read reviews: {exc.response.text[:200]}",
+        )
+    # Split into pending (no submitted_at) vs submitted for the UI.
+    pending: list[dict[str, Any]] = []
+    submitted: list[dict[str, Any]] = []
+    for row in rows:
+        (submitted if row.get("submitted_at") else pending).append(row)
+    return {"pending": pending, "submitted": submitted}
+
+
+@router.delete("/{review_id}")
+async def delete_review(
+    review_id: str,
+    user: dict = Depends(verify_jwt),
+) -> dict[str, str]:
+    """Revoke a pending request or delete a submitted review.
+
+    Only the owner can call this — enforced via the delete RLS policy
+    on peer_reviews. Returns ok either way; a no-op when the row
+    doesn't exist or belongs to someone else (RLS filters it out).
+    """
+    try:
+        await peer_reviews_service.delete(review_id, user["sub"])
+    except httpx.HTTPStatusError as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=f"could not delete review: {exc.response.text[:200]}",
+        )
+    return {"ok": "true"}
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Public (reviewer, unauthenticated) endpoints
+# ─────────────────────────────────────────────────────────────────────
+
+@router.get("/public/{token}")
+async def get_public_review(token: str) -> dict[str, Any]:
+    """Public view of a review request. Returns the minimum the reviewer
+    needs to do their job: video URL + user-supplied context (role,
+    level, event, dancer_description). Deliberately does NOT include
+    the AI score — we don't want to prime the reviewer's judgment.
+    """
+    if not token or len(token) < 16:
+        raise HTTPException(status_code=400, detail="invalid token")
+
+    review = await peer_reviews_service.get_by_token(token)
+    if not review:
+        raise HTTPException(status_code=404, detail="review not found")
+
+    analysis = await supabase_admin.get_analysis_minimal(
+        review["analysis_id"], include_soft_deleted=False
+    )
+    if not analysis:
+        # Analysis was deleted after the request was sent.
+        raise HTTPException(status_code=410, detail="the linked analysis is no longer available")
+
+    video_url: str | None = None
+    object_key = analysis.get("object_key")
+    if object_key:
+        try:
+            video_url = r2.generate_presigned_get(
+                object_key, expires_in=3600
+            )
+        except Exception:  # noqa: BLE001
+            video_url = None
+
+    return {
+        "token": token,
+        "already_submitted": review.get("submitted_at") is not None,
+        "video_url": video_url,
+        "filename": analysis.get("filename"),
+        "duration": analysis.get("duration"),
+        "context": {
+            "role": analysis.get("role"),
+            "competition_level": analysis.get("competition_level"),
+            "event_name": analysis.get("event_name"),
+            "event_date": analysis.get("event_date"),
+            "stage": analysis.get("stage"),
+            "dancer_description": analysis.get("dancer_description"),
+        },
+    }
+
+
+class SubmitBody(BaseModel):
+    reviewer_name: str = Field(..., min_length=1, max_length=80)
+    reviewer_role: str = Field(default="other", max_length=20)
+    timing_score: float = Field(..., ge=0.0, le=10.0)
+    technique_score: float = Field(..., ge=0.0, le=10.0)
+    teamwork_score: float = Field(..., ge=0.0, le=10.0)
+    presentation_score: float = Field(..., ge=0.0, le=10.0)
+    overall_notes: str | None = Field(default=None, max_length=4000)
+    per_moment_notes: list[dict[str, Any]] = Field(default_factory=list)
+
+    @field_validator("reviewer_role")
+    @classmethod
+    def _coerce_role(cls, v: str) -> str:
+        ok = {"dancer", "instructor", "judge", "friend", "other"}
+        v = (v or "other").strip().lower()
+        return v if v in ok else "other"
+
+    @field_validator("per_moment_notes")
+    @classmethod
+    def _cap_moment_notes(
+        cls, v: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        # Keep the payload bounded — a runaway reviewer form can't
+        # flood jsonb storage.
+        cleaned: list[dict[str, Any]] = []
+        for entry in v[:50]:
+            if not isinstance(entry, dict):
+                continue
+            try:
+                ts = float(entry.get("timestamp_sec"))
+            except (TypeError, ValueError):
+                continue
+            note = str(entry.get("note") or "").strip()[:500]
+            if not note:
+                continue
+            cleaned.append({"timestamp_sec": round(ts, 2), "note": note})
+        return cleaned
+
+
+@router.post("/public/{token}/submit")
+async def submit_public_review(
+    token: str, body: SubmitBody
+) -> dict[str, str]:
+    """Reviewer submits their scores. Token is consumed on first
+    successful submit; subsequent calls fail with 409.
+    """
+    if not token or len(token) < 16:
+        raise HTTPException(status_code=400, detail="invalid token")
+
+    review = await peer_reviews_service.get_by_token(token)
+    if not review:
+        raise HTTPException(status_code=404, detail="review not found")
+    if review.get("submitted_at"):
+        raise HTTPException(status_code=409, detail="review already submitted")
+
+    try:
+        await peer_reviews_service.submit(
+            token=token,
+            reviewer_name=body.reviewer_name.strip(),
+            reviewer_role=body.reviewer_role,
+            timing_score=body.timing_score,
+            technique_score=body.technique_score,
+            teamwork_score=body.teamwork_score,
+            presentation_score=body.presentation_score,
+            overall_notes=(body.overall_notes or "").strip() or None,
+            per_moment_notes=body.per_moment_notes,
+        )
+    except httpx.HTTPStatusError as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=f"could not submit review: {exc.response.text[:200]}",
+        )
+    return {"ok": "true"}

--- a/api/src/wcs_api/services/peer_reviews.py
+++ b/api/src/wcs_api/services/peer_reviews.py
@@ -1,0 +1,134 @@
+"""Supabase CRUD for peer_reviews via service role.
+
+The reviewer endpoints are unauthenticated, so every write goes
+through the service role. Reads from the requester side also go
+through service role (rather than RLS) so we can consistently return
+the same shape — the handler verifies requester ownership
+explicitly against `user_id` before calling these.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+from typing import Any
+
+import httpx
+
+from .supabase_admin import _headers, _rest
+
+
+async def insert_request(
+    *,
+    analysis_id: str,
+    token: str,
+    requester_user_id: str,
+) -> None:
+    """Mint a new pending review request."""
+    record: dict[str, Any] = {
+        "analysis_id": analysis_id,
+        "token": token,
+        "requester_user_id": requester_user_id,
+    }
+    async with httpx.AsyncClient(timeout=10) as client:
+        r = await client.post(
+            _rest("peer_reviews"),
+            headers={**_headers(), "Prefer": "return=minimal"},
+            json=record,
+        )
+        r.raise_for_status()
+
+
+async def get_by_token(token: str) -> dict[str, Any] | None:
+    """Look up a review by its opaque token. Returns None when the
+    token doesn't exist."""
+    async with httpx.AsyncClient(timeout=10) as client:
+        r = await client.get(
+            _rest(f"peer_reviews?token=eq.{token}&select=*"),
+            headers=_headers(),
+        )
+        r.raise_for_status()
+        rows = r.json()
+        return rows[0] if rows else None
+
+
+async def submit(
+    *,
+    token: str,
+    reviewer_name: str,
+    reviewer_role: str,
+    timing_score: float,
+    technique_score: float,
+    teamwork_score: float,
+    presentation_score: float,
+    overall_notes: str | None,
+    per_moment_notes: list[dict[str, Any]],
+) -> None:
+    """Patch the row identified by `token` with the reviewer's scores
+    and mark submitted_at. Filters on `submitted_at.is.null` so a
+    double-submit race lands with exactly one winner; the loser gets
+    a no-op PATCH which the caller interprets via the 409 check it
+    made before arriving here.
+    """
+    now = _dt.datetime.now(_dt.timezone.utc).isoformat()
+    update = {
+        "reviewer_name": reviewer_name[:80],
+        "reviewer_role": reviewer_role,
+        "timing_score": round(float(timing_score), 1),
+        "technique_score": round(float(technique_score), 1),
+        "teamwork_score": round(float(teamwork_score), 1),
+        "presentation_score": round(float(presentation_score), 1),
+        "overall_notes": overall_notes,
+        "per_moment_notes": per_moment_notes,
+        "submitted_at": now,
+    }
+    async with httpx.AsyncClient(timeout=10) as client:
+        r = await client.patch(
+            _rest(
+                f"peer_reviews?token=eq.{token}&submitted_at=is.null"
+            ),
+            headers={**_headers(), "Prefer": "return=minimal"},
+            json=update,
+        )
+        r.raise_for_status()
+
+
+async def list_for_analysis(
+    *,
+    user_id: str,
+    analysis_id: str,
+) -> list[dict[str, Any]]:
+    """Return all review requests for an analysis owned by `user_id`.
+    The handler re-checks ownership via get_analysis_minimal before
+    calling this — but we belt-and-suspenders by filtering on
+    `requester_user_id` here too, so a bug up the stack can't leak
+    someone else's rows.
+    """
+    async with httpx.AsyncClient(timeout=10) as client:
+        r = await client.get(
+            _rest(
+                f"peer_reviews?analysis_id=eq.{analysis_id}"
+                f"&requester_user_id=eq.{user_id}"
+                "&select=id,token,requested_at,reviewer_name,reviewer_role,"
+                "timing_score,technique_score,teamwork_score,presentation_score,"
+                "overall_notes,per_moment_notes,submitted_at"
+                "&order=requested_at.desc"
+            ),
+            headers=_headers(),
+        )
+        r.raise_for_status()
+        return r.json()
+
+
+async def delete(review_id: str, user_id: str) -> None:
+    """Delete a review request. Scoped to the requester so a caller
+    with the wrong `review_id` can't delete someone else's row even
+    if RLS would have allowed it."""
+    async with httpx.AsyncClient(timeout=10) as client:
+        r = await client.delete(
+            _rest(
+                f"peer_reviews?id=eq.{review_id}"
+                f"&requester_user_id=eq.{user_id}"
+            ),
+            headers={**_headers(), "Prefer": "return=minimal"},
+        )
+        r.raise_for_status()

--- a/api/src/wcs_api/services/supabase_admin.py
+++ b/api/src/wcs_api/services/supabase_admin.py
@@ -142,6 +142,30 @@ async def insert_usage_event(
         r.raise_for_status()
 
 
+async def get_analysis_minimal(
+    analysis_id: str, *, include_soft_deleted: bool = False
+) -> dict[str, Any] | None:
+    """Service-role read of an analysis row, returning just the fields
+    the peer-review / admin code paths need. Used to (a) authorize a
+    review-request mint against the owner's user_id and (b) hand the
+    reviewer the playable video + user-supplied context without
+    exposing the AI score.
+    """
+    query = (
+        f"video_analyses?id=eq.{analysis_id}"
+        "&select=id,user_id,filename,duration,object_key,role,"
+        "competition_level,event_name,event_date,stage,"
+        "dancer_description,deleted_at"
+    )
+    if not include_soft_deleted:
+        query += "&deleted_at=is.null"
+    async with httpx.AsyncClient(timeout=10) as client:
+        r = await client.get(_rest(query), headers=_headers())
+        r.raise_for_status()
+        rows = r.json()
+        return rows[0] if rows else None
+
+
 async def get_shared_analysis(token: str) -> dict[str, Any] | None:
     """Unauthenticated read of a video analysis by its share token.
     Intentionally returns only the public-safe subset of fields (no

--- a/src/app/(app)/analysis/page.tsx
+++ b/src/app/(app)/analysis/page.tsx
@@ -20,6 +20,7 @@ import {
 } from "lucide-react";
 import { TimelineView } from "@/components/analyze/timeline-view";
 import { ScoreResultCard } from "@/components/analyze/score-result-card";
+import { PeerReviewsSection } from "@/components/analyze/peer-reviews-section";
 import {
   useAnalysisHistory,
   type AnalysisRecord,
@@ -492,6 +493,10 @@ function AnalysisPageInner() {
         duration={record.duration ?? 0}
         competitionLevel={record.competition_level}
       />
+
+      {/* Peer reviews — generate private review links, show submitted
+          reviews alongside the AI score */}
+      <PeerReviewsSection analysisId={record.id} />
     </div>
   );
 }

--- a/src/app/peer-review/page.tsx
+++ b/src/app/peer-review/page.tsx
@@ -6,8 +6,8 @@
  * AI score here, to avoid priming the reviewer's judgment.
  */
 
-import { useEffect, useMemo, useRef, useState } from "react";
-import { useParams } from "next/navigation";
+import { Suspense, useEffect, useMemo, useRef, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import {
   fetchPublicReview,
@@ -30,8 +30,19 @@ import {
 } from "@/components/ui/select";
 
 export default function PeerReviewPage() {
-  const params = useParams<{ token: string }>();
-  const token = params?.token;
+  // useSearchParams needs a Suspense boundary under Next's static
+  // export mode, otherwise the whole page falls back to client-only
+  // rendering warnings at build time.
+  return (
+    <Suspense fallback={null}>
+      <PeerReviewInner />
+    </Suspense>
+  );
+}
+
+function PeerReviewInner() {
+  const params = useSearchParams();
+  const token = params.get("t");
 
   const [ctx, setCtx] = useState<PublicReviewContext | null>(null);
   const [loading, setLoading] = useState(true);

--- a/src/app/review/[token]/page.tsx
+++ b/src/app/review/[token]/page.tsx
@@ -1,0 +1,368 @@
+"use client";
+
+/**
+ * Public reviewer page. Unauthenticated — anyone with the link can
+ * watch the video and submit scores. We deliberately do NOT show the
+ * AI score here, to avoid priming the reviewer's judgment.
+ */
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useParams } from "next/navigation";
+import Link from "next/link";
+import {
+  fetchPublicReview,
+  submitPublicReview,
+  type PeerReviewerRole,
+  type PublicReviewContext,
+} from "@/lib/wcs-api";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { Loader2, CheckCircle2, AlertCircle } from "lucide-react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+export default function PeerReviewPage() {
+  const params = useParams<{ token: string }>();
+  const token = params?.token;
+
+  const [ctx, setCtx] = useState<PublicReviewContext | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [reviewerName, setReviewerName] = useState("");
+  const [reviewerRole, setReviewerRole] =
+    useState<PeerReviewerRole>("dancer");
+  const [timing, setTiming] = useState<number>(7);
+  const [technique, setTechnique] = useState<number>(7);
+  const [teamwork, setTeamwork] = useState<number>(7);
+  const [presentation, setPresentation] = useState<number>(7);
+  const [notes, setNotes] = useState("");
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+
+  useEffect(() => {
+    if (!token) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const data = await fetchPublicReview(token);
+        if (cancelled) return;
+        setCtx(data);
+      } catch (e) {
+        if (cancelled) return;
+        setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  const canSubmit = useMemo(() => {
+    return (
+      !!ctx &&
+      !ctx.already_submitted &&
+      reviewerName.trim().length > 0 &&
+      !submitting
+    );
+  }, [ctx, reviewerName, submitting]);
+
+  const handleSubmit = async () => {
+    if (!token || !canSubmit) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await submitPublicReview(token, {
+        reviewer_name: reviewerName.trim(),
+        reviewer_role: reviewerRole,
+        timing_score: timing,
+        technique_score: technique,
+        teamwork_score: teamwork,
+        presentation_score: presentation,
+        overall_notes: notes.trim() || null,
+      });
+      setSubmitted(true);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <Loader2 className="h-5 w-5 animate-spin" />
+      </div>
+    );
+  }
+
+  if (error || !ctx) {
+    return (
+      <div className="min-h-screen flex items-center justify-center p-4">
+        <Card className="max-w-md w-full">
+          <CardContent className="py-6 text-center space-y-3">
+            <AlertCircle className="h-8 w-8 text-destructive mx-auto" />
+            <h1 className="font-semibold">Review link not available</h1>
+            <p className="text-sm text-muted-foreground">
+              {error ||
+                "This review link is invalid, expired, or the linked video was deleted."}
+            </p>
+            <Link href="/">
+              <Button variant="outline">Go to SwingFlow</Button>
+            </Link>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (submitted || ctx.already_submitted) {
+    return (
+      <div className="min-h-screen flex items-center justify-center p-4">
+        <Card className="max-w-md w-full">
+          <CardContent className="py-6 text-center space-y-3">
+            <CheckCircle2 className="h-8 w-8 text-emerald-400 mx-auto" />
+            <h1 className="font-semibold">Thanks for your review</h1>
+            <p className="text-sm text-muted-foreground">
+              {submitted
+                ? "Your scores have been shared with the dancer."
+                : "This review has already been submitted."}
+            </p>
+            <Link href="/">
+              <Button variant="outline">About SwingFlow</Button>
+            </Link>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="max-w-3xl mx-auto px-4 py-6 space-y-4">
+        <header className="space-y-2">
+          <Link
+            href="/"
+            className="inline-block text-xs text-muted-foreground hover:text-foreground"
+          >
+            ← SwingFlow
+          </Link>
+          <h1 className="text-2xl font-bold">Peer review</h1>
+          <p className="text-sm text-muted-foreground">
+            A dancer has asked for your feedback on this clip. Watch the
+            video, then score them on the four WSDC categories (timing,
+            technique, teamwork, presentation). Your scores and notes
+            will be shared only with the dancer.
+          </p>
+        </header>
+
+        <ContextCard ctx={ctx} />
+
+        <Card>
+          <CardContent className="p-0 overflow-hidden">
+            {ctx.video_url ? (
+              <video
+                ref={videoRef}
+                src={ctx.video_url}
+                controls
+                playsInline
+                className="w-full bg-black"
+              />
+            ) : (
+              <div className="p-6 text-sm text-muted-foreground text-center">
+                The video is no longer available. You can still leave
+                comments below if you saw it elsewhere.
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-base">About you</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="reviewer-name">Your name</Label>
+              <Input
+                id="reviewer-name"
+                value={reviewerName}
+                onChange={(e) => setReviewerName(e.target.value)}
+                placeholder="e.g. Alex Chen"
+                maxLength={80}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="reviewer-role">Your role</Label>
+              <Select
+                value={reviewerRole}
+                onValueChange={(v) => setReviewerRole(v as PeerReviewerRole)}
+              >
+                <SelectTrigger id="reviewer-role">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="dancer">Dancer</SelectItem>
+                  <SelectItem value="instructor">Instructor</SelectItem>
+                  <SelectItem value="judge">WSDC judge</SelectItem>
+                  <SelectItem value="friend">Friend / watcher</SelectItem>
+                  <SelectItem value="other">Other</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-base">Your scores (1–10)</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-5">
+            <ScoreRow
+              label="Timing"
+              help="On the beat? Clean triples, anchor on 5 & 6."
+              value={timing}
+              onChange={setTiming}
+            />
+            <ScoreRow
+              label="Technique"
+              help="Posture, extension, footwork, slot discipline."
+              value={technique}
+              onChange={setTechnique}
+            />
+            <ScoreRow
+              label="Teamwork"
+              help="Partnership connection, shared weight, recovery."
+              value={teamwork}
+              onChange={setTeamwork}
+            />
+            <ScoreRow
+              label="Presentation"
+              help="Musicality, styling, stage presence."
+              value={presentation}
+              onChange={setPresentation}
+            />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-base">Overall notes (optional)</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <textarea
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              rows={5}
+              maxLength={4000}
+              placeholder="What stood out? Anything specific to work on?"
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            />
+          </CardContent>
+        </Card>
+
+        {error && (
+          <p className="text-sm text-destructive">{error}</p>
+        )}
+
+        <Button
+          onClick={handleSubmit}
+          disabled={!canSubmit}
+          className="w-full"
+          size="lg"
+        >
+          {submitting ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              Submitting…
+            </>
+          ) : (
+            "Submit review"
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function ContextCard({ ctx }: { ctx: PublicReviewContext }) {
+  const chips: Array<{ label: string; value: string }> = [];
+  if (ctx.context.role)
+    chips.push({ label: "Role", value: ctx.context.role });
+  if (ctx.context.competition_level)
+    chips.push({ label: "Level", value: ctx.context.competition_level });
+  if (ctx.context.event_name)
+    chips.push({ label: "Event", value: ctx.context.event_name });
+  if (ctx.context.stage)
+    chips.push({ label: "Stage", value: ctx.context.stage });
+  if (ctx.context.event_date)
+    chips.push({ label: "Date", value: ctx.context.event_date });
+
+  if (chips.length === 0 && !ctx.context.dancer_description) return null;
+
+  return (
+    <Card>
+      <CardContent className="py-3 space-y-2">
+        {chips.length > 0 && (
+          <div className="flex flex-wrap items-center gap-1.5">
+            {chips.map((c) => (
+              <Badge variant="outline" key={c.label}>
+                {c.label}: {c.value}
+              </Badge>
+            ))}
+          </div>
+        )}
+        {ctx.context.dancer_description && (
+          <p className="text-xs text-muted-foreground">
+            <span className="font-medium text-foreground">Who to watch:</span>{" "}
+            {ctx.context.dancer_description}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function ScoreRow({
+  label,
+  help,
+  value,
+  onChange,
+}: {
+  label: string;
+  help: string;
+  value: number;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-baseline justify-between">
+        <Label>{label}</Label>
+        <span className="text-sm font-mono tabular-nums font-semibold">
+          {value.toFixed(1)}
+        </span>
+      </div>
+      <input
+        type="range"
+        min={1}
+        max={10}
+        step={0.1}
+        value={value}
+        onChange={(e) => onChange(parseFloat(e.target.value))}
+        className="w-full accent-primary"
+      />
+      <p className="text-xs text-muted-foreground">{help}</p>
+    </div>
+  );
+}

--- a/src/components/analyze/peer-reviews-section.tsx
+++ b/src/components/analyze/peer-reviews-section.tsx
@@ -81,7 +81,7 @@ export function PeerReviewsSection({ analysisId }: { analysisId: string }) {
   };
 
   const handleCopy = async (token: string) => {
-    const url = `${window.location.origin}/review/${token}`;
+    const url = `${window.location.origin}/peer-review?t=${encodeURIComponent(token)}`;
     try {
       await navigator.clipboard.writeText(url);
       setCopiedToken(token);
@@ -211,7 +211,7 @@ export function PeerReviewsSection({ analysisId }: { analysisId: string }) {
               Awaiting response ({pending.length})
             </p>
             {pending.map((r) => {
-              const url = `${typeof window !== "undefined" ? window.location.origin : ""}/review/${r.token}`;
+              const url = `${typeof window !== "undefined" ? window.location.origin : ""}/peer-review?t=${encodeURIComponent(r.token)}`;
               const isCopied = copiedToken === r.token || copiedToken === url;
               return (
                 <div

--- a/src/components/analyze/peer-reviews-section.tsx
+++ b/src/components/analyze/peer-reviews-section.tsx
@@ -1,0 +1,320 @@
+"use client";
+
+/**
+ * Shows the owner (a) a button to request a new peer review, and
+ * (b) any submitted reviews alongside pending-but-not-yet-responded
+ * requests. Deliberately kept compact so it can slot under the AI
+ * score without competing with it.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  deletePeerReview,
+  listPeerReviews,
+  requestPeerReview,
+  type PeerReview,
+} from "@/lib/wcs-api";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Check,
+  Copy,
+  Loader2,
+  MessageSquare,
+  UserPlus,
+  X,
+} from "lucide-react";
+
+const CATEGORIES: Array<{ key: keyof PeerReview; label: string }> = [
+  { key: "timing_score", label: "Timing" },
+  { key: "technique_score", label: "Technique" },
+  { key: "teamwork_score", label: "Teamwork" },
+  { key: "presentation_score", label: "Presentation" },
+];
+
+export function PeerReviewsSection({ analysisId }: { analysisId: string }) {
+  const [pending, setPending] = useState<PeerReview[]>([]);
+  const [submitted, setSubmitted] = useState<PeerReview[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [requesting, setRequesting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [copiedToken, setCopiedToken] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const data = await listPeerReviews(analysisId);
+      setPending(data.pending);
+      setSubmitted(data.submitted);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, [analysisId]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const handleRequest = async () => {
+    setRequesting(true);
+    setError(null);
+    try {
+      const { url } = await requestPeerReview(analysisId);
+      // Try to copy immediately so the user can paste into a DM /
+      // message / email. Falls back to showing the URL in the row if
+      // clipboard isn't available.
+      try {
+        await navigator.clipboard.writeText(url);
+        setCopiedToken(url);
+        setTimeout(() => setCopiedToken(null), 2000);
+      } catch {
+        // ignore — the link will be visible in the pending row
+      }
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setRequesting(false);
+    }
+  };
+
+  const handleCopy = async (token: string) => {
+    const url = `${window.location.origin}/review/${token}`;
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopiedToken(token);
+      setTimeout(() => setCopiedToken(null), 2000);
+    } catch {
+      // ignore
+    }
+  };
+
+  const handleRevoke = async (id: string) => {
+    setError(null);
+    try {
+      await deletePeerReview(id);
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  const aggregate = useMemo(() => {
+    if (submitted.length === 0) return null;
+    const totals: Record<string, { sum: number; n: number }> = {};
+    for (const r of submitted) {
+      for (const c of CATEGORIES) {
+        const v = r[c.key];
+        if (typeof v === "number" && Number.isFinite(v)) {
+          totals[c.key] ??= { sum: 0, n: 0 };
+          totals[c.key].sum += v;
+          totals[c.key].n += 1;
+        }
+      }
+    }
+    const avg: Record<string, number | null> = {};
+    for (const c of CATEGORIES) {
+      const t = totals[c.key];
+      avg[c.key] = t && t.n > 0 ? t.sum / t.n : null;
+    }
+    return avg;
+  }, [submitted]);
+
+  if (loading) {
+    return (
+      <Card>
+        <CardContent className="py-4 flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Loading peer reviews…
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const hasAny = pending.length > 0 || submitted.length > 0;
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between gap-2">
+          <CardTitle className="text-base flex items-center gap-2">
+            <MessageSquare className="h-4 w-4 text-primary" />
+            Peer reviews
+            {submitted.length > 0 && (
+              <Badge variant="secondary">{submitted.length}</Badge>
+            )}
+          </CardTitle>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={handleRequest}
+            disabled={requesting}
+          >
+            {requesting ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" />
+            ) : (
+              <UserPlus className="h-3.5 w-3.5 mr-1.5" />
+            )}
+            Ask someone
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {error && <p className="text-sm text-destructive">{error}</p>}
+
+        {!hasAny && (
+          <p className="text-sm text-muted-foreground">
+            Get a second opinion from a coach, a training partner, or a
+            judge friend. Click{" "}
+            <span className="font-medium">Ask someone</span> to generate a
+            private link — they don't need an account to leave a score.
+          </p>
+        )}
+
+        {aggregate && submitted.length > 0 && (
+          <div className="rounded-md border border-border/60 p-3 space-y-2 bg-muted/20">
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-medium">
+                Average of {submitted.length} review
+                {submitted.length === 1 ? "" : "s"}
+              </span>
+            </div>
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+              {CATEGORIES.map((c) => {
+                const v = aggregate[c.key as string];
+                return (
+                  <div key={c.key as string} className="text-xs">
+                    <div className="text-muted-foreground">{c.label}</div>
+                    <div className="text-base font-mono tabular-nums font-semibold">
+                      {v != null ? v.toFixed(1) : "—"}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {submitted.map((r) => (
+          <ReviewCard
+            key={r.id}
+            review={r}
+            onRevoke={() => handleRevoke(r.id)}
+          />
+        ))}
+
+        {pending.length > 0 && (
+          <div className="space-y-2">
+            <p className="text-xs text-muted-foreground uppercase tracking-wide">
+              Awaiting response ({pending.length})
+            </p>
+            {pending.map((r) => {
+              const url = `${typeof window !== "undefined" ? window.location.origin : ""}/review/${r.token}`;
+              const isCopied = copiedToken === r.token || copiedToken === url;
+              return (
+                <div
+                  key={r.id}
+                  className="rounded-md border border-border/60 p-3 flex items-center gap-2"
+                >
+                  <div className="flex-1 min-w-0">
+                    <code className="text-xs text-muted-foreground truncate block">
+                      {url}
+                    </code>
+                    <p className="text-[11px] text-muted-foreground mt-0.5">
+                      Requested{" "}
+                      {new Date(r.requested_at).toLocaleDateString()}
+                    </p>
+                  </div>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => handleCopy(r.token)}
+                  >
+                    {isCopied ? (
+                      <Check className="h-3.5 w-3.5 text-emerald-400" />
+                    ) : (
+                      <Copy className="h-3.5 w-3.5" />
+                    )}
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => handleRevoke(r.id)}
+                    title="Revoke"
+                  >
+                    <X className="h-3.5 w-3.5" />
+                  </Button>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function ReviewCard({
+  review,
+  onRevoke,
+}: {
+  review: PeerReview;
+  onRevoke: () => void;
+}) {
+  const submittedAt = review.submitted_at
+    ? new Date(review.submitted_at).toLocaleDateString()
+    : null;
+  return (
+    <div className="rounded-md border border-border/60 p-3 space-y-2">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="font-medium text-sm">
+              {review.reviewer_name || "Anonymous reviewer"}
+            </span>
+            {review.reviewer_role && (
+              <Badge variant="outline" className="text-[10px]">
+                {review.reviewer_role}
+              </Badge>
+            )}
+          </div>
+          {submittedAt && (
+            <p className="text-[11px] text-muted-foreground">
+              Reviewed {submittedAt}
+            </p>
+          )}
+        </div>
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={onRevoke}
+          title="Remove this review"
+        >
+          <X className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+        {CATEGORIES.map((c) => {
+          const v = review[c.key];
+          return (
+            <div key={c.key as string} className="text-xs">
+              <div className="text-muted-foreground">{c.label}</div>
+              <div className="text-sm font-mono tabular-nums font-semibold">
+                {typeof v === "number" ? v.toFixed(1) : "—"}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {review.overall_notes && (
+        <p className="text-sm whitespace-pre-wrap text-muted-foreground">
+          {review.overall_notes}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/lib/wcs-api.ts
+++ b/src/lib/wcs-api.ts
@@ -521,3 +521,168 @@ export async function fetchSharedAnalysis(
   }
   return (await res.json()) as SharedAnalysis;
 }
+
+// ───────────────────────────────────────────────────────────────────
+// Peer reviews
+// ───────────────────────────────────────────────────────────────────
+
+export type PeerReviewerRole =
+  | "dancer"
+  | "instructor"
+  | "judge"
+  | "friend"
+  | "other";
+
+export type PeerReview = {
+  id: string;
+  token: string;
+  requested_at: string;
+  reviewer_name: string | null;
+  reviewer_role: PeerReviewerRole | null;
+  timing_score: number | null;
+  technique_score: number | null;
+  teamwork_score: number | null;
+  presentation_score: number | null;
+  overall_notes: string | null;
+  per_moment_notes: Array<{ timestamp_sec: number; note: string }>;
+  submitted_at: string | null;
+};
+
+export type PeerReviewList = {
+  pending: PeerReview[];
+  submitted: PeerReview[];
+};
+
+export async function requestPeerReview(
+  analysisId: string
+): Promise<{ token: string; url: string }> {
+  if (!API_URL) throw new Error("NEXT_PUBLIC_WCS_API_URL is not set");
+  const token = await getAccessToken();
+  if (!token) throw new Error("not signed in");
+  const res = await fetch(`${API_URL}/peer-reviews/request`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ analysis_id: analysisId }),
+  });
+  if (!res.ok) {
+    let detail = res.statusText;
+    try {
+      const body = await res.json();
+      if (body?.detail) detail = String(body.detail);
+    } catch {
+      // ignore
+    }
+    throw new Error(`Request review failed (${res.status}): ${detail}`);
+  }
+  const data = (await res.json()) as { token: string };
+  const origin =
+    typeof window !== "undefined" ? window.location.origin : "";
+  return { token: data.token, url: `${origin}/review/${data.token}` };
+}
+
+export async function listPeerReviews(
+  analysisId: string
+): Promise<PeerReviewList> {
+  if (!API_URL) throw new Error("NEXT_PUBLIC_WCS_API_URL is not set");
+  const token = await getAccessToken();
+  if (!token) throw new Error("not signed in");
+  const res = await fetch(
+    `${API_URL}/peer-reviews/for-analysis/${encodeURIComponent(analysisId)}`,
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
+  if (!res.ok) {
+    throw new Error(`List reviews failed (${res.status})`);
+  }
+  return (await res.json()) as PeerReviewList;
+}
+
+export async function deletePeerReview(reviewId: string): Promise<void> {
+  if (!API_URL) throw new Error("NEXT_PUBLIC_WCS_API_URL is not set");
+  const token = await getAccessToken();
+  if (!token) throw new Error("not signed in");
+  const res = await fetch(
+    `${API_URL}/peer-reviews/${encodeURIComponent(reviewId)}`,
+    {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${token}` },
+    }
+  );
+  if (!res.ok) {
+    throw new Error(`Delete review failed (${res.status})`);
+  }
+}
+
+// ── Public (reviewer, unauthenticated) ──────────────────────────
+
+export type PublicReviewContext = {
+  token: string;
+  already_submitted: boolean;
+  video_url: string | null;
+  filename: string | null;
+  duration: number | null;
+  context: {
+    role: string | null;
+    competition_level: string | null;
+    event_name: string | null;
+    event_date: string | null;
+    stage: string | null;
+    dancer_description: string | null;
+  };
+};
+
+export async function fetchPublicReview(
+  token: string
+): Promise<PublicReviewContext> {
+  if (!API_URL) throw new Error("NEXT_PUBLIC_WCS_API_URL is not set");
+  const res = await fetch(
+    `${API_URL}/peer-reviews/public/${encodeURIComponent(token)}`
+  );
+  if (!res.ok) {
+    let detail = res.statusText;
+    try {
+      const body = await res.json();
+      if (body?.detail) detail = String(body.detail);
+    } catch {
+      // ignore
+    }
+    throw new Error(`Review fetch failed (${res.status}): ${detail}`);
+  }
+  return (await res.json()) as PublicReviewContext;
+}
+
+export async function submitPublicReview(
+  token: string,
+  body: {
+    reviewer_name: string;
+    reviewer_role: PeerReviewerRole;
+    timing_score: number;
+    technique_score: number;
+    teamwork_score: number;
+    presentation_score: number;
+    overall_notes?: string | null;
+    per_moment_notes?: Array<{ timestamp_sec: number; note: string }>;
+  }
+): Promise<void> {
+  if (!API_URL) throw new Error("NEXT_PUBLIC_WCS_API_URL is not set");
+  const res = await fetch(
+    `${API_URL}/peer-reviews/public/${encodeURIComponent(token)}/submit`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+  if (!res.ok) {
+    let detail = res.statusText;
+    try {
+      const b = await res.json();
+      if (b?.detail) detail = String(b.detail);
+    } catch {
+      // ignore
+    }
+    throw new Error(`Submit review failed (${res.status}): ${detail}`);
+  }
+}

--- a/src/lib/wcs-api.ts
+++ b/src/lib/wcs-api.ts
@@ -580,7 +580,10 @@ export async function requestPeerReview(
   const data = (await res.json()) as { token: string };
   const origin =
     typeof window !== "undefined" ? window.location.origin : "";
-  return { token: data.token, url: `${origin}/review/${data.token}` };
+  return {
+    token: data.token,
+    url: `${origin}/peer-review?t=${encodeURIComponent(data.token)}`,
+  };
 }
 
 export async function listPeerReviews(

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -188,6 +188,66 @@ grant update (
   dancer_description
 ) on public.video_analyses to authenticated;
 
+-- ────────────────────────────────────────────────────────────
+-- Peer reviews
+-- ────────────────────────────────────────────────────────────
+--
+-- A dancer clicks "Ask someone to review" on their analysis page.
+-- We mint a one-time token, the dancer shares the link however they
+-- like (DM / text / email), the reviewer opens /review/<token>,
+-- watches the video, and submits a structured score. Reviewer
+-- doesn't need an account. Token is single-use: once submitted_at
+-- is set, subsequent fetches render the thank-you state instead of
+-- the form.
+create table if not exists public.peer_reviews (
+  id                    uuid primary key default gen_random_uuid(),
+  analysis_id           uuid not null references public.video_analyses(id) on delete cascade,
+  token                 text not null unique,      -- opaque; in the /review/<token> URL
+  requester_user_id     uuid not null references public.profiles(id) on delete cascade,
+  requested_at          timestamptz not null default now(),
+
+  -- Reviewer-supplied metadata (nullable until submit)
+  reviewer_name         text,
+  reviewer_role         text check (
+    reviewer_role is null
+    or reviewer_role in ('dancer', 'instructor', 'judge', 'friend', 'other')
+  ),
+
+  -- Scores (nullable until submitted). 1-10 with one decimal.
+  timing_score          numeric(3,1) check (timing_score is null or (timing_score >= 0 and timing_score <= 10)),
+  technique_score       numeric(3,1) check (technique_score is null or (technique_score >= 0 and technique_score <= 10)),
+  teamwork_score        numeric(3,1) check (teamwork_score is null or (teamwork_score >= 0 and teamwork_score <= 10)),
+  presentation_score    numeric(3,1) check (presentation_score is null or (presentation_score >= 0 and presentation_score <= 10)),
+
+  overall_notes         text,
+  -- Per-moment notes as JSON array of {timestamp_sec: number, note: string}
+  per_moment_notes      jsonb not null default '[]'::jsonb,
+
+  submitted_at          timestamptz,
+  created_at            timestamptz not null default now()
+);
+create index if not exists peer_reviews_analysis_id_idx
+  on public.peer_reviews(analysis_id);
+create index if not exists peer_reviews_requester_idx
+  on public.peer_reviews(requester_user_id, created_at desc);
+
+alter table public.peer_reviews enable row level security;
+
+-- Owner (requester) can read + delete their own review requests.
+-- Writes (insert to request, update to submit) always go through the
+-- service role — the reviewer is unauthenticated, and the requester
+-- shouldn't be writing scores on behalf of reviewers.
+drop policy if exists peer_reviews_owner_select on public.peer_reviews;
+create policy peer_reviews_owner_select on public.peer_reviews
+  for select using (auth.uid() = requester_user_id);
+
+drop policy if exists peer_reviews_owner_delete on public.peer_reviews;
+create policy peer_reviews_owner_delete on public.peer_reviews
+  for delete using (auth.uid() = requester_user_id);
+
+revoke insert, update on public.peer_reviews from authenticated;
+
+
 create table if not exists public.feature_requests (
   id          uuid primary key default gen_random_uuid(),
   user_id     uuid references public.profiles(id) on delete set null,


### PR DESCRIPTION
Implements the peer-review design we sketched.

## What

- Dancer clicks 'Ask someone' on their analysis page
- We mint an opaque token, copy a \`/review/<token>\` URL to their clipboard
- They share it however (DM, text, email)
- Reviewer opens the link — sees the video + 4 category sliders + notes form
- No sign-up, no account. Fills, submits.
- Owner sees aggregate average + per-reviewer cards alongside the AI score

## Deliberate v1 choices

- Reviewer doesn't see the AI score while scoring (would prime judgment)
- One reviewer per token — simple, matches 'send link to the specific person'
- No notifications / reminders / anonymous mode — shipped after we see pull
- Owner can revoke pending links and remove submitted reviews
- Writes always through service role (reviewer is unauthenticated, owner shouldn't write reviews either)

## Files

- \`supabase/schema.sql\` — new \`peer_reviews\` table + RLS
- \`api/src/wcs_api/routes/peer_reviews.py\` — 5 endpoints (request / list / delete / public fetch / public submit)
- \`api/src/wcs_api/services/peer_reviews.py\` — supabase CRUD
- \`api/src/wcs_api/services/supabase_admin.py\` — new \`get_analysis_minimal\` helper
- \`api/src/wcs_api/main.py\` — register router
- \`src/lib/wcs-api.ts\` — client wrappers + types
- \`src/app/review/[token]/page.tsx\` — reviewer landing page
- \`src/components/analyze/peer-reviews-section.tsx\` — owner panel
- \`src/app/(app)/analysis/page.tsx\` — slot the section in

## Migration

Run the updated \`supabase/schema.sql\` — creates the new table + RLS. No destructive changes. Idempotent.

## Verified

- \`npx tsc --noEmit\` clean
- Backend import smoke clean
- 5 new routes visible in \`app.routes\`:
  - POST   /peer-reviews/request
  - GET    /peer-reviews/for-analysis/{id}
  - DELETE /peer-reviews/{review_id}
  - GET    /peer-reviews/public/{token}
  - POST   /peer-reviews/public/{token}/submit

## Follow-ups (out of scope for v1)

- Email/SMS notifications when a review lands
- Anonymous reviewer mode
- Reviewer can see the AI score only AFTER they submit (for judge calibration diff)
- Per-moment timestamp comments in the UI (backend + schema already support them)