### PR TITLE
Timeline keyboard support (#82)

### DIFF
--- a/src/components/analyze/timeline-view.tsx
+++ b/src/components/analyze/timeline-view.tsx
@@ -371,13 +371,41 @@ export function TimelineView({
 
         <div
           ref={barRef}
-          className="relative h-12 sm:h-14 rounded-md bg-muted/30 overflow-hidden border border-border cursor-pointer group/bar"
+          className="relative h-12 sm:h-14 rounded-md bg-muted/30 overflow-hidden border border-border cursor-pointer group/bar focus:outline-none focus-visible:ring-2 focus-visible:ring-foreground/40"
           role="slider"
-          aria-label="Pattern timeline — click to scrub"
+          tabIndex={0}
+          aria-label="Pattern timeline — click or use arrow keys to scrub"
           aria-valuemin={0}
           aria-valuemax={Math.round(effectiveDuration)}
           aria-valuenow={Math.round(currentTime)}
+          aria-valuetext={`${formatTime(currentTime)} of ${formatTime(effectiveDuration)}`}
           onClick={scrubToClick}
+          onKeyDown={(e) => {
+            // Arrow-key scrubbing. Step sizes tuned for reviewing
+            // technique: 1s fine step catches a single beat at most
+            // tempos; 5s large step (shift-arrow) lets you skip
+            // between patterns quickly. Home / End snap to boundaries.
+            const step = e.shiftKey ? 5 : 1;
+            if (e.key === "ArrowRight" || e.key === "ArrowUp") {
+              e.preventDefault();
+              seek(currentTime + step);
+            } else if (e.key === "ArrowLeft" || e.key === "ArrowDown") {
+              e.preventDefault();
+              seek(currentTime - step);
+            } else if (e.key === "Home") {
+              e.preventDefault();
+              seek(0);
+            } else if (e.key === "End") {
+              e.preventDefault();
+              seek(effectiveDuration);
+            } else if (e.key === " " || e.key === "Enter") {
+              // Space/Enter is the expected activation on a focused
+              // slider in most ATs — use it to play/pause so users
+              // can scrub + review without reaching for the mouse.
+              e.preventDefault();
+              togglePlay();
+            }
+          }}
         >
           {/* Pre-dance / post-dance bands. Rendered under the
               pattern blocks so stray out-of-window entries (if any


### PR DESCRIPTION
Closes #82.

## Summary
The timeline bar advertised `role="slider"` but had no keyboard handling — it claimed accessibility semantics it didn't implement.

- `tabIndex={0}` + focus-visible ring so keyboard users can reach it
- Arrow keys scrub ±1s, Shift+arrow ±5s (1s catches a single beat at most tempos; 5s skips between pattern blocks)
- `Home` / `End` snap to boundaries
- Space / Enter toggles play — expected activation on a focused slider in most screen readers
- `aria-valuetext` for "0:32 of 1:45" announcements instead of the raw second count

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `next build` — compiles
- [ ] Manual: tab to timeline, confirm focus ring visible, press → right arrow, verify playhead advances 1s; shift+→ advances 5s; Home → 0:00, End → end; Space → play/pause
- [ ] Manual: with VoiceOver/NVDA, focus the bar and confirm announcement is "Pattern timeline — click or use arrow keys to scrub, 0:32 of 1:45"
