### PR TITLE
Beat map shows effective BPM at playback rate + tighten musicality constraints

### DIFF
--- a/api/src/wcs_api/services/video_analysis/prompts.py
+++ b/api/src/wcs_api/services/video_analysis/prompts.py
@@ -1147,10 +1147,19 @@ Respond in this exact JSON format. Fill `reasoning` BEFORE `score` in each categ
 Constraints on musical_moments:
 - This field is independent of patterns. It's your audio-first analysis: listen to the song and identify moments where the music DEMANDS a response — a horn stab, a bass drop, the top of a chorus, a vocal break, a rhythmic hit. Then judge whether the couple caught it.
 - "Caught" means their movement aligned with the musical moment: an anchor that settles on the break, a freeze that matches a stop, a body roll that hits with the horn, a head snap on the accent. "Missed" means they kept dancing past it as if it weren't there.
-- Target: 4-12 moments per 90s of dancing, focused on the most salient events. Do NOT enumerate every beat. Pick the musical peaks that a dancer should be responding to.
-- Prefer moments that are unambiguous — a clear stop, a clear hit, a clear phrase top — over vague "build" moments.
+
+- **DEMANDS-A-RESPONSE TEST.** Before listing any moment, ask: "Would a reasonable WCS instructor, watching this clip with sound on, say this music had a clear event the couple should have interpreted?" If the answer is "not really — it's a groove" or "the music kept going", DON'T list it. Phrase tops, tempo shifts, and chord changes on their own are NOT enough — they need to be accompanied by a specific audible event (horn stab, drum fill, stop, bass drop, vocal break, rhythmic hit).
+- Do NOT list "phrase top" or "tempo shift" or "phrase boundary" as musical moments unless there is ALSO a specific audible hit at that moment. A phrase boundary in continuous dance music is not something a Novice-level dancer needs to catch.
+- **PER-LEVEL CALIBRATION.** Calibrate which moments to list based on the dancer's observed_level:
+  · Newcomer / Novice → list 0-3 moments per 90s of dancing. ONLY list unambiguous hits (stops, drops, horn stabs that stop the music briefly). These are the ones even a learner should catch. Staying on beat through a phrase boundary is NOT missing a moment — leave it off the list entirely.
+  · Intermediate → list 2-6 moments per 90s. Include the clear hits AND medium-salience events (strong breaks, phrase tops WITH an audible hit, vocal stabs). For moments where the couple stayed on beat with no drop of energy but didn't specifically interpret, skew toward caught=true (they're level-appropriate).
+  · Advanced / All-Star / Champion → list 4-12 moments per 90s. Now phrase tops, builds, and subtle micro-musicality are fair game — these dancers are expected to interpret broader musical structure, not just hits.
+
+- **PREFER CAUGHT=TRUE AT LOW LEVELS WHEN AMBIGUOUS.** If it's a Newcomer/Novice couple and the music has a subtle event and they just kept the pattern clean through it, mark caught=true. "They stayed in the dance through the moment" is the bar at that level — save caught=false for clear failures (e.g. the music stops and they keep moving, or there's a horn stab and they walk through it with no response).
+- Target density after filtering: 0-12 moments total for a 90s dance, with the low end for Newcomer/Novice and the high end for Advanced+. A Novice-level 90s dance with 3 moments all marked missed should make you suspicious — recheck whether those were truly demanding moments or whether you're scoring the dancer at a higher tier than observed.
+- Prefer moments that are unambiguous — a clear stop, a clear hit, a clear phrase top WITH an audible hit — over vague "build" moments.
 - Each timestamp_sec is a single moment in time (the moment of the musical event), not a range.
-- If the music is too continuous to pick standout moments (pure groove, no hits), return an empty array rather than inventing filler.
+- If the music is too continuous to pick standout moments (pure groove, no hits), return an empty array rather than inventing filler. An empty array is the CORRECT answer for many Novice-level clips where the song is a continuous groove.
 
 Constraints on follower_initiative:
 - Capture moments where the FOLLOWER authored something — not just executed what was led. Modern WCS follows co-create: they hijack anchors, add syncopations, style through bass walks, interpret the music on their own. This field surfaces those moments.

--- a/src/components/analyze/timeline-view.tsx
+++ b/src/components/analyze/timeline-view.tsx
@@ -434,6 +434,7 @@ export function TimelineView({
         offBeats={offBeats}
         effectiveDuration={effectiveDuration}
         currentTime={currentTime}
+        playbackRate={playbackRate}
         onSeek={seek}
       />
 
@@ -1015,12 +1016,14 @@ function BeatPanel({
   offBeats,
   effectiveDuration,
   currentTime,
+  playbackRate,
   onSeek,
 }: {
   grid: VideoScoreResult["beat_grid"] | null | undefined;
   offBeats: Array<{ t: number; description?: string; beat_count?: string }>;
   effectiveDuration: number;
   currentTime: number;
+  playbackRate: number;
   onSeek: (t: number) => void;
 }) {
   // Empty state — beat detection didn't run or failed. Render a clear
@@ -1047,6 +1050,7 @@ function BeatPanel({
       offBeats={offBeats}
       effectiveDuration={effectiveDuration}
       currentTime={currentTime}
+      playbackRate={playbackRate}
       onSeek={onSeek}
     />
   );
@@ -1057,12 +1061,14 @@ function BeatStrip({
   offBeats,
   effectiveDuration,
   currentTime,
+  playbackRate,
   onSeek,
 }: {
   grid: NonNullable<VideoScoreResult["beat_grid"]>;
   offBeats: Array<{ t: number; description?: string; beat_count?: string }>;
   effectiveDuration: number;
   currentTime: number;
+  playbackRate: number;
   onSeek: (t: number) => void;
 }) {
   const beats = grid.beats ?? [];
@@ -1120,8 +1126,25 @@ function BeatStrip({
     <div className="space-y-1.5">
       <div className="flex items-center justify-between text-xs text-muted-foreground">
         <span className="font-medium uppercase tracking-wide">Beat map</span>
-        <span className="text-[10px] tabular-nums">
-          {grid.bpm.toFixed(0)} BPM
+        <span
+          className="text-[10px] tabular-nums"
+          title={
+            playbackRate !== 1
+              ? `Song is ${grid.bpm.toFixed(0)} BPM at 1x; you're practicing at ${playbackRate}x → ${(grid.bpm * playbackRate).toFixed(0)} BPM effective`
+              : undefined
+          }
+        >
+          {playbackRate === 1 ? (
+            <>{grid.bpm.toFixed(0)} BPM</>
+          ) : (
+            <>
+              {(grid.bpm * playbackRate).toFixed(0)} BPM
+              <span className="text-muted-foreground/60">
+                {" "}
+                (song {grid.bpm.toFixed(0)} @ {playbackRate}x)
+              </span>
+            </>
+          )}
           {grid.source ? ` · ${grid.source}` : ""}
           {" · "}
           {downbeats.length} bars


### PR DESCRIPTION
Two fixes from user feedback on the new beat map section.

## 1. BPM tracks playback rate

> \"bpm doesn't change with this chart!\"

When you slow to 0.5x for practice, a 104 BPM song actually plays at 52 BPM — but the beat map header still said 104. Now it shows the effective BPM:

- **At 1x:** \`104 BPM · beat_this · 95 bars\` (unchanged)
- **At 0.5x:** \`52 BPM (song 104 @ 0.5x) · beat_this · 95 bars\`
- **At 1.5x:** \`156 BPM (song 104 @ 1.5x) · beat_this · 95 bars\`

Tooltip on the header explains the math. Threaded \`playbackRate\` through TimelineView → BeatPanel → BeatStrip so both the analysis page and the /practice play-along card get the live readout.

## 2. Musicality over-flagged "missed"

> \"I like this musicality thing but it doesn't seem correct!\"

Verified against the user's prod analysis (IMG_8665.MOV): the model listed 3 musical_moments — all phrase boundaries / tempo shifts, all marked **caught=false**. That's the textbook over-strict failure mode.

### Three constraint changes

**a) Demands-a-response test.** Phrase tops, tempo shifts, and chord changes alone are now explicitly NOT enough to list as a moment. They need an accompanying audible hit (horn stab, drum fill, stop, bass drop, vocal break).

**b) Per-level calibration.** Different bars for different levels:
- **Newcomer / Novice** → 0–3 moments per 90s, UNAMBIGUOUS hits only. Staying on beat through a phrase is NOT missing a moment.
- **Intermediate** → 2–6 moments, clear + medium-salience events; skew \`caught=true\` when the couple stayed on beat with no energy drop.
- **Advanced / All-Star / Champion** → 4–12 moments, broader musical structure in play.

**c) Prefer caught=true at low levels when ambiguous.** Explicit rule:
> \"They stayed in the dance through the moment\" IS the bar for Newcomer/Novice. Save caught=false for clear failures (music stops and they keep moving, horn stab and they walk through it with no response).

### Self-correction hook

> \"A Novice-level 90s dance with 3 moments all marked missed should make you suspicious — recheck whether those were truly demanding moments or whether you're scoring the dancer at a higher tier than observed.\"

Empty array explicitly labeled the CORRECT answer for continuous-groove songs.

## Scope

\`+37 / -5\` total — no schema change, no DB migration. The prompt change lands on the next analysis after Railway redeploys.

## Verified

- \`npx tsc --noEmit\` clean
- \`uv run python -c \"from wcs_api.services.video_analysis import prompts\"\` clean
- Re-checking your prod data: IMG_8665 had 3 moments = phrase_top / phrase_top / drop, all caught=false, desc = \"Tempo shift and phrase boundary\" / \"Major phrase change\" / \"Tempo shift near the end\" — exactly the over-listing pattern this PR targets. A Novice re-analyze with the new prompt should see most of those dropped or flipped to caught=true.