### PR TITLE
Timestamped peer-review comments (#127)

### DIFF
--- a/src/app/peer-review/page.tsx
+++ b/src/app/peer-review/page.tsx
@@ -21,7 +21,13 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { Checkbox } from "@/components/ui/checkbox";
-import { Loader2, CheckCircle2, AlertCircle } from "lucide-react";
+import {
+  Loader2,
+  CheckCircle2,
+  AlertCircle,
+  Pin,
+  Trash2,
+} from "lucide-react";
 import {
   Select,
   SelectContent,
@@ -29,6 +35,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+
+function formatPinTime(sec: number): string {
+  if (!Number.isFinite(sec) || sec < 0) return "0:00";
+  const m = Math.floor(sec / 60);
+  const s = Math.floor(sec % 60);
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}
 
 export default function PeerReviewPage() {
   // useSearchParams needs a Suspense boundary under Next's static
@@ -62,6 +75,19 @@ function PeerReviewInner() {
   // stays off unless the reviewer actively checks the box.
   const [trainingConsent, setTrainingConsent] = useState(false);
   const videoRef = useRef<HTMLVideoElement | null>(null);
+  // Timestamped comments pinned to specific moments in the clip.
+  // Reviewers get a "Pin at current time" button over the video and
+  // can compose short comments against the second they saw the
+  // issue (#127). Max of MAX_PINS to keep the UI/timeline readable.
+  const [pins, setPins] = useState<
+    Array<{ timestamp_sec: number; note: string }>
+  >([]);
+  const [pinDraft, setPinDraft] = useState<{
+    timestamp_sec: number;
+    note: string;
+  } | null>(null);
+  const MAX_PINS = 20;
+  const MAX_PIN_CHARS = 200;
 
   useEffect(() => {
     if (!token) return;
@@ -105,6 +131,12 @@ function PeerReviewInner() {
         teamwork_score: teamwork,
         presentation_score: presentation,
         overall_notes: notes.trim() || null,
+        per_moment_notes: pins
+          .map((p) => ({
+            timestamp_sec: Math.round(p.timestamp_sec * 10) / 10,
+            note: p.note.trim(),
+          }))
+          .filter((p) => p.note.length > 0),
         training_consent: trainingConsent,
       });
       setSubmitted(true);
@@ -203,6 +235,155 @@ function PeerReviewInner() {
             )}
           </CardContent>
         </Card>
+
+        {/* Timestamped pins — reviewers click at a specific second
+            and leave a short comment tied to that moment. This is
+            the most useful thing humans add over the AI score: "at
+            0:34 you anchored late" beats "Timing: 7/10" every time.
+            Hidden when the video is unavailable. See #127. */}
+        {ctx.video_url && (
+          <Card>
+            <CardHeader className="pb-3 flex flex-row items-center justify-between space-y-0 gap-2">
+              <div>
+                <CardTitle className="text-base flex items-center gap-2">
+                  <Pin className="h-4 w-4 text-primary" />
+                  Pin a comment at a specific moment
+                </CardTitle>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  Pause at the moment you want to comment on, then
+                  click &ldquo;Pin here.&rdquo; Dancers find
+                  &ldquo;anchor late at 0:34&rdquo; more actionable
+                  than a category score.
+                </p>
+              </div>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                disabled={pins.length >= MAX_PINS || pinDraft !== null}
+                onClick={() => {
+                  const t = videoRef.current?.currentTime ?? 0;
+                  setPinDraft({ timestamp_sec: t, note: "" });
+                }}
+                title={
+                  pins.length >= MAX_PINS
+                    ? `Max ${MAX_PINS} pins per review`
+                    : "Pin at the current playback time"
+                }
+              >
+                <Pin className="h-3.5 w-3.5 sm:mr-2" />
+                <span className="hidden sm:inline">Pin here</span>
+              </Button>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              {/* Draft composer — appears when user clicks Pin and
+                  disappears when they Save or Cancel. Kept
+                  single-active so the UI doesn't turn into a
+                  comment-thread mess. */}
+              {pinDraft && (
+                <div className="rounded-md border border-primary/50 bg-primary/5 p-2.5 space-y-2">
+                  <div className="flex items-center gap-2 text-xs">
+                    <span className="font-mono tabular-nums font-medium">
+                      {formatPinTime(pinDraft.timestamp_sec)}
+                    </span>
+                    <span className="text-muted-foreground">
+                      Pinned to this moment
+                    </span>
+                  </div>
+                  <textarea
+                    value={pinDraft.note}
+                    onChange={(e) =>
+                      setPinDraft({
+                        ...pinDraft,
+                        note: e.target.value.slice(0, MAX_PIN_CHARS),
+                      })
+                    }
+                    autoFocus
+                    rows={2}
+                    maxLength={MAX_PIN_CHARS}
+                    placeholder="e.g. Anchor hit late — settled on 7 instead of 5 & 6."
+                    className="w-full rounded-md border border-input bg-background px-2.5 py-1.5 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  />
+                  <div className="flex items-center justify-between">
+                    <span className="text-[10px] text-muted-foreground tabular-nums">
+                      {pinDraft.note.length} / {MAX_PIN_CHARS}
+                    </span>
+                    <div className="flex gap-2">
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => setPinDraft(null)}
+                      >
+                        Cancel
+                      </Button>
+                      <Button
+                        type="button"
+                        size="sm"
+                        disabled={pinDraft.note.trim().length === 0}
+                        onClick={() => {
+                          setPins((prev) =>
+                            [...prev, pinDraft].sort(
+                              (a, b) => a.timestamp_sec - b.timestamp_sec
+                            )
+                          );
+                          setPinDraft(null);
+                        }}
+                      >
+                        Save pin
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              )}
+              {/* Saved pins list — each row seeks the video back to
+                  the pinned second on click. */}
+              {pins.length === 0 && !pinDraft && (
+                <p className="text-xs text-muted-foreground text-center py-2">
+                  No pins yet. This is optional — leave category
+                  scores below even if you skip pins.
+                </p>
+              )}
+              {pins.map((p, i) => (
+                <div
+                  key={`${p.timestamp_sec}-${i}`}
+                  className="flex items-start gap-2 rounded-md border border-border bg-muted/10 p-2 text-sm"
+                >
+                  <button
+                    type="button"
+                    onClick={() => {
+                      const v = videoRef.current;
+                      if (v) {
+                        v.currentTime = p.timestamp_sec;
+                        v.play().catch(() => {
+                          /* autoplay may be blocked */
+                        });
+                      }
+                    }}
+                    className="font-mono tabular-nums text-primary hover:underline shrink-0"
+                    title="Jump to this moment"
+                  >
+                    {formatPinTime(p.timestamp_sec)}
+                  </button>
+                  <p className="flex-1 min-w-0 text-muted-foreground whitespace-pre-wrap break-words">
+                    {p.note}
+                  </p>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      setPins((prev) => prev.filter((_, idx) => idx !== i))
+                    }
+                    className="text-muted-foreground hover:text-destructive shrink-0"
+                    aria-label="Remove pin"
+                    title="Remove pin"
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </button>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+        )}
 
         <Card>
           <CardHeader className="pb-3">

--- a/src/components/analyze/peer-reviews-section.tsx
+++ b/src/components/analyze/peer-reviews-section.tsx
@@ -22,9 +22,17 @@ import {
   Copy,
   Loader2,
   MessageSquare,
+  Pin,
   UserPlus,
   X,
 } from "lucide-react";
+
+function formatPinTime(sec: number): string {
+  if (!Number.isFinite(sec) || sec < 0) return "0:00";
+  const m = Math.floor(sec / 60);
+  const s = Math.floor(sec % 60);
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}
 
 const CATEGORIES: Array<{ key: keyof PeerReview; label: string }> = [
   { key: "timing_score", label: "Timing" },
@@ -309,6 +317,41 @@ function ReviewCard({
           );
         })}
       </div>
+
+      {/* Timestamped pins from the reviewer (#127). Rendered as a
+          compact list of time + note pairs — the most useful thing
+          humans add over the AI score. */}
+      {review.per_moment_notes && review.per_moment_notes.length > 0 && (
+        <div className="space-y-1.5">
+          <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            <Pin className="h-3 w-3" />
+            <span className="uppercase tracking-wide font-medium">
+              Pinned moments
+            </span>
+            <span className="tabular-nums">
+              ({review.per_moment_notes.length})
+            </span>
+          </div>
+          <div className="space-y-1">
+            {review.per_moment_notes
+              .slice()
+              .sort((a, b) => a.timestamp_sec - b.timestamp_sec)
+              .map((p, i) => (
+                <div
+                  key={`pin-${i}-${p.timestamp_sec}`}
+                  className="flex items-start gap-2 rounded-md border border-border/60 bg-muted/20 p-2 text-sm"
+                >
+                  <span className="font-mono tabular-nums text-primary shrink-0">
+                    {formatPinTime(p.timestamp_sec)}
+                  </span>
+                  <p className="flex-1 min-w-0 text-muted-foreground whitespace-pre-wrap break-words">
+                    {p.note}
+                  </p>
+                </div>
+              ))}
+          </div>
+        </div>
+      )}
 
       {review.overall_notes && (
         <p className="text-sm whitespace-pre-wrap text-muted-foreground">


### PR DESCRIPTION
Closes #127 (v1).

## Summary
Timestamped peer-review comments — reviewers click "Pin here" to anchor a ≤200-char comment to the current playback second. Dancers see "anchor late at **0:34**" instead of just "Timing: 7/10".

**Good news:** the schema + backend were already wired — `peer_reviews.per_moment_notes jsonb`, FastAPI validator, and service-layer UPDATE all accept the field. The UI just didn't expose it. This PR is pure frontend.

## Changes
- **Reviewer page** (`/peer-review`) — new "Pin a comment at a specific moment" card between the video and the About-you block. "Pin here" grabs `videoRef.current.currentTime`. Inline composer, click-to-seek on saved pins, remove button. Single active draft (no nested thread mess). Cap of 20 pins per review so the UI stays readable.
- **Submit payload** — `submitPublicReview` now includes `per_moment_notes`, trimmed, rounded to 0.1s, and filtered to non-empty notes.
- **Owner side** (`PeerReviewsSection`) — new "Pinned moments" section per submitted review, sorted by timestamp, as a compact time + note list.

## Intentionally deferred to phase 2
- **Pin markers on the owner's `TimelineView`** (overlaid alongside pattern blocks with click-to-seek). Needs `TimelineView` to accept a `comments` prop + coordinate with `PeerReviewsSection` on the analysis page. Own PR.
- **Split `overall_notes` → `strengths[]` / `improvements[]`** structured lists. Needs schema + backend changes.
- **Reviewer credential weighting** (dancer level dropdown). Already have `reviewer_role`; weighting would need aggregation UX.
- **Emoji reactions on pattern blocks**.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `next build` — compiles, all pages generate
- [ ] Manual (reviewer): open a peer-review link, pause at ~0:30, click "Pin here", type "anchor late", Save. Verify pin row appears with the timestamp + click-to-seek jumps the video back to 0:30
- [ ] Manual (reviewer): add 3 pins, submit — verify success thank-you state
- [ ] Manual (owner): open the analysis after submission, confirm "Pinned moments (3)" section renders with the pins in time order
- [ ] Manual: hit the 20-pin cap; verify "Pin here" disables with the max-pins tooltip


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pinned moment notes feature for peer reviews: reviewers can create and save timestamped notes while watching videos
  * Pinned moments display with formatted timestamps and note content for easy reference
  * Notes are sorted and can be managed throughout the review process
  * New pinned moments section shows count and details of all saved pins

<!-- end of auto-generated comment: release notes by coderabbit.ai -->