### PR TITLE
Bump monthly video quota from 2 to 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ Includes WCS pattern presets, tempo ramp for progressive difficulty, timing accu
 ### Practice Timer
 Guided warm-up routines in 5, 15, or 30-minute sessions. Covers joint mobility, body isolation, walking practice, triple step drills, anchor variations, and pattern work.
 
-### Accounts & Plan Tiers
-- **Free** — 2 video analyses / month, 2-minute clips, unlimited music analysis
-- **Basic ($10/mo)** — 10 video analyses / month, 5-minute clips, unlimited music analysis
-- Per-user quota overrides on the `profiles` table for beta testers and refunds
-- Google-auth-free: email + password via Supabase Auth
+### Accounts & Quota
+- Free for everyone — 10 video analyses / month, up to ~3-minute clips, unlimited music analysis
+- Monthly allowance resets on the 1st
+- Per-user `monthly_video_override` / `max_video_seconds_override` on `profiles` for comp credits
+- Email + password via Supabase Auth
 
 ### Feedback
 - In-app feedback form writes to a `feature_requests` table (RLS-protected)

--- a/api/src/wcs_api/settings.py
+++ b/api/src/wcs_api/settings.py
@@ -32,10 +32,10 @@ class Settings(BaseSettings):
     r2_secret_access_key: str = ""
     r2_bucket: str = "swingflow-uploads"
     r2_upload_ttl_seconds: int = 3600
-    # Everyone gets 2 video analyses per month (resets on the 1st via
+    # Everyone gets 10 video analyses per month (resets on the 1st via
     # the month-start usage-events query). Per-user comp credits live
     # on the profiles.monthly_video_override column.
-    monthly_video: int = 2
+    monthly_video: int = 10
     max_video_seconds: int = 200
 
     @property

--- a/src/app/(app)/analyze/page.tsx
+++ b/src/app/(app)/analyze/page.tsx
@@ -291,7 +291,7 @@ export default function AnalyzePage() {
       </div>
 
       {/* Quota card — purely informational. Free for everyone; the
-          counter just helps users pace their 2/month allowance. */}
+          counter just helps users pace their 10/month allowance. */}
       <Card>
         <CardHeader className="pb-3">
           <CardTitle className="text-base">Monthly usage</CardTitle>

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -115,7 +115,7 @@ export default function LoginPage() {
             </TabsContent>
             <TabsContent value="signup" className="pt-2">
               <p className="text-center text-xs text-muted-foreground">
-                Free tier: 2 video analyses / month. Music analysis is
+                Free tier: 10 video analyses / month. Music analysis is
                 unlimited.
               </p>
             </TabsContent>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -93,7 +93,7 @@ export default function HomePage() {
                 </Button>
               </div>
               <p className="text-xs text-muted-foreground pt-2">
-                Free · 2 video analyses / month · Unlimited music analysis
+                Free · 10 video analyses / month · Unlimited music analysis
               </p>
             </div>
           </div>
@@ -397,7 +397,7 @@ export default function HomePage() {
                     <li className="flex items-start gap-2">
                       <Check className="h-4 w-4 text-primary mt-0.5 shrink-0" />
                       <span>
-                        2 dance video analyses / month (up to ~3 min each)
+                        10 dance video analyses / month (up to ~3 min each)
                       </span>
                     </li>
                     <li className="flex items-start gap-2">
@@ -494,7 +494,7 @@ export default function HomePage() {
             />
             <FaqItem
               q="What if I run out of videos for the month?"
-              a="Your 2/month allowance resets on the 1st of each month. If you need more sooner, drop us a line via the Feedback page — we can usually comp extra credits for active users."
+              a="Your 10/month allowance resets on the 1st of each month. If you need more sooner, drop us a line via the Feedback page — we can usually comp extra credits for active users."
             />
             <FaqItem
               q="Do you support longer videos?"


### PR DESCRIPTION
## Why

Prioritizing learning feedback over a conservative cost ceiling. Current 2/month hits active users fast.

## Cost context

Real numbers from Supabase across the last 26 analyses with cost tracked:

| metric | value |
|---|---|
| mean | $0.416 |
| median | $0.439 |
| range | $0.19 – $0.74 |
| model | gemini-3.1-pro-preview (all) |
| mean duration | 113s |

**Worst-case impact:** $4.20/user/mo (vs $0.84 today). At 50 active users on full quota ≈ $210/mo ceiling.

## What

- `api/settings.py`: `monthly_video 2 → 10`
- Landing: hero subtitle, pricing card, FAQ answer
- Login: signup tab copy
- Analyze page: quota-card comment (UI pulls limit dynamically from `/analyze/video/quota`, so no hardcoded number)
- README: collapsed old 2-tier block into one free-tier description

## Deploy note

Railway needs a redeploy after merge so `settings.monthly_video = 10` takes effect. **But the redeploy is still blocked on `supabase/schema.sql` being applied in prod** — #121's new `claim_video_quota` RPC must exist first or `/analyze/video` 500s. Sequence: run schema.sql → redeploy Railway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Features**
  * Increased free tier allowance from 2 to 10 video analyses per month.
  * Unified to single free offering for all users (tiered pricing removed).

* **Documentation**
  * Updated README with revised quota structure and authentication details.
  * Updated UI displays across login, signup, and pricing pages to reflect new monthly limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->