### PR TITLE
Practice mode: speed control + beat-map + local clip (#108)

### DIFF
--- a/src/app/(app)/analysis/page.tsx
+++ b/src/app/(app)/analysis/page.tsx
@@ -17,6 +17,8 @@ import {
   Copy,
   Eye,
   AlertCircle,
+  FileVideo,
+  X,
 } from "lucide-react";
 import { TimelineView } from "@/components/analyze/timeline-view";
 import { ScoreResultCard } from "@/components/analyze/score-result-card";
@@ -61,6 +63,36 @@ function AnalysisPageInner() {
   const [overrideResult, setOverrideResult] = useState<VideoScoreResult | null>(
     null
   );
+  // Practice mode: let the user point the player at a local video
+  // file (not stored server-side) so they can slow-scrub any clip —
+  // their own, a pro's, a YouTube download — against the detected
+  // beat grid + pattern timeline. Local clips never leave the
+  // browser; we just create an object URL.
+  const [localVideo, setLocalVideo] = useState<{
+    url: string;
+    name: string;
+  } | null>(null);
+  const [dragging, setDragging] = useState(false);
+
+  // Revoke the object URL when the local clip changes or we unmount.
+  // Leaking object URLs holds the underlying Blob in memory and can
+  // easily pin 100s of MB per session for users trying a few clips.
+  useEffect(() => {
+    if (!localVideo) return;
+    return () => {
+      URL.revokeObjectURL(localVideo.url);
+    };
+  }, [localVideo]);
+
+  const handleLocalFile = useCallback((file: File) => {
+    if (!file.type.startsWith("video/")) return;
+    const url = URL.createObjectURL(file);
+    setLocalVideo({ url, name: file.name });
+  }, []);
+
+  const clearLocalVideo = useCallback(() => {
+    setLocalVideo(null);
+  }, []);
 
   // Find the record from the history hook. history.records already
   // filters soft-deleted rows by default, so if the id is missing
@@ -480,11 +512,81 @@ function AnalysisPageInner() {
         </Card>
       )}
 
+      {/* Practice-mode local clip picker. Drops a local video over
+          the stored clip so the user can scrub any video (their own,
+          a pro's, a download) against this analysis's beat + pattern
+          timeline. File stays in the browser — no upload. */}
+      <div
+        className={
+          "rounded-md border border-dashed p-3 text-xs transition-colors " +
+          (dragging
+            ? "border-primary bg-primary/5"
+            : "border-border bg-muted/10")
+        }
+        onDragOver={(e) => {
+          e.preventDefault();
+          setDragging(true);
+        }}
+        onDragLeave={() => setDragging(false)}
+        onDrop={(e) => {
+          e.preventDefault();
+          setDragging(false);
+          const f = e.dataTransfer.files?.[0];
+          if (f) handleLocalFile(f);
+        }}
+      >
+        {localVideo ? (
+          <div className="flex items-center gap-2">
+            <FileVideo className="h-4 w-4 text-primary shrink-0" />
+            <div className="min-w-0 flex-1">
+              <p className="font-medium truncate">
+                Practice clip: {localVideo.name}
+              </p>
+              <p className="text-muted-foreground text-[11px]">
+                Playing local clip against this analysis&rsquo;s beat + pattern
+                timeline. Use the speed control for slow practice.
+              </p>
+            </div>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={clearLocalVideo}
+              className="h-7"
+            >
+              <X className="h-3.5 w-3.5 mr-1" />
+              Remove
+            </Button>
+          </div>
+        ) : (
+          <div className="flex items-center gap-3 flex-wrap">
+            <FileVideo className="h-4 w-4 text-muted-foreground shrink-0" />
+            <span className="text-muted-foreground flex-1 min-w-[180px]">
+              Practice with a local clip — drop any video here (or pick one)
+              to play it against this beat map at 0.25&ndash;1.5x.
+            </span>
+            <label className="inline-flex items-center gap-1.5 cursor-pointer rounded-md border border-border bg-background px-2 py-1 text-xs hover:bg-muted/40 transition-colors">
+              <input
+                type="file"
+                accept="video/*"
+                className="hidden"
+                onChange={(e) => {
+                  const f = e.target.files?.[0];
+                  if (f) handleLocalFile(f);
+                  // Reset so selecting the same file twice still fires.
+                  e.target.value = "";
+                }}
+              />
+              Choose video
+            </label>
+          </div>
+        )}
+      </div>
+
       {/* Timeline + video */}
       <TimelineView
         result={currentResult}
         duration={record.duration ?? 0}
-        videoSrc={videoUrl}
+        videoSrc={localVideo?.url ?? videoUrl}
       />
 
       {/* Score + sub-scores + patterns + strengths + improvements */}

--- a/src/components/analyze/timeline-view.tsx
+++ b/src/components/analyze/timeline-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Play,
   Pause,
@@ -8,6 +8,7 @@ import {
   VolumeX,
   Maximize,
   SkipBack,
+  Gauge,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type {
@@ -77,6 +78,48 @@ export function TimelineView({
   // "not loaded yet; use the prop".
   const [videoDuration, setVideoDuration] = useState(0);
   const [muted, setMuted] = useState(false);
+  // Practice-mode playback rate. Read from localStorage so a user's
+  // preferred slow-down sticks across clips. preservesPitch keeps the
+  // music listenable at 0.5x instead of sounding chipmunk/demonic.
+  const [playbackRate, setPlaybackRate] = useState<number>(1);
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const raw = window.localStorage.getItem("swingflow:playbackRate");
+    const n = raw ? parseFloat(raw) : NaN;
+    if (Number.isFinite(n) && n > 0 && n <= 2) setPlaybackRate(n);
+  }, []);
+  const applyRate = useCallback((rate: number) => {
+    setPlaybackRate(rate);
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem("swingflow:playbackRate", String(rate));
+    }
+    const v = videoRef.current;
+    if (v) {
+      v.playbackRate = rate;
+      // Prefixed flags for older Safari/Chrome so pitch stays native.
+      v.preservesPitch = true;
+      const vAny = v as HTMLVideoElement & {
+        mozPreservesPitch?: boolean;
+        webkitPreservesPitch?: boolean;
+      };
+      vAny.mozPreservesPitch = true;
+      vAny.webkitPreservesPitch = true;
+    }
+  }, []);
+  // Re-apply after the video element mounts / src changes — a fresh
+  // video element defaults back to rate=1 and preservesPitch=false.
+  useEffect(() => {
+    const v = videoRef.current;
+    if (!v) return;
+    v.playbackRate = playbackRate;
+    v.preservesPitch = true;
+    const vAny = v as HTMLVideoElement & {
+      mozPreservesPitch?: boolean;
+      webkitPreservesPitch?: boolean;
+    };
+    vAny.mozPreservesPitch = true;
+    vAny.webkitPreservesPitch = true;
+  }, [videoSrc, playbackRate]);
   // Detail shown below the bar. Manual intent (hover / tap-select)
   // wins. Otherwise track whatever pattern the video is currently
   // playing through so a user just pressing play watches the detail
@@ -274,6 +317,7 @@ export function TimelineView({
               />
             )}
             <div className="ml-auto flex items-center gap-1">
+              <SpeedSelector rate={playbackRate} onChange={applyRate} />
               <button
                 type="button"
                 onClick={toggleMute}
@@ -493,6 +537,20 @@ export function TimelineView({
             });
           })()}
         </div>
+
+        {/* Beat-map strip — renders the detected beat grid underneath
+            the pattern timeline so users practicing at slow speed can
+            visually track boom-tick-boom-tick against what they hear.
+            Hidden when beat detection failed (silent-fallback path). */}
+        {result.beat_grid &&
+          (result.beat_grid.beats?.length ?? 0) > 0 && (
+            <BeatStrip
+              grid={result.beat_grid}
+              effectiveDuration={effectiveDuration}
+              currentTime={currentTime}
+              onSeek={seek}
+            />
+          )}
 
         {/* Legend */}
         <div className="flex flex-wrap items-center gap-3 text-[10px] text-muted-foreground pt-1">
@@ -753,6 +811,208 @@ function MusicalityStrip({
           )}
         </div>
       )}
+    </div>
+  );
+}
+
+const SPEED_OPTIONS: number[] = [0.25, 0.5, 0.75, 1, 1.25, 1.5];
+
+function SpeedSelector({
+  rate,
+  onChange,
+}: {
+  rate: number;
+  onChange: (r: number) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  // Close on outside click. Pointerdown (not click) so the dropdown
+  // closes before any click handler on a different button fires.
+  const rootRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: PointerEvent) => {
+      if (!rootRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("pointerdown", onDown);
+    return () => document.removeEventListener("pointerdown", onDown);
+  }, [open]);
+  const label = rate === 1 ? "1x" : `${rate}x`;
+  return (
+    <div className="relative" ref={rootRef}>
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="flex items-center gap-1 text-white/80 hover:text-white px-1.5 py-1 rounded transition-colors font-mono tabular-nums text-[11px]"
+        aria-label={`Playback speed (${label})`}
+        title={`Playback speed (${label}) — pitch preserved`}
+        aria-haspopup="menu"
+        aria-expanded={open}
+      >
+        <Gauge className="h-3.5 w-3.5" />
+        <span>{label}</span>
+      </button>
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 bottom-full mb-1 min-w-[72px] rounded-md border border-border bg-black/95 shadow-lg py-1 z-20"
+        >
+          {SPEED_OPTIONS.map((r) => (
+            <button
+              key={r}
+              type="button"
+              role="menuitemradio"
+              aria-checked={r === rate}
+              onClick={() => {
+                onChange(r);
+                setOpen(false);
+              }}
+              className={cn(
+                "block w-full text-left px-2.5 py-1 font-mono tabular-nums text-[11px] transition-colors",
+                r === rate
+                  ? "bg-primary/30 text-white"
+                  : "text-white/80 hover:bg-white/10 hover:text-white"
+              )}
+            >
+              {r === 1 ? "1x" : `${r}x`}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function BeatStrip({
+  grid,
+  effectiveDuration,
+  currentTime,
+  onSeek,
+}: {
+  grid: NonNullable<VideoScoreResult["beat_grid"]>;
+  effectiveDuration: number;
+  currentTime: number;
+  onSeek: (t: number) => void;
+}) {
+  const beats = grid.beats ?? [];
+  const downbeats = grid.downbeats ?? [];
+
+  const visibleBeats = useMemo(
+    () => beats.filter((b) => b >= 0 && b <= effectiveDuration),
+    [beats, effectiveDuration]
+  );
+  const downbeatSet = useMemo(
+    () => new Set(downbeats.map((d) => d.toFixed(3))),
+    [downbeats]
+  );
+
+  // Phrase markers — every 8 counts of music. A WCS phrase is 8 beats
+  // starting on a downbeat. Step through downbeats and mark every 8th
+  // so the user can see where the "1" of each phrase lands.
+  const phraseMarkers = useMemo(() => {
+    if (downbeats.length < 2) return [];
+    // Infer beats-per-downbeat from the beat:downbeat ratio. WCS and
+    // most swing music is in 4 — one downbeat per 4 beats. Two
+    // downbeats therefore span one bar; 8 beats = 2 bars = 1 phrase.
+    const barsPerPhrase = 2;
+    const out: number[] = [];
+    for (let i = 0; i < downbeats.length; i += barsPerPhrase) {
+      const d = downbeats[i];
+      if (d >= 0 && d <= effectiveDuration) out.push(d);
+    }
+    return out;
+  }, [downbeats, effectiveDuration]);
+
+  const barRef = useRef<HTMLDivElement>(null);
+  const scrub = (e: React.MouseEvent<HTMLDivElement>) => {
+    const bar = barRef.current;
+    if (!bar) return;
+    const rect = bar.getBoundingClientRect();
+    if (rect.width <= 0) return;
+    const pct = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
+    onSeek(pct * effectiveDuration);
+  };
+
+  // Cull dense beat grids — at 150 BPM over 2 minutes you get 300
+  // ticks and the strip becomes a smear. Subsample to ~240 max,
+  // always keeping downbeats so the bar structure stays readable.
+  const renderedBeats = useMemo(() => {
+    const MAX = 240;
+    if (visibleBeats.length <= MAX) return visibleBeats;
+    const stride = Math.ceil(visibleBeats.length / MAX);
+    return visibleBeats.filter(
+      (b, i) => i % stride === 0 || downbeatSet.has(b.toFixed(3))
+    );
+  }, [visibleBeats, downbeatSet]);
+
+  return (
+    <div className="space-y-1.5 pt-1">
+      <div className="flex items-center justify-between text-xs text-muted-foreground">
+        <span className="font-medium uppercase tracking-wide">Beat map</span>
+        <span className="text-[10px] tabular-nums">
+          {grid.bpm.toFixed(0)} BPM
+          {grid.source ? ` · ${grid.source}` : ""}
+          {" · "}
+          {downbeats.length} bars
+        </span>
+      </div>
+      <div
+        ref={barRef}
+        className="relative h-7 rounded-md bg-muted/30 border border-border overflow-hidden cursor-pointer"
+        onClick={scrub}
+        role="img"
+        aria-label={`Beat map — ${downbeats.length} bars at ${grid.bpm.toFixed(0)} BPM`}
+        title="Click to seek. Tall ticks = downbeats (boom). Short = offbeats (tick)."
+      >
+        {/* Beat ticks */}
+        {renderedBeats.map((b, i) => {
+          const pct = (b / effectiveDuration) * 100;
+          const isDownbeat = downbeatSet.has(b.toFixed(3));
+          return (
+            <div
+              key={`bt-${i}-${b}`}
+              className={cn(
+                "absolute top-1 bottom-1 pointer-events-none",
+                isDownbeat
+                  ? "w-[2px] bg-emerald-400"
+                  : "w-px bg-white/40"
+              )}
+              style={{ left: `calc(${pct}% - 0.5px)` }}
+            />
+          );
+        })}
+        {/* Phrase markers — full-height ghost lines every 8 counts. */}
+        {phraseMarkers.map((t, i) => (
+          <div
+            key={`ph-${i}`}
+            className="absolute top-0 bottom-0 w-[2px] bg-amber-400/60 pointer-events-none"
+            style={{ left: `calc(${(t / effectiveDuration) * 100}% - 1px)` }}
+            title={`Phrase ${i + 1} at ${formatTime(t)}`}
+          />
+        ))}
+        {/* Playhead */}
+        <div
+          className="absolute top-0 bottom-0 w-[2px] bg-foreground pointer-events-none"
+          style={{
+            left: `${Math.min(100, (currentTime / effectiveDuration) * 100)}%`,
+          }}
+        />
+      </div>
+      <div className="flex flex-wrap items-center gap-3 text-[10px] text-muted-foreground">
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block h-3 w-[2px] bg-emerald-400" />
+          downbeat (boom)
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block h-3 w-px bg-white/40" />
+          beat (tick)
+        </span>
+        {phraseMarkers.length > 0 && (
+          <span className="flex items-center gap-1.5">
+            <span className="inline-block h-3 w-[2px] bg-amber-400/60" />
+            phrase (every 8)
+          </span>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Closes #108.

## Summary
- **Speed control** in the video control row: 0.25x / 0.5x / 0.75x / 1x / 1.25x / 1.5x with `preservesPitch` so slow playback stays listenable. Persists to `localStorage` so a user's preferred slow-down sticks across clips.
- **Beat-map strip** below the pattern timeline. Renders `beat_grid.beats` as ticks, `downbeats` as taller emerald ticks ("boom"), plus amber phrase markers every 8 counts ("1 of each phrase"). Click anywhere to seek. Dense grids subsample to ~240 ticks max (always keeping downbeats) so long clips don't smear.
- **Local practice clip** on `/analysis`: drag-and-drop or pick any local video; it plays against this analysis's detected beat grid and pattern timeline. Never uploaded — just `URL.createObjectURL`. The object URL is revoked on unmount/change to avoid pinning blobs in memory.

All data already exists in the analysis payload (`beat_grid`, `patterns_identified`) — pure UI work.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `next build` — compiles, all 77 pages generate
- [x] Dev server renders `/analyze` (307 redirect to login, expected)
- [ ] Manual: open an analysis with a stored clip, flip speed to 0.5x, confirm music pitch stays natural
- [ ] Manual: confirm beat ticks align with the metronome dot pulse and downbeats look taller/green
- [ ] Manual: drag a local `.mp4` into the practice zone, confirm it plays + beat-map scrolls with it
- [ ] Manual: confirm seeking via beat-strip click lands on the clicked time
- [ ] Manual: confirm localStorage persists playback rate between page loads


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added drag-and-drop support to upload and practice with local video files
  * Introduced playback speed control with pitch preservation and persistent settings
  * Enhanced timeline with new beat map visualization showing beat patterns and downbeats

<!-- end of auto-generated comment: release notes by coderabbit.ai -->