### PR TITLE
Beat map as separate graph + move monthly usage to settings

### DIFF
--- a/src/app/(app)/analyze/page.tsx
+++ b/src/app/(app)/analyze/page.tsx
@@ -290,43 +290,9 @@ export default function AnalyzePage() {
         </p>
       </div>
 
-      {/* Quota card — purely informational. Free for everyone; the
-          counter just helps users pace their 10/month allowance. */}
-      <Card>
-        <CardHeader className="pb-3">
-          <CardTitle className="text-base">Monthly usage</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-2">
-          {quotaLoading ? (
-            <div className="flex items-center gap-2 text-sm text-muted-foreground">
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              Loading…
-            </div>
-          ) : quotaError ? (
-            <p className="text-sm text-destructive">{quotaError}</p>
-          ) : quota ? (
-            <>
-              <div className="flex items-center justify-between text-sm">
-                <span>
-                  {quota.used} of {quota.limit} videos used
-                </span>
-                <span className="text-muted-foreground">
-                  up to {Math.round(quota.max_seconds / 60)} min each
-                </span>
-              </div>
-              <Progress
-                value={Math.min(100, (quota.used / quota.limit) * 100)}
-                className="h-2"
-              />
-              {isPaywalled && state.status !== "success" && (
-                <p className="text-xs text-muted-foreground">
-                  Your allowance resets on the 1st of next month.
-                </p>
-              )}
-            </>
-          ) : null}
-        </CardContent>
-      </Card>
+      {/* Monthly usage card moved to /settings — analyze page is
+          about picking a clip, not staring at a quota bar. The paywall
+          banner still renders below when the user runs out. */}
 
       {/* How scoring works — quietly collapsed by default so it
           doesn't dominate the page, but always accessible for users

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { Info, Trash2 } from "lucide-react";
+import { MonthlyUsageCard } from "@/components/settings/monthly-usage-card";
 
 export default function SettingsPage() {
   const handleClearData = () => {
@@ -23,6 +24,8 @@ export default function SettingsPage() {
         <h1 className="text-2xl font-bold">Settings</h1>
         <p className="text-muted-foreground">App preferences</p>
       </div>
+
+      <MonthlyUsageCard />
 
       <Card>
         <CardHeader>

--- a/src/components/analyze/timeline-view.tsx
+++ b/src/components/analyze/timeline-view.tsx
@@ -422,6 +422,21 @@ export function TimelineView({
         />
       )}
 
+      {/* Beat map — rendered as its own separate graph ABOVE the
+          pattern timeline so users can visually track the rhythm
+          independently of pattern blocks. Shows detected beats,
+          downbeats, phrase markers, and AI-flagged off-beat moments.
+          BeatPanel renders a clear empty state when beat_grid is
+          missing (silent-fallback or old analyses) rather than
+          hiding the whole section. */}
+      <BeatPanel
+        grid={result.beat_grid}
+        offBeats={offBeats}
+        effectiveDuration={effectiveDuration}
+        currentTime={currentTime}
+        onSeek={seek}
+      />
+
       {/* Pattern timeline = the scrubber (single source of truth) */}
       <div className="space-y-1.5">
         <div className="flex items-center justify-between text-xs text-muted-foreground gap-2">
@@ -663,19 +678,7 @@ export function TimelineView({
           })()}
         </div>
 
-        {/* Beat-map strip — renders the detected beat grid underneath
-            the pattern timeline so users practicing at slow speed can
-            visually track boom-tick-boom-tick against what they hear.
-            Hidden when beat detection failed (silent-fallback path). */}
-        {result.beat_grid &&
-          (result.beat_grid.beats?.length ?? 0) > 0 && (
-            <BeatStrip
-              grid={result.beat_grid}
-              effectiveDuration={effectiveDuration}
-              currentTime={currentTime}
-              onSeek={seek}
-            />
-          )}
+        {/* Beat map moved above the pattern timeline — see BeatPanel. */}
 
         {/* Legend */}
         <div className="flex flex-wrap items-center gap-3 text-[10px] text-muted-foreground pt-1">
@@ -1007,13 +1010,57 @@ function SpeedSelector({
   );
 }
 
+function BeatPanel({
+  grid,
+  offBeats,
+  effectiveDuration,
+  currentTime,
+  onSeek,
+}: {
+  grid: VideoScoreResult["beat_grid"] | null | undefined;
+  offBeats: Array<{ t: number; description?: string; beat_count?: string }>;
+  effectiveDuration: number;
+  currentTime: number;
+  onSeek: (t: number) => void;
+}) {
+  // Empty state — beat detection didn't run or failed. Render a clear
+  // placeholder instead of silently hiding the strip so the user can
+  // tell this is a missing signal vs. a UI bug.
+  const hasBeats = grid && (grid.beats?.length ?? 0) > 0;
+  if (!hasBeats) {
+    return (
+      <div className="space-y-1.5">
+        <div className="flex items-center justify-between text-xs text-muted-foreground">
+          <span className="font-medium uppercase tracking-wide">Beat map</span>
+          <span className="text-[10px]">not available</span>
+        </div>
+        <div className="h-7 rounded-md bg-muted/20 border border-dashed border-border flex items-center justify-center text-[11px] text-muted-foreground px-3">
+          Beat detection wasn&rsquo;t available for this analysis — re-analyze
+          to generate a beat grid.
+        </div>
+      </div>
+    );
+  }
+  return (
+    <BeatStrip
+      grid={grid}
+      offBeats={offBeats}
+      effectiveDuration={effectiveDuration}
+      currentTime={currentTime}
+      onSeek={onSeek}
+    />
+  );
+}
+
 function BeatStrip({
   grid,
+  offBeats,
   effectiveDuration,
   currentTime,
   onSeek,
 }: {
   grid: NonNullable<VideoScoreResult["beat_grid"]>;
+  offBeats: Array<{ t: number; description?: string; beat_count?: string }>;
   effectiveDuration: number;
   currentTime: number;
   onSeek: (t: number) => void;
@@ -1070,7 +1117,7 @@ function BeatStrip({
   }, [visibleBeats, downbeatSet]);
 
   return (
-    <div className="space-y-1.5 pt-1">
+    <div className="space-y-1.5">
       <div className="flex items-center justify-between text-xs text-muted-foreground">
         <span className="font-medium uppercase tracking-wide">Beat map</span>
         <span className="text-[10px] tabular-nums">
@@ -1082,11 +1129,11 @@ function BeatStrip({
       </div>
       <div
         ref={barRef}
-        className="relative h-7 rounded-md bg-muted/30 border border-border overflow-hidden cursor-pointer"
+        className="relative h-8 rounded-md bg-muted/30 border border-border overflow-hidden cursor-pointer"
         onClick={scrub}
         role="img"
         aria-label={`Beat map — ${downbeats.length} bars at ${grid.bpm.toFixed(0)} BPM`}
-        title="Click to seek. Tall ticks = downbeats (boom). Short = offbeats (tick)."
+        title="Click to seek. Tall ticks = downbeats (boom). Short = offbeats (tick). Red dots = AI-flagged off-beat."
       >
         {/* Beat ticks */}
         {renderedBeats.map((b, i) => {
@@ -1114,6 +1161,19 @@ function BeatStrip({
             title={`Phrase ${i + 1} at ${formatTime(t)}`}
           />
         ))}
+        {/* Off-beat markers — red dots from AI timing analysis. */}
+        {offBeats.map((m, i) => (
+          <div
+            key={`ob-${i}`}
+            className="absolute top-0 h-2 w-2 -translate-x-1/2 rounded-full bg-rose-500 shadow-[0_0_0_1px_rgba(0,0,0,0.5)] pointer-events-auto"
+            style={{ left: `${(m.t / effectiveDuration) * 100}%` }}
+            title={
+              m.description
+                ? `Off-beat at ${m.beat_count ?? formatTime(m.t)}: ${m.description}`
+                : `Off-beat at ${formatTime(m.t)}`
+            }
+          />
+        ))}
         {/* Playhead */}
         <div
           className="absolute top-0 bottom-0 w-[2px] bg-foreground pointer-events-none"
@@ -1135,6 +1195,12 @@ function BeatStrip({
           <span className="flex items-center gap-1.5">
             <span className="inline-block h-3 w-[2px] bg-amber-400/60" />
             phrase (every 8)
+          </span>
+        )}
+        {offBeats.length > 0 && (
+          <span className="flex items-center gap-1.5">
+            <span className="inline-block h-2 w-2 rounded-full bg-rose-500" />
+            off-beat ({offBeats.length})
           </span>
         )}
       </div>

--- a/src/components/settings/monthly-usage-card.tsx
+++ b/src/components/settings/monthly-usage-card.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+// Monthly video-analysis quota. Moved from the analyze page to the
+// settings page — the analyze page should be about picking + uploading
+// a clip, and the quota counter was taking up that top real estate.
+// Self-contained: fetches its own quota so settings doesn't need the
+// larger useVideoAnalysis hook (which also owns upload state).
+
+import { useEffect, useState } from "react";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+import { Loader2, Gauge } from "lucide-react";
+import { getVideoQuota, type VideoQuota } from "@/lib/wcs-api";
+
+export function MonthlyUsageCard() {
+  const [quota, setQuota] = useState<VideoQuota | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const q = await getVideoQuota();
+        if (!cancelled) setQuota(q);
+      } catch (e) {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : "Failed to load quota");
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base flex items-center gap-2">
+          <Gauge className="h-4 w-4" />
+          Monthly usage
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {loading ? (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            Loading…
+          </div>
+        ) : error ? (
+          <p className="text-sm text-destructive">{error}</p>
+        ) : quota ? (
+          <>
+            <div className="flex items-center justify-between text-sm">
+              <span>
+                {quota.used} of {quota.limit} videos used this month
+              </span>
+              <span className="text-muted-foreground">
+                up to {Math.round(quota.max_seconds / 60)} min each
+              </span>
+            </div>
+            <Progress
+              value={Math.min(100, (quota.used / quota.limit) * 100)}
+              className="h-2"
+            />
+            <p className="text-xs text-muted-foreground pt-1">
+              Your allowance resets on the 1st of each month.
+            </p>
+          </>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
Addresses two user asks from the latest round of feedback.

## 1. Beat map as a SEPARATE graph

**Feedback:** \"I don't see any beat map, I just see the patterns. I want the beat graph separate from pattern timelines in both the places.\"

Three changes:

### a) Promote beat map above the pattern timeline

It was rendered BELOW the pattern timeline as a subtle addition (from #120). Now moved ABOVE with its own labeled section (\"BEAT MAP\"), so it reads as a distinct graph. Cascades to both the analysis page and the /practice play-along card (both render via TimelineView).

### b) Off-beat markers on the beat strip

The AI's \`off_beat_moments\` timestamps now appear as red dots on the beat strip with a hover tooltip (\"Off-beat at {beat_count}: {description}\"). Previously only surfaced as text notes.

### c) Explicit empty state when beat_grid is missing

The user reported not seeing a beat map. Root cause: **every analysis in their history has \`beat_grid: null\`** — beat tracking is silent-failing on Railway. The old code just hid the whole strip when grid was missing, so the user couldn't tell if it was broken or just not implemented.

Now the section always renders: either the populated strip, OR a labeled empty-state card — \"Beat map | not available — re-analyze to generate a beat grid\". Makes the missing signal visible, so the next question becomes \"why is beat tracking silent-failing on Railway\" rather than \"where's the feature?\".

**Infra follow-up (separate work):** all analyses have \`beat_grid: null\`, which means the beat tracker's silent-fail path is triggered on every run. Likely Beat This! (CPJKU) and librosa both failing on Railway's container. Needs log dive + a fix.

## 2. Move \"Monthly usage\" to /settings

The analyze page was burning top real estate on a quota bar. Users arrive at /analyze to pick a clip and start an upload — they don't need a full-width Monthly-usage card every single time. Moved it to /settings where it belongs alongside data-storage info.

- New \`src/components/settings/monthly-usage-card.tsx\` — self-contained (fetches its own quota); settings doesn't need to pull in \`useVideoAnalysis\` (which owns upload state).
- The paywall banner inside /analyze still renders when users are out of quota. Only the always-on counter moved.

## Files

\`+170 / -53\` across:
- \`src/components/analyze/timeline-view.tsx\` — new BeatPanel wrapper, offBeats prop, empty state, render-above-pattern-timeline
- \`src/app/(app)/analyze/page.tsx\` — remove quota card block
- \`src/app/(app)/settings/page.tsx\` — slot MonthlyUsageCard above About
- \`src/components/settings/monthly-usage-card.tsx\` — new, self-contained

## Verified

- \`npx tsc --noEmit\` clean
- BeatPanel branches correctly for both null and populated grids
- No dead imports on /analyze

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced beat visualization with AI-detected off-beat markers displayed on the timeline, including improved legend and formatting

* **Changes**
  * Relocated monthly usage quota information from the analyze page to the settings page, now displaying usage limits and monthly reset details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->