### PR TITLE
Fix blank share-card canvas (race with Radix portal mount)

### DIFF
--- a/src/components/analyze/share-card-dialog.tsx
+++ b/src/components/analyze/share-card-dialog.tsx
@@ -9,7 +9,12 @@
 // the issue originally suggested — isn't an option. Canvas rendering
 // in the browser covers the same ground for this deployment model.
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import {
   Dialog,
   DialogContent,
@@ -216,27 +221,63 @@ export function ShareCardDialog({
   const songStyle =
     (result as { song_style?: string }).song_style ?? null;
 
-  // Redraw whenever the dialog opens or the data changes. Fonts
-  // in a canvas context don't pick up web-font swaps, so rendering
-  // on open ensures the user sees the up-to-date values in the
-  // expected Inter-like sans stack.
-  useEffect(() => {
+  // Radix Dialog mounts DialogContent inside a portal + runs an
+  // enter animation. If we draw in a plain useEffect the canvas ref
+  // has landed in the DOM but the portal mount + layout cycle isn't
+  // guaranteed to be finished on this tick — drawing races and leaves
+  // a blank buffer in some browsers. useLayoutEffect + rAF gives us a
+  // frame after the browser has committed the mount, when getContext
+  // is reliable. Also wait for document.fonts.ready (when available)
+  // so text is drawn with the declared Inter-family stack rather than
+  // whatever glyph state the browser happens to have on first paint.
+  useLayoutEffect(() => {
     if (!open) return;
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-    const ctx = canvas.getContext("2d");
-    if (!ctx) return;
-    canvas.width = CARD_SIZE;
-    canvas.height = CARD_SIZE;
-    drawCard(ctx, {
-      score: result.overall?.score ?? null,
-      grade: result.overall?.grade ?? null,
-      role,
-      level: observedLevel ?? competitionLevel,
-      bpm,
-      style: songStyle,
-      url: shareUrl,
+    let cancelled = false;
+
+    const paint = () => {
+      const canvas = canvasRef.current;
+      if (!canvas || cancelled) return;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) {
+        console.error("share-card: 2d context unavailable");
+        return;
+      }
+      canvas.width = CARD_SIZE;
+      canvas.height = CARD_SIZE;
+      try {
+        drawCard(ctx, {
+          score: result.overall?.score ?? null,
+          grade: result.overall?.grade ?? null,
+          role,
+          level: observedLevel ?? competitionLevel,
+          bpm,
+          style: songStyle,
+          url: shareUrl,
+        });
+      } catch (err) {
+        // Surface, don't swallow — a blank card is worse than a logged
+        // error because there's no way to diagnose it after the fact.
+        console.error("share-card: drawCard failed", err);
+      }
+    };
+
+    const rafId = requestAnimationFrame(() => {
+      const fonts = (
+        document as Document & { fonts?: { ready?: Promise<unknown> } }
+      ).fonts;
+      if (fonts?.ready) {
+        fonts.ready.then(() => {
+          if (!cancelled) paint();
+        });
+      } else {
+        paint();
+      }
     });
+
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(rafId);
+    };
   }, [
     open,
     result,


### PR DESCRIPTION
## Symptom

Share card dialog opens, canvas is visible at the right aspect ratio, but the preview is **completely blank** — no gradient, no wordmark, no score. Download yielded the same blank PNG.

![blank-share-card](https://user-images.githubusercontent.com/placeholder.png)

## Cause

Drawing was racing Radix Dialog's portal-mount + enter-animation cycle. The \`useEffect\` fired with the canvas ref populated, but on some browsers the drawing buffer isn't stable on that tick, so the fill / text calls landed on a buffer that was then discarded by the mount completion.

## Fix

- \`useEffect\` → \`useLayoutEffect\` so paint runs before browser paint, not after.
- Defer one \`requestAnimationFrame\` so the browser has committed the portal mount before touching \`getContext\` + setting width/height.
- Await \`document.fonts.ready\` (when available) before drawing, so text renders with the declared Inter-family stack instead of whatever glyph state the browser has on first open.
- Wrap \`drawCard\` in \`try/catch\` with \`console.error\` — a silent swallow is why this took a round-trip to diagnose. Next failure will be visible in devtools.
- Guard mid-cycle unmount with a \`cancelled\` flag + \`cancelAnimationFrame\` on cleanup.

## Scope

- Only \`src/components/analyze/share-card-dialog.tsx\`.
- No API changes, no layout changes, no visual difference when it was already working.
- \`+61 / -20\`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed timing issues and race conditions in the Share Card dialog that could cause rendering problems when opened.
  * Improved text rendering to ensure fonts load correctly before display.
  * Enhanced error reporting for troubleshooting canvas rendering issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->