### PR TITLE
Atomic video quota reservation (#72)

### DIFF
--- a/api/src/wcs_api/routes/video.py
+++ b/api/src/wcs_api/routes/video.py
@@ -100,12 +100,20 @@ async def analyze_video_endpoint(
     if not r2.object_key_belongs_to_user(body.object_key, user_id):
         raise HTTPException(status_code=403, detail="object does not belong to user")
 
-    # Quota gate.
+    # Quota reservation — atomic. Two concurrent requests from the
+    # same user cannot both claim the final slot; one will get
+    # reservation_id and the other None (→ 429). See #72.
     try:
         quota_status = await quota.get_video_quota_status(user_id)
     except httpx.HTTPStatusError as exc:
         raise _admin_error_to_http(exc)
-    if quota_status["remaining"] <= 0:
+    try:
+        reservation_id = await supabase_admin.claim_video_quota(
+            user_id=user_id, limit=quota_status["limit"]
+        )
+    except httpx.HTTPStatusError as exc:
+        raise _admin_error_to_http(exc)
+    if reservation_id is None:
         raise HTTPException(
             status_code=status.HTTP_429_TOO_MANY_REQUESTS,
             detail=(
@@ -115,38 +123,43 @@ async def analyze_video_endpoint(
             ),
         )
 
-    if not settings.gemini_api_key:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="video analysis not configured (GEMINI_API_KEY missing)",
-        )
-
-    # Validate the object exists in R2 and check size.
-    head = r2.head_object(body.object_key)
-    if not head:
-        raise HTTPException(
-            status_code=404,
-            detail="object not found — upload may have expired or failed",
-        )
-
-    content_length = int(head.get("ContentLength", 0))
-    if content_length > settings.max_video_bytes:
-        r2.delete_object(body.object_key)
-        limit_mb = settings.max_video_bytes / (1024 * 1024)
-        size_mb = content_length / (1024 * 1024)
-        raise HTTPException(
-            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
-            detail=f"file is {size_mb:.0f} MB, limit is {limit_mb:.0f} MB",
-        )
-
-    # Download to a tempfile and run the existing pipeline.
-    suffix = os.path.splitext(body.filename or body.object_key)[1] or ".mp4"
+    # From here on, a reservation is held. If anything short of a
+    # completed analysis happens, release it so the user doesn't get
+    # charged for validation failures / infra errors.
+    reservation_finalized = False
+    tmp_path: str | None = None
     try:
-        tmp_path = r2.download_to_tempfile(body.object_key, suffix=suffix)
-    except Exception as exc:  # noqa: BLE001
-        raise HTTPException(status_code=502, detail=f"failed to download from R2: {exc}")
+        if not settings.gemini_api_key:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="video analysis not configured (GEMINI_API_KEY missing)",
+            )
 
-    try:
+        # Validate the object exists in R2 and check size.
+        head = r2.head_object(body.object_key)
+        if not head:
+            raise HTTPException(
+                status_code=404,
+                detail="object not found — upload may have expired or failed",
+            )
+
+        content_length = int(head.get("ContentLength", 0))
+        if content_length > settings.max_video_bytes:
+            r2.delete_object(body.object_key)
+            limit_mb = settings.max_video_bytes / (1024 * 1024)
+            size_mb = content_length / (1024 * 1024)
+            raise HTTPException(
+                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                detail=f"file is {size_mb:.0f} MB, limit is {limit_mb:.0f} MB",
+            )
+
+        # Download to a tempfile and run the existing pipeline.
+        suffix = os.path.splitext(body.filename or body.object_key)[1] or ".mp4"
+        try:
+            tmp_path = r2.download_to_tempfile(body.object_key, suffix=suffix)
+        except Exception as exc:  # noqa: BLE001
+            raise HTTPException(status_code=502, detail=f"failed to download from R2: {exc}")
+
         try:
             duration = get_video_duration(tmp_path)
         except VideoAnalysisError as exc:
@@ -192,22 +205,25 @@ async def analyze_video_endpoint(
         # admin dashboards can aggregate it.
         usage = result.pop("usage", None)
 
-        # Usage logging is analytics — if it fails, we still want to
-        # return the analysis the user paid for. A Supabase hiccup
-        # on the INSERT here should never throw away a completed
-        # Gemini call. Quota enforcement already ran above; the only
-        # downside to a missed usage_event is that the monthly count
-        # is off by one, which is self-healing the next month.
+        # Gemini succeeded — the user has consumed their slot. Mark
+        # the reservation finalized BEFORE attempting the cosmetic
+        # UPDATE / row insert so a Supabase hiccup on those side
+        # channels can't release the quota we legitimately charged.
+        reservation_finalized = True
+
+        # Best-effort: fill in usage fields on the reservation row.
+        # If this fails, the slot is still counted (reservation row
+        # already exists) and the analysis is still returned. The
+        # only downside is admin dashboards miss one cost row.
         try:
-            await supabase_admin.insert_usage_event(
-                user_id=user_id,
-                kind="video",
+            await supabase_admin.finalize_video_quota(
+                reservation_id=reservation_id,
                 duration_sec=int(duration),
                 usage=usage,
             )
         except Exception as exc:  # noqa: BLE001
             logger.warning(
-                "insert_usage_event failed for user=%s (analysis still returned): %s",
+                "finalize_video_quota failed for user=%s (analysis still returned): %s",
                 user_id,
                 exc,
             )
@@ -254,10 +270,25 @@ async def analyze_video_endpoint(
             },
         }
     finally:
-        try:
-            os.unlink(tmp_path)
-        except OSError:
-            pass
+        # Release the quota reservation if we didn't finalize — i.e.
+        # the analysis failed before Gemini returned useful work.
+        # Best-effort: a failure here leaves the reservation in
+        # place, which is the safer direction.
+        if not reservation_finalized:
+            try:
+                await supabase_admin.release_video_quota(reservation_id)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "release_video_quota failed for user=%s res=%s: %s",
+                    user_id,
+                    reservation_id,
+                    exc,
+                )
+        if tmp_path is not None:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
         # Delete from R2 by default — privacy-preserving. Users who
         # opted in to `store_video` keep their clip so they can
         # replay it against the pattern timeline later; they can

--- a/api/src/wcs_api/services/supabase_admin.py
+++ b/api/src/wcs_api/services/supabase_admin.py
@@ -142,6 +142,83 @@ async def insert_usage_event(
         r.raise_for_status()
 
 
+async def claim_video_quota(user_id: str, limit: int) -> str | None:
+    """Atomically reserve a monthly video-quota slot. Returns the
+    usage_events.id of the reservation row, or None if the user is
+    already at or above limit. The RPC is serialized per-user via a
+    transaction-scope advisory lock, so concurrent requests from the
+    same user cannot both claim the last remaining slot (fixes #72).
+
+    Callers MUST either `finalize_video_quota` (on success) or
+    `release_video_quota` (on failure) the returned id — a dangling
+    reservation still counts toward monthly usage, which is the
+    intentional failure-mode: a partial failure costs the user one
+    slot rather than silently overspending quota.
+    """
+    async with httpx.AsyncClient(timeout=10) as client:
+        r = await client.post(
+            f"{settings.supabase_url}/rest/v1/rpc/claim_video_quota",
+            headers={**_headers(), "Prefer": "return=representation"},
+            json={"p_user": user_id, "p_limit": limit},
+        )
+        r.raise_for_status()
+        data = r.json()
+        # PostgREST may return the scalar directly or as a 1-element
+        # list depending on version. Accept both; treat null / None
+        # as over-limit.
+        if isinstance(data, list):
+            data = data[0] if data else None
+        if data in (None, "", False):
+            return None
+        return str(data)
+
+
+async def finalize_video_quota(
+    reservation_id: str,
+    duration_sec: int | None,
+    job_id: str | None = None,
+    usage: dict[str, Any] | None = None,
+) -> None:
+    """Fill in the post-Gemini details on a previously-reserved
+    usage_events row. Idempotent w.r.t. quota count — the row was
+    already inserted at claim time; this just enriches it.
+    """
+    model = usage.get("model") if usage else None
+    prompt_tokens = usage.get("prompt_tokens") if usage else None
+    response_tokens = usage.get("response_tokens") if usage else None
+    cost_usd_micros = usage.get("cost_usd_micros") if usage else None
+    async with httpx.AsyncClient(timeout=10) as client:
+        r = await client.post(
+            f"{settings.supabase_url}/rest/v1/rpc/finalize_video_quota",
+            headers={**_headers(), "Prefer": "return=minimal"},
+            json={
+                "p_id": reservation_id,
+                "p_duration_sec": duration_sec,
+                "p_job_id": job_id,
+                "p_model": model,
+                "p_prompt_tokens": prompt_tokens,
+                "p_response_tokens": response_tokens,
+                "p_cost_usd_micros": cost_usd_micros,
+            },
+        )
+        r.raise_for_status()
+
+
+async def release_video_quota(reservation_id: str) -> None:
+    """Delete a reservation row so the user isn't charged for a
+    failed analysis. Best-effort: a failure here leaves the
+    reservation in place (user loses one slot), which is the safer
+    direction than accidentally un-charging on a flaky call.
+    """
+    async with httpx.AsyncClient(timeout=10) as client:
+        r = await client.post(
+            f"{settings.supabase_url}/rest/v1/rpc/release_video_quota",
+            headers={**_headers(), "Prefer": "return=minimal"},
+            json={"p_id": reservation_id},
+        )
+        r.raise_for_status()
+
+
 async def get_analysis_result(analysis_id: str) -> dict[str, Any] | None:
     """Service-role read of just the stored AI `result` blob for an
     analysis. Used when we need to freeze a snapshot of the AI output

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -365,3 +365,103 @@ begin
   return coalesce(new_count, 0);
 end;
 $$;
+
+-- ────────────────────────────────────────────────────────────
+-- Atomic video-quota reservation (fixes #72)
+--
+-- The previous flow was check-then-charge: the route counted
+-- usage_events, ran Gemini, then inserted the usage row. Concurrent
+-- requests from the same user could both see "remaining >= 1" and
+-- both proceed, overspending quota. If the post-Gemini INSERT
+-- failed, the completed analysis was charged to no one.
+--
+-- Fix: reserve a quota slot atomically BEFORE Gemini runs. Returns
+-- the reservation id (the usage_events.id) or NULL when over limit.
+-- The caller finalizes on success (fills in duration/usage) or
+-- releases on failure (deletes the reservation).
+--
+-- Serialization is via a per-user transaction-scope advisory lock,
+-- so different users don't block each other but one user's
+-- concurrent requests wait in line. The lock auto-releases on
+-- COMMIT/ROLLBACK — no explicit unlock needed.
+-- ────────────────────────────────────────────────────────────
+
+create or replace function public.claim_video_quota(
+  p_user uuid,
+  p_limit integer
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_used integer;
+  v_id uuid;
+  v_month_start timestamptz;
+begin
+  -- Per-user xact lock. hashtextextended gives a well-distributed
+  -- bigint keyed on the user_id so two concurrent requests for the
+  -- same user serialize; two different users don't.
+  perform pg_advisory_xact_lock(hashtextextended(p_user::text, 0));
+
+  v_month_start := date_trunc('month', (now() at time zone 'UTC'));
+
+  select count(*) into v_used
+  from public.usage_events
+  where user_id = p_user
+    and kind = 'video'
+    and created_at >= v_month_start;
+
+  if v_used >= p_limit then
+    return null;
+  end if;
+
+  -- Insert a placeholder reservation row. It already counts toward
+  -- this month's usage, so a concurrent claim immediately after
+  -- sees the updated count. Duration/usage fields are filled by
+  -- finalize_video_quota when Gemini completes.
+  insert into public.usage_events (user_id, kind)
+  values (p_user, 'video')
+  returning id into v_id;
+
+  return v_id;
+end;
+$$;
+
+create or replace function public.finalize_video_quota(
+  p_id uuid,
+  p_duration_sec integer,
+  p_job_id text,
+  p_model text,
+  p_prompt_tokens integer,
+  p_response_tokens integer,
+  p_cost_usd_micros integer
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  update public.usage_events
+    set duration_sec    = p_duration_sec,
+        job_id          = p_job_id,
+        model           = p_model,
+        prompt_tokens   = p_prompt_tokens,
+        response_tokens = p_response_tokens,
+        cost_usd_micros = p_cost_usd_micros
+    where id = p_id;
+end;
+$$;
+
+create or replace function public.release_video_quota(p_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  delete from public.usage_events where id = p_id;
+end;
+$$;


### PR DESCRIPTION
Closes #72.

## Summary
- Atomic video-quota reservation via new Supabase RPC `claim_video_quota(user, limit)` using `pg_advisory_xact_lock(hashtextextended(user::text, 0))` — concurrent requests from the same user serialize; two requests can't both claim the last slot. Different users don't block each other.
- Reservation happens BEFORE Gemini. If anything upstream fails (validation, download, analyze), `release_video_quota` deletes the row so the user isn't charged. On Gemini success, `finalize_video_quota` UPDATEs the same row with duration + cost fields.
- `reservation_finalized` flag is flipped to true the instant Gemini returns useful work, so a later `finalize` or `insert_video_analysis` failure can't release the slot we legitimately charged. A Supabase hiccup after Gemini no longer drops the analysis.

## Migration required
Re-run `supabase/schema.sql` in the Supabase SQL editor. Adds three RPCs; no table changes, no data migration.

## Test plan
- [x] `python -m ast` syntax-check on both modified Python files
- [ ] Apply migration in Supabase dashboard, verify the three functions appear in the RPC list
- [ ] Curl two concurrent `POST /video` from the same user at quota=0; expect exactly one 200 and one 429
- [ ] Simulate Gemini failure (set invalid `GEMINI_API_KEY`); verify the reservation row is deleted afterward
- [ ] Simulate Supabase hiccup on the `finalize_video_quota` call (e.g. wrong URL env var); verify analysis is still returned to the client
- [ ] Normal happy-path upload → confirm one usage_events row with populated model/tokens/cost
