### PR TITLE
Peer reviews: training consent checkbox + frozen AI snapshot

### DIFF
--- a/api/src/wcs_api/routes/peer_reviews.py
+++ b/api/src/wcs_api/routes/peer_reviews.py
@@ -175,6 +175,10 @@ class SubmitBody(BaseModel):
     presentation_score: float = Field(..., ge=0.0, le=10.0)
     overall_notes: str | None = Field(default=None, max_length=4000)
     per_moment_notes: list[dict[str, Any]] = Field(default_factory=list)
+    # Opt-in to let SwingFlow use this review to improve the AI
+    # scoring. Defaults to False — we never train on reviews where
+    # the reviewer didn't actively check the box.
+    training_consent: bool = Field(default=False)
 
     @field_validator("reviewer_role")
     @classmethod
@@ -221,6 +225,19 @@ async def submit_public_review(
     if review.get("submitted_at"):
         raise HTTPException(status_code=409, detail="review already submitted")
 
+    # Snapshot the AI result as it stands RIGHT NOW so the training
+    # pair is frozen. Best-effort: if the analysis was deleted between
+    # the public GET and this POST, we still accept the review — the
+    # snapshot is useful for training but not load-bearing for the
+    # submit itself.
+    ai_result_snapshot: dict[str, Any] | None = None
+    try:
+        ai_result_snapshot = await supabase_admin.get_analysis_result(
+            review["analysis_id"]
+        )
+    except httpx.HTTPStatusError:
+        ai_result_snapshot = None
+
     try:
         await peer_reviews_service.submit(
             token=token,
@@ -232,6 +249,8 @@ async def submit_public_review(
             presentation_score=body.presentation_score,
             overall_notes=(body.overall_notes or "").strip() or None,
             per_moment_notes=body.per_moment_notes,
+            training_consent=body.training_consent,
+            ai_result_snapshot=ai_result_snapshot,
         )
     except httpx.HTTPStatusError as exc:
         raise HTTPException(

--- a/api/src/wcs_api/services/peer_reviews.py
+++ b/api/src/wcs_api/services/peer_reviews.py
@@ -62,15 +62,21 @@ async def submit(
     presentation_score: float,
     overall_notes: str | None,
     per_moment_notes: list[dict[str, Any]],
+    training_consent: bool,
+    ai_result_snapshot: dict[str, Any] | None,
 ) -> None:
     """Patch the row identified by `token` with the reviewer's scores
     and mark submitted_at. Filters on `submitted_at.is.null` so a
     double-submit race lands with exactly one winner; the loser gets
     a no-op PATCH which the caller interprets via the 409 check it
     made before arriving here.
+
+    Also freezes the AI result snapshot so future re-analyses don't
+    desync the (human_score, ai_score) training pair, and stamps
+    `consent_given_at` when the reviewer opted in to training use.
     """
     now = _dt.datetime.now(_dt.timezone.utc).isoformat()
-    update = {
+    update: dict[str, Any] = {
         "reviewer_name": reviewer_name[:80],
         "reviewer_role": reviewer_role,
         "timing_score": round(float(timing_score), 1),
@@ -79,6 +85,9 @@ async def submit(
         "presentation_score": round(float(presentation_score), 1),
         "overall_notes": overall_notes,
         "per_moment_notes": per_moment_notes,
+        "training_consent": bool(training_consent),
+        "consent_given_at": now if training_consent else None,
+        "ai_result_snapshot": ai_result_snapshot,
         "submitted_at": now,
     }
     async with httpx.AsyncClient(timeout=10) as client:

--- a/api/src/wcs_api/services/supabase_admin.py
+++ b/api/src/wcs_api/services/supabase_admin.py
@@ -142,6 +142,28 @@ async def insert_usage_event(
         r.raise_for_status()
 
 
+async def get_analysis_result(analysis_id: str) -> dict[str, Any] | None:
+    """Service-role read of just the stored AI `result` blob for an
+    analysis. Used when we need to freeze a snapshot of the AI output
+    (e.g. when a peer review is submitted) so later re-analyses can't
+    mutate the training pair retroactively.
+    """
+    async with httpx.AsyncClient(timeout=10) as client:
+        r = await client.get(
+            _rest(
+                f"video_analyses?id=eq.{analysis_id}"
+                "&select=result"
+            ),
+            headers=_headers(),
+        )
+        r.raise_for_status()
+        rows = r.json()
+        if not rows:
+            return None
+        result = rows[0].get("result")
+        return result if isinstance(result, dict) else None
+
+
 async def get_analysis_minimal(
     analysis_id: str, *, include_soft_deleted: bool = False
 ) -> dict[str, Any] | None:

--- a/src/app/peer-review/page.tsx
+++ b/src/app/peer-review/page.tsx
@@ -20,6 +20,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Loader2, CheckCircle2, AlertCircle } from "lucide-react";
 import {
   Select,
@@ -57,6 +58,9 @@ function PeerReviewInner() {
   const [teamwork, setTeamwork] = useState<number>(7);
   const [presentation, setPresentation] = useState<number>(7);
   const [notes, setNotes] = useState("");
+  // Opt-in to use this review to improve the AI. Default false;
+  // stays off unless the reviewer actively checks the box.
+  const [trainingConsent, setTrainingConsent] = useState(false);
   const videoRef = useRef<HTMLVideoElement | null>(null);
 
   useEffect(() => {
@@ -101,6 +105,7 @@ function PeerReviewInner() {
         teamwork_score: teamwork,
         presentation_score: presentation,
         overall_notes: notes.trim() || null,
+        training_consent: trainingConsent,
       });
       setSubmitted(true);
     } catch (e) {
@@ -280,6 +285,33 @@ function PeerReviewInner() {
               placeholder="What stood out? Anything specific to work on?"
               className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
             />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="py-4">
+            <label className="flex items-start gap-3 cursor-pointer">
+              <Checkbox
+                checked={trainingConsent}
+                onCheckedChange={(v) =>
+                  setTrainingConsent(v === true)
+                }
+                className="mt-0.5"
+              />
+              <div className="space-y-1">
+                <p className="text-sm font-medium leading-snug">
+                  It's OK to use my review to improve SwingFlow's AI
+                </p>
+                <p className="text-xs text-muted-foreground leading-relaxed">
+                  Optional — off by default. If checked, we may use
+                  your scores and notes (along with the AI's score on
+                  the same clip) to calibrate and fine-tune the
+                  scoring model. Your name is stored with the review
+                  but isn't published anywhere outside the dancer you're
+                  reviewing for.
+                </p>
+              </div>
+            </label>
           </CardContent>
         </Card>
 

--- a/src/lib/wcs-api.ts
+++ b/src/lib/wcs-api.ts
@@ -667,6 +667,8 @@ export async function submitPublicReview(
     presentation_score: number;
     overall_notes?: string | null;
     per_moment_notes?: Array<{ timestamp_sec: number; note: string }>;
+    // Opt-in: true = SwingFlow may use this review to improve scoring
+    training_consent: boolean;
   }
 ): Promise<void> {
   if (!API_URL) throw new Error("NEXT_PUBLIC_WCS_API_URL is not set");

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -223,13 +223,40 @@ create table if not exists public.peer_reviews (
   -- Per-moment notes as JSON array of {timestamp_sec: number, note: string}
   per_moment_notes      jsonb not null default '[]'::jsonb,
 
+  -- Training-data consent. We ask the reviewer explicitly on the
+  -- submit form whether we can use their score + notes to improve
+  -- the AI. Default false — nothing training-usable unless the
+  -- reviewer actively checks the box.
+  training_consent      boolean not null default false,
+  consent_given_at      timestamptz,
+
+  -- Frozen snapshot of the AI analysis result as it stood at the
+  -- time this review was submitted. Necessary for training because
+  -- the owner can re-analyze the same video later and mutate
+  -- `video_analyses.result` — without a snapshot the human score
+  -- and AI score could desync, ruining the training pair.
+  ai_result_snapshot    jsonb,
+
   submitted_at          timestamptz,
   created_at            timestamptz not null default now()
 );
+
+-- Migration: add training-data columns to pre-existing rows. Idempotent.
+alter table public.peer_reviews
+  add column if not exists training_consent   boolean not null default false,
+  add column if not exists consent_given_at   timestamptz,
+  add column if not exists ai_result_snapshot jsonb;
+
 create index if not exists peer_reviews_analysis_id_idx
   on public.peer_reviews(analysis_id);
 create index if not exists peer_reviews_requester_idx
   on public.peer_reviews(requester_user_id, created_at desc);
+-- Partial index to make 'give me every training-usable row' cheap.
+-- Only submitted + consented rows count as training data, and that's
+-- what a calibration/fine-tune export always filters on.
+create index if not exists peer_reviews_training_idx
+  on public.peer_reviews(submitted_at desc)
+  where submitted_at is not null and training_consent = true;
 
 alter table public.peer_reviews enable row level security;
 


### PR DESCRIPTION
Two additions on top of #118 so peer reviews can be used as training data later without compromising reviewer trust.

## 1. Reviewer consent (opt-in, off by default)

On the reviewer form, above the Submit button:

> ☐ **It's OK to use my review to improve SwingFlow's AI**
> Optional — off by default. If checked, we may use your scores and notes (along with the AI's score on the same clip) to calibrate and fine-tune the scoring model. Your name is stored with the review but isn't published anywhere outside the dancer you're reviewing for.

- New \`training_consent\` boolean column (default false)
- \`consent_given_at\` stamped when the reviewer checks the box
- Partial index \`peer_reviews_training_idx\` on \`(submitted_at)\` WHERE consent makes training-data queries cheap

## 2. Frozen AI snapshot

When a review is submitted, we snapshot the current \`video_analyses.result\` into \`peer_reviews.ai_result_snapshot\`. Without this, a later re-analyze would mutate the AI side of the pair, making (human_score, ai_score) pairs drift over time — useless for training.

- Snapshot is best-effort; a failed read doesn't block submit
- New helper \`supabase_admin.get_analysis_result\`

## Training data query (for future reference)

```sql
select reviewer_role, timing_score, technique_score, teamwork_score,
       presentation_score, overall_notes, per_moment_notes,
       ai_result_snapshot, submitted_at
from public.peer_reviews
where submitted_at is not null and training_consent = true
order by submitted_at desc;
```

## Migration

Idempotent — \`alter table ... add column if not exists\` wrapped. Safe to re-run against prod even though the base peer_reviews table shipped in #118.

## Verified

- \`next build\` green — \`/peer-review\` static route still there
- \`SubmitBody\` pydantic model defaults \`training_consent\` to false
- Helper imports cleanly