### PR TITLE
Label tab: users annotate their own patterns (#142)

### DIFF
--- a/src/app/(app)/label/editor/page.tsx
+++ b/src/app/(app)/label/editor/page.tsx
@@ -1,0 +1,708 @@
+"use client";
+
+// Label editor — scrub through a video and build a corrected pattern
+// timeline. Pre-populates from the AI's `patterns_identified` so the
+// user is correcting, not starting from zero.
+//
+// Kept deliberately simple: a table-style list of pattern blocks,
+// click a row to edit, plus a "Save" per row. The timeline renders
+// below so the user can see the blocks visually but editing happens
+// in the table to keep form focus stable.
+
+import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  ArrowLeft,
+  Plus,
+  Check,
+  Trash2,
+  Edit2,
+  Loader2,
+  AlertCircle,
+  Tags,
+  Sparkles,
+} from "lucide-react";
+import { useAnalysisHistory } from "@/hooks/use-analysis-history";
+import {
+  usePatternLabels,
+  type PatternLabel,
+  type LabelSource,
+  type PatternLabelDraft,
+} from "@/hooks/use-pattern-labels";
+import {
+  PATTERN_FAMILIES,
+  normalizePatternName,
+  variantsFor,
+  type PatternFamily,
+} from "@/lib/pattern-vocabulary";
+import { getViewUrl } from "@/lib/wcs-api";
+
+function formatTime(sec: number): string {
+  if (!Number.isFinite(sec) || sec < 0) return "0:00";
+  const m = Math.floor(sec / 60);
+  const s = (sec % 60).toFixed(1);
+  return `${m}:${s.padStart(4, "0")}`;
+}
+
+export default function LabelEditorPage() {
+  return (
+    <Suspense fallback={<p className="text-sm text-muted-foreground">Loading…</p>}>
+      <LabelEditorInner />
+    </Suspense>
+  );
+}
+
+function LabelEditorInner() {
+  const params = useSearchParams();
+  const analysisId = params.get("id");
+  const history = useAnalysisHistory();
+  const { labels, loading: labelsLoading, add, update, remove } =
+    usePatternLabels(analysisId);
+  const [videoUrl, setVideoUrl] = useState<string | null>(null);
+  const [videoError, setVideoError] = useState<string | null>(null);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [editing, setEditing] = useState<EditingState | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  const record = useMemo(
+    () =>
+      analysisId ? history.records.find((r) => r.id === analysisId) : null,
+    [history.records, analysisId]
+  );
+
+  // Load a playable URL for the video. Mirrors the analysis page.
+  useEffect(() => {
+    if (!record?.object_key) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const url = await getViewUrl(record.object_key!);
+        if (!cancelled) setVideoUrl(url);
+      } catch (e) {
+        if (!cancelled) {
+          setVideoError(e instanceof Error ? e.message : "Failed to load video");
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [record?.object_key]);
+
+  // AI-predicted patterns we can accept/edit. Only show ones inside
+  // the dance window when it's available.
+  const aiPatterns = useMemo(() => {
+    if (!record?.result?.patterns_identified) return [];
+    return record.result.patterns_identified.filter(
+      (p) => (p.start_time ?? 0) >= 0
+    );
+  }, [record]);
+
+  // Match AI patterns to existing labels — if the user has already
+  // accepted/edited an AI block, we know not to show it as pending.
+  const acceptedWindows = useMemo(() => {
+    const out = new Set<string>();
+    for (const l of labels) {
+      if (l.source === "ai_accepted" || l.source === "ai_edited") {
+        out.add(`${l.start_time.toFixed(2)}-${l.end_time.toFixed(2)}`);
+      }
+    }
+    return out;
+  }, [labels]);
+
+  const pendingAi = useMemo(() => {
+    return aiPatterns.filter((p) => {
+      const s = (p.start_time ?? 0).toFixed(2);
+      const e = (p.end_time ?? p.start_time ?? 0).toFixed(2);
+      return !acceptedWindows.has(`${s}-${e}`);
+    });
+  }, [aiPatterns, acceptedWindows]);
+
+  const handleAcceptAi = useCallback(
+    async (idx: number) => {
+      const p = aiPatterns[idx];
+      if (!p) return;
+      const start = p.start_time ?? 0;
+      const end = p.end_time ?? start + 3;
+      const normalized = normalizePatternName(p.name);
+      try {
+        setBusyId(`ai-${idx}`);
+        await add({
+          analysis_id: analysisId!,
+          start_time: start,
+          end_time: end,
+          name: normalized ?? (p.name ?? "unknown"),
+          variant: p.variant ?? null,
+          count: inferCount(normalized ?? p.name),
+          confidence: null,
+          source: "ai_accepted",
+          notes: null,
+        });
+      } catch (e) {
+        alert(e instanceof Error ? e.message : "Save failed");
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [add, aiPatterns, analysisId]
+  );
+
+  const handleEditAi = useCallback(
+    (idx: number) => {
+      const p = aiPatterns[idx];
+      if (!p) return;
+      const normalized = normalizePatternName(p.name);
+      setEditing({
+        mode: "new_from_ai",
+        start_time: p.start_time ?? 0,
+        end_time: p.end_time ?? (p.start_time ?? 0) + 3,
+        name: normalized ?? "",
+        variant: p.variant ?? "basic",
+        count: inferCount(normalized ?? p.name) ?? 6,
+        notes: p.notes ?? "",
+      });
+    },
+    [aiPatterns]
+  );
+
+  const handleAddAtPlayhead = useCallback(() => {
+    setEditing({
+      mode: "new",
+      start_time: Math.max(0, currentTime - 1.5),
+      end_time: currentTime + 1.5,
+      name: "",
+      variant: "basic",
+      count: 6,
+      notes: "",
+    });
+  }, [currentTime]);
+
+  const handleEditExisting = useCallback((l: PatternLabel) => {
+    setEditing({
+      mode: "edit",
+      id: l.id,
+      start_time: l.start_time,
+      end_time: l.end_time,
+      name: l.name,
+      variant: l.variant ?? "basic",
+      count: l.count ?? 6,
+      notes: l.notes ?? "",
+      originalSource: l.source,
+    });
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    if (!editing || !analysisId) return;
+    const draft: PatternLabelDraft = {
+      analysis_id: analysisId,
+      start_time: editing.start_time,
+      end_time: editing.end_time,
+      name: editing.name,
+      variant:
+        editing.variant && editing.variant !== "basic" ? editing.variant : null,
+      count: editing.count ?? null,
+      confidence: null,
+      source:
+        editing.mode === "new_from_ai"
+          ? "ai_edited"
+          : editing.mode === "edit" && editing.originalSource === "ai_accepted"
+            ? "ai_edited"
+            : editing.mode === "edit"
+              ? (editing.originalSource as LabelSource)
+              : "user",
+      notes: editing.notes?.trim() || null,
+    };
+    try {
+      if (editing.mode === "edit" && editing.id) {
+        await update(editing.id, draft);
+      } else {
+        await add(draft);
+      }
+      setEditing(null);
+    } catch (e) {
+      alert(e instanceof Error ? e.message : "Save failed");
+    }
+  }, [editing, analysisId, add, update]);
+
+  if (!analysisId) {
+    return (
+      <div className="max-w-lg">
+        <Card>
+          <CardContent className="py-8 text-center space-y-3">
+            <AlertCircle className="h-6 w-6 mx-auto text-muted-foreground" />
+            <p className="text-sm">No analysis selected.</p>
+            <Button asChild variant="outline" size="sm">
+              <Link href="/label">Back to list</Link>
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (history.loading) {
+    return <p className="text-sm text-muted-foreground">Loading analysis…</p>;
+  }
+
+  if (!record) {
+    return (
+      <div className="max-w-lg">
+        <Card>
+          <CardContent className="py-8 text-center space-y-3">
+            <AlertCircle className="h-6 w-6 mx-auto text-muted-foreground" />
+            <p className="text-sm">
+              Analysis not found. It may have been deleted.
+            </p>
+            <Button asChild variant="outline" size="sm">
+              <Link href="/label">Back to list</Link>
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-5xl space-y-4">
+      <header className="flex items-center gap-3 flex-wrap">
+        <Button asChild variant="ghost" size="sm">
+          <Link href="/label">
+            <ArrowLeft className="h-4 w-4 mr-1" />
+            All analyses
+          </Link>
+        </Button>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2 flex-wrap">
+            <Tags className="h-4 w-4 text-primary" />
+            <h1 className="text-lg font-semibold truncate">
+              {record.filename ?? "Labeling"}
+            </h1>
+            <Badge variant="outline" className="text-[10px]">
+              {labels.length} labeled
+            </Badge>
+            <Badge variant="outline" className="text-[10px]">
+              {pendingAi.length} AI pending
+            </Badge>
+          </div>
+        </div>
+        <Button size="sm" onClick={handleAddAtPlayhead}>
+          <Plus className="h-3.5 w-3.5 mr-1" />
+          Add at {formatTime(currentTime)}
+        </Button>
+      </header>
+
+      {videoError ? (
+        <Card>
+          <CardContent className="py-6 text-sm text-muted-foreground">
+            Couldn&rsquo;t load video: {videoError}. You can still label
+            by entering timestamps manually.
+          </CardContent>
+        </Card>
+      ) : videoUrl ? (
+        <Card>
+          <CardContent className="p-0 overflow-hidden">
+            <video
+              src={videoUrl}
+              controls
+              playsInline
+              className="w-full bg-black max-h-[60vh]"
+              onTimeUpdate={(e) =>
+                setCurrentTime((e.target as HTMLVideoElement).currentTime)
+              }
+            />
+          </CardContent>
+        </Card>
+      ) : !record.object_key ? (
+        <Card>
+          <CardContent className="py-6 text-sm text-muted-foreground">
+            No source video stored for this analysis. Labels only — enter
+            timestamps manually based on memory or external playback.
+          </CardContent>
+        </Card>
+      ) : (
+        <p className="text-sm text-muted-foreground">Loading video…</p>
+      )}
+
+      {/* AI suggestions — pending blocks the user hasn't accepted/edited yet. */}
+      {pendingAi.length > 0 && (
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm flex items-center gap-2">
+              <Sparkles className="h-4 w-4 text-primary" />
+              AI-predicted patterns ({pendingAi.length} pending review)
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-1.5">
+            {aiPatterns.map((p, idx) => {
+              const s = (p.start_time ?? 0).toFixed(2);
+              const e = (p.end_time ?? p.start_time ?? 0).toFixed(2);
+              const isAccepted = acceptedWindows.has(`${s}-${e}`);
+              if (isAccepted) return null;
+              return (
+                <div
+                  key={idx}
+                  className="flex items-center gap-2 flex-wrap p-2 rounded-md border border-border/60 bg-muted/10"
+                >
+                  <span className="font-mono text-xs tabular-nums text-muted-foreground w-24 shrink-0">
+                    {formatTime(p.start_time ?? 0)}–
+                    {formatTime(p.end_time ?? p.start_time ?? 0)}
+                  </span>
+                  <span className="text-sm truncate flex-1 min-w-[120px]">
+                    <span className="font-medium">{p.name}</span>
+                    {p.variant && p.variant !== "basic" && (
+                      <span className="text-muted-foreground">
+                        {" "}
+                        · {p.variant}
+                      </span>
+                    )}
+                  </span>
+                  <div className="flex items-center gap-1.5 shrink-0">
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="h-7"
+                      onClick={() => handleEditAi(idx)}
+                    >
+                      <Edit2 className="h-3 w-3 mr-1" />
+                      Fix
+                    </Button>
+                    <Button
+                      size="sm"
+                      className="h-7"
+                      onClick={() => handleAcceptAi(idx)}
+                      disabled={busyId === `ai-${idx}`}
+                    >
+                      {busyId === `ai-${idx}` ? (
+                        <Loader2 className="h-3 w-3 mr-1 animate-spin" />
+                      ) : (
+                        <Check className="h-3 w-3 mr-1" />
+                      )}
+                      Accept
+                    </Button>
+                  </div>
+                </div>
+              );
+            })}
+          </CardContent>
+        </Card>
+      )}
+
+      {/* User labels */}
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm">
+            Your labels ({labels.length})
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-1.5">
+          {labelsLoading ? (
+            <p className="text-xs text-muted-foreground">Loading…</p>
+          ) : labels.length === 0 ? (
+            <p className="text-xs text-muted-foreground">
+              None yet. Accept an AI block above or click
+              &ldquo;Add at {formatTime(currentTime)}&rdquo;.
+            </p>
+          ) : (
+            labels.map((l) => (
+              <div
+                key={l.id}
+                className="flex items-center gap-2 flex-wrap p-2 rounded-md border border-border/60"
+              >
+                <span className="font-mono text-xs tabular-nums text-muted-foreground w-24 shrink-0">
+                  {formatTime(l.start_time)}–{formatTime(l.end_time)}
+                </span>
+                <span className="text-sm truncate flex-1 min-w-[120px]">
+                  <span className="font-medium">{l.name}</span>
+                  {l.variant && (
+                    <span className="text-muted-foreground">
+                      {" "}
+                      · {l.variant}
+                    </span>
+                  )}
+                  {l.count && (
+                    <span className="text-muted-foreground text-[10px] ml-1">
+                      ({l.count}-ct)
+                    </span>
+                  )}
+                </span>
+                <Badge
+                  variant="outline"
+                  className={
+                    "text-[10px] " +
+                    (l.source === "user"
+                      ? "border-primary/40 text-primary"
+                      : l.source === "ai_accepted"
+                        ? "border-emerald-500/40 text-emerald-400"
+                        : "border-amber-500/40 text-amber-400")
+                  }
+                >
+                  {l.source === "user"
+                    ? "you"
+                    : l.source === "ai_accepted"
+                      ? "ai ✓"
+                      : "ai ✎"}
+                </Badge>
+                <div className="flex items-center gap-1.5 shrink-0">
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="h-7"
+                    onClick={() => handleEditExisting(l)}
+                  >
+                    <Edit2 className="h-3 w-3" />
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="h-7 text-destructive hover:text-destructive"
+                    onClick={async () => {
+                      if (!confirm("Delete this label?")) return;
+                      try {
+                        await remove(l.id);
+                      } catch (e) {
+                        alert(
+                          e instanceof Error ? e.message : "Delete failed"
+                        );
+                      }
+                    }}
+                  >
+                    <Trash2 className="h-3 w-3" />
+                  </Button>
+                </div>
+              </div>
+            ))
+          )}
+        </CardContent>
+      </Card>
+
+      {editing && (
+        <EditLabelDialog
+          state={editing}
+          onChange={setEditing}
+          onSave={handleSave}
+          onCancel={() => setEditing(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+type EditingState = {
+  mode: "new" | "new_from_ai" | "edit";
+  id?: string;
+  start_time: number;
+  end_time: number;
+  name: string;
+  variant: string;
+  count: number | null;
+  notes: string;
+  originalSource?: LabelSource;
+};
+
+function EditLabelDialog({
+  state,
+  onChange,
+  onSave,
+  onCancel,
+}: {
+  state: EditingState;
+  onChange: (s: EditingState) => void;
+  onSave: () => void;
+  onCancel: () => void;
+}) {
+  const groupedFamilies = useMemo(() => {
+    const groups: Record<string, PatternFamily[]> = {};
+    for (const f of PATTERN_FAMILIES) {
+      (groups[f.group] = groups[f.group] ?? []).push(f);
+    }
+    return groups;
+  }, []);
+
+  const availableVariants = useMemo(
+    () => (state.name ? variantsFor(state.name) : []),
+    [state.name]
+  );
+
+  const canSave =
+    state.name.trim().length > 0 && state.end_time > state.start_time;
+
+  const handleFamilyChange = (id: string) => {
+    const fam = PATTERN_FAMILIES.find((f) => f.id === id);
+    onChange({
+      ...state,
+      name: id,
+      variant: "basic",
+      count: fam?.defaultCount ?? state.count,
+    });
+  };
+
+  return (
+    <Dialog open onOpenChange={(open) => !open && onCancel()}>
+      <DialogContent className="sm:max-w-[480px]">
+        <DialogHeader>
+          <DialogTitle>
+            {state.mode === "edit" ? "Edit label" : "New label"}
+          </DialogTitle>
+          <DialogDescription>
+            Pick the pattern that was actually danced in this window.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3">
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="start">Start (sec)</Label>
+              <Input
+                id="start"
+                type="number"
+                step="0.1"
+                min={0}
+                value={state.start_time}
+                onChange={(e) =>
+                  onChange({
+                    ...state,
+                    start_time: parseFloat(e.target.value) || 0,
+                  })
+                }
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="end">End (sec)</Label>
+              <Input
+                id="end"
+                type="number"
+                step="0.1"
+                min={0}
+                value={state.end_time}
+                onChange={(e) =>
+                  onChange({
+                    ...state,
+                    end_time: parseFloat(e.target.value) || 0,
+                  })
+                }
+              />
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label>Pattern family</Label>
+            <Select value={state.name} onValueChange={handleFamilyChange}>
+              <SelectTrigger>
+                <SelectValue placeholder="Pick a pattern" />
+              </SelectTrigger>
+              <SelectContent>
+                {Object.entries(groupedFamilies).map(([group, families]) => (
+                  <SelectGroup key={group}>
+                    <SelectLabel className="text-[10px] uppercase tracking-wide">
+                      {group}
+                    </SelectLabel>
+                    {families.map((f) => (
+                      <SelectItem key={f.id} value={f.id}>
+                        {f.label}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {availableVariants.length > 1 && (
+            <div className="space-y-1.5">
+              <Label>Variant</Label>
+              <Select
+                value={state.variant}
+                onValueChange={(v) => onChange({ ...state, variant: v })}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {availableVariants.map((v) => (
+                    <SelectItem key={v.id} value={v.id}>
+                      {v.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          <div className="space-y-1.5">
+            <Label>Count</Label>
+            <Select
+              value={String(state.count ?? "")}
+              onValueChange={(v) =>
+                onChange({ ...state, count: v ? parseInt(v, 10) : null })
+              }
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="6 or 8" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="6">6-count</SelectItem>
+                <SelectItem value="8">8-count</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="notes">Notes (optional)</Label>
+            <textarea
+              id="notes"
+              rows={2}
+              value={state.notes}
+              onChange={(e) => onChange({ ...state, notes: e.target.value })}
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              placeholder="Anything worth remembering later"
+              maxLength={400}
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button onClick={onSave} disabled={!canSave}>
+            Save label
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function inferCount(
+  name: string | null | undefined
+): number | null {
+  if (!name) return null;
+  const f = PATTERN_FAMILIES.find((x) => x.id === name);
+  return f?.defaultCount ?? null;
+}

--- a/src/app/(app)/label/page.tsx
+++ b/src/app/(app)/label/page.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+// /label — lists the user's past analyses with label-progress
+// indicators. Click into one to open the label editor. Exists as a
+// separate tab (not on /analysis) because labeling is a focused
+// activity for building training data, not a viewing activity.
+
+import Link from "next/link";
+import { useMemo } from "react";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Tags, ArrowRight, FileVideo, Download } from "lucide-react";
+import { useAnalysisHistory } from "@/hooks/use-analysis-history";
+import { useLabelCounts } from "@/hooks/use-pattern-labels";
+import { exportAllLabels } from "@/lib/label-export";
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export default function LabelListPage() {
+  const history = useAnalysisHistory();
+  const { counts, loading: countsLoading } = useLabelCounts();
+
+  const rows = useMemo(
+    () =>
+      history.records.map((r) => {
+        const aiCount = (r.result?.patterns_identified ?? []).length;
+        const labelCount = counts[r.id] ?? 0;
+        return { record: r, aiCount, labelCount };
+      }),
+    [history.records, counts]
+  );
+
+  return (
+    <div className="max-w-4xl space-y-6">
+      <header className="flex items-start justify-between gap-4 flex-wrap">
+        <div>
+          <div className="flex items-center gap-2">
+            <Tags className="h-5 w-5 text-primary" />
+            <h1 className="text-2xl font-bold">Label</h1>
+          </div>
+          <p className="text-muted-foreground mt-1 max-w-prose">
+            Correct the AI&rsquo;s pattern identifications on your clips.
+            Your labels train a better model over time &mdash; pick an
+            analysis to start. Nothing published; labels stay yours.
+          </p>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={async () => {
+            try {
+              await exportAllLabels(history.records, counts);
+            } catch (e) {
+              alert(e instanceof Error ? e.message : "Export failed");
+            }
+          }}
+          disabled={Object.keys(counts).length === 0}
+          title="Download all your labels as JSON (training-ready schema)"
+        >
+          <Download className="h-3.5 w-3.5 mr-2" />
+          Export JSON
+        </Button>
+      </header>
+
+      {history.loading || countsLoading ? (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      ) : rows.length === 0 ? (
+        <Card className="border-dashed">
+          <CardContent className="py-8 text-center space-y-3">
+            <FileVideo className="h-8 w-8 mx-auto text-muted-foreground" />
+            <p className="text-sm text-muted-foreground">
+              You don&rsquo;t have any analyses yet. Analyze a clip first,
+              then come back to label it.
+            </p>
+            <Button asChild size="sm">
+              <Link href="/analyze">Analyze a clip</Link>
+            </Button>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-2">
+          {rows.map(({ record, aiCount, labelCount }) => {
+            const progressPct = aiCount
+              ? Math.min(100, Math.round((labelCount / aiCount) * 100))
+              : 0;
+            return (
+              <Link
+                key={record.id}
+                href={`/label/editor?id=${record.id}`}
+                className="block"
+              >
+                <Card className="hover:border-primary/40 transition-colors">
+                  <CardContent className="p-4 flex items-center gap-4 flex-wrap">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <p className="font-medium truncate">
+                          {record.filename ?? "Untitled"}
+                        </p>
+                        {record.competition_level && (
+                          <Badge variant="outline" className="text-[10px]">
+                            {record.competition_level}
+                          </Badge>
+                        )}
+                        {record.role && (
+                          <Badge variant="outline" className="text-[10px]">
+                            {record.role}
+                          </Badge>
+                        )}
+                      </div>
+                      <p className="text-xs text-muted-foreground mt-0.5">
+                        {formatDate(record.created_at)}
+                        {" · "}
+                        {aiCount} AI patterns
+                        {" · "}
+                        <span
+                          className={
+                            labelCount > 0
+                              ? "text-primary"
+                              : "text-muted-foreground"
+                          }
+                        >
+                          {labelCount} labeled
+                        </span>
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-3">
+                      <div className="w-28 h-1.5 bg-muted/40 rounded overflow-hidden">
+                        <div
+                          className="h-full bg-primary/70 transition-all"
+                          style={{ width: `${progressPct}%` }}
+                        />
+                      </div>
+                      <span className="text-[10px] text-muted-foreground tabular-nums w-10 text-right">
+                        {progressPct}%
+                      </span>
+                      <ArrowRight className="h-4 w-4 text-muted-foreground" />
+                    </div>
+                  </CardContent>
+                </Card>
+              </Link>
+            );
+          })}
+        </div>
+      )}
+
+      <Card className="bg-muted/10 border-dashed">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm">Why label?</CardTitle>
+        </CardHeader>
+        <CardContent className="text-xs text-muted-foreground space-y-1.5">
+          <p>
+            Pattern identification isn&rsquo;t perfect. Your corrections
+            become ground truth we can use to measure accuracy and
+            eventually fine-tune a better model.
+          </p>
+          <p>
+            Start with 5&ndash;10 of your cleanest clips. You don&rsquo;t
+            have to label everything &mdash; just accept the AI&rsquo;s
+            correct calls and fix the wrong ones.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/sidebar-nav.tsx
+++ b/src/components/sidebar-nav.tsx
@@ -9,6 +9,7 @@ import {
   Video,
   Settings,
   MessageSquare,
+  Tags,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -17,6 +18,7 @@ const navItems = [
   { href: "/rhythm", label: "Rhythm", icon: Music },
   { href: "/analyze", label: "Analyze", icon: Video },
   { href: "/practice", label: "Practice", icon: Timer },
+  { href: "/label", label: "Label", icon: Tags },
   { href: "/feedback", label: "Feedback", icon: MessageSquare },
   { href: "/settings", label: "Settings", icon: Settings },
 ];

--- a/src/hooks/use-pattern-labels.ts
+++ b/src/hooks/use-pattern-labels.ts
@@ -1,0 +1,153 @@
+"use client";
+
+// CRUD for pattern_labels (#142). Labels belong to the user who
+// authored them; RLS enforces the isolation, and we pass user_id
+// explicitly on insert so the row passes the RLS insert-check.
+
+import { useCallback, useEffect, useState } from "react";
+import { getSupabase, isSupabaseConfigured } from "@/lib/supabase";
+import { useUser } from "@/hooks/use-user";
+
+export type LabelSource = "user" | "ai_accepted" | "ai_edited";
+
+export type PatternLabel = {
+  id: string;
+  analysis_id: string;
+  user_id: string;
+  start_time: number;
+  end_time: number;
+  name: string;
+  variant: string | null;
+  count: number | null;
+  confidence: number | null;
+  source: LabelSource;
+  notes: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type PatternLabelDraft = Omit<
+  PatternLabel,
+  "id" | "user_id" | "created_at" | "updated_at"
+>;
+
+export function usePatternLabels(analysisId: string | null) {
+  const { user } = useUser();
+  const [labels, setLabels] = useState<PatternLabel[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!analysisId || !isSupabaseConfigured || !user) {
+      setLabels([]);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    const sb = getSupabase();
+    const { data, error: err } = await sb
+      .from("pattern_labels")
+      .select("*")
+      .eq("analysis_id", analysisId)
+      .order("start_time", { ascending: true });
+    if (err) {
+      setError(err.message);
+    } else {
+      setLabels((data as PatternLabel[]) ?? []);
+    }
+    setLoading(false);
+  }, [analysisId, user]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const add = useCallback(
+    async (draft: PatternLabelDraft) => {
+      if (!user) throw new Error("not signed in");
+      const sb = getSupabase();
+      const { data, error: err } = await sb
+        .from("pattern_labels")
+        .insert({ ...draft, user_id: user.id })
+        .select("*")
+        .single();
+      if (err) throw err;
+      const row = data as PatternLabel;
+      setLabels((cur) =>
+        [...cur, row].sort((a, b) => a.start_time - b.start_time)
+      );
+      return row;
+    },
+    [user]
+  );
+
+  const update = useCallback(
+    async (id: string, patch: Partial<PatternLabelDraft>) => {
+      const sb = getSupabase();
+      const { data, error: err } = await sb
+        .from("pattern_labels")
+        .update(patch)
+        .eq("id", id)
+        .select("*")
+        .single();
+      if (err) throw err;
+      const row = data as PatternLabel;
+      setLabels((cur) =>
+        cur
+          .map((l) => (l.id === id ? row : l))
+          .sort((a, b) => a.start_time - b.start_time)
+      );
+      return row;
+    },
+    []
+  );
+
+  const remove = useCallback(async (id: string) => {
+    const sb = getSupabase();
+    const { error: err } = await sb
+      .from("pattern_labels")
+      .delete()
+      .eq("id", id);
+    if (err) throw err;
+    setLabels((cur) => cur.filter((l) => l.id !== id));
+  }, []);
+
+  return { labels, loading, error, refresh, add, update, remove };
+}
+
+// Separate hook for the /label list page — counts labels per analysis
+// so we can show "3 labels / 18 patterns" progress indicators.
+export function useLabelCounts() {
+  const { user } = useUser();
+  const [counts, setCounts] = useState<Record<string, number>>({});
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!isSupabaseConfigured || !user) {
+      setCounts({});
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      const sb = getSupabase();
+      const { data } = await sb
+        .from("pattern_labels")
+        .select("analysis_id")
+        .eq("user_id", user.id);
+      if (cancelled) return;
+      const out: Record<string, number> = {};
+      for (const r of (data as { analysis_id: string }[]) ?? []) {
+        out[r.analysis_id] = (out[r.analysis_id] ?? 0) + 1;
+      }
+      setCounts(out);
+      setLoading(false);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [user]);
+
+  return { counts, loading };
+}

--- a/src/lib/label-export.ts
+++ b/src/lib/label-export.ts
@@ -1,0 +1,118 @@
+// Exports user-authored labels as a JSON file that matches the
+// grading harness schema from #139. Downloads client-side — no
+// upload, no server call.
+
+import { getSupabase, isSupabaseConfigured } from "@/lib/supabase";
+import type { AnalysisRecord } from "@/hooks/use-analysis-history";
+import type { PatternLabel } from "@/hooks/use-pattern-labels";
+
+type TruthEntry = {
+  start: number;
+  end: number;
+  name: string;
+  variant: string | null;
+  count: number | null;
+  source: string;
+  notes: string | null;
+};
+
+type ExportClip = {
+  clip_id: string;
+  analysis_id: string;
+  filename: string | null;
+  role: string | null;
+  competition_level: string | null;
+  dance_start_sec: number | null;
+  dance_end_sec: number | null;
+  duration: number | null;
+  labeled_at: string;
+  truth: TruthEntry[];
+};
+
+type ExportBundle = {
+  schema: "swingflow.pattern-labels/v1";
+  exported_at: string;
+  clip_count: number;
+  label_count: number;
+  clips: ExportClip[];
+};
+
+export async function exportAllLabels(
+  records: AnalysisRecord[],
+  counts: Record<string, number>
+): Promise<void> {
+  if (!isSupabaseConfigured) throw new Error("Supabase not configured");
+
+  // Only include analyses the user has actually labeled — keeps the
+  // export tight and avoids 50 empty clip entries.
+  const labeledIds = Object.keys(counts).filter((id) => counts[id] > 0);
+  if (labeledIds.length === 0) {
+    throw new Error("No labels to export yet.");
+  }
+
+  const sb = getSupabase();
+  const { data, error } = await sb
+    .from("pattern_labels")
+    .select("*")
+    .in("analysis_id", labeledIds)
+    .order("analysis_id", { ascending: true })
+    .order("start_time", { ascending: true });
+  if (error) throw error;
+
+  const labels = (data as PatternLabel[]) ?? [];
+  const byAnalysis = new Map<string, PatternLabel[]>();
+  for (const l of labels) {
+    const arr = byAnalysis.get(l.analysis_id) ?? [];
+    arr.push(l);
+    byAnalysis.set(l.analysis_id, arr);
+  }
+
+  const clips: ExportClip[] = [];
+  for (const record of records) {
+    const labelsForAnalysis = byAnalysis.get(record.id);
+    if (!labelsForAnalysis?.length) continue;
+    clips.push({
+      clip_id: record.filename ?? record.id,
+      analysis_id: record.id,
+      filename: record.filename,
+      role: record.role,
+      competition_level: record.competition_level,
+      dance_start_sec: record.result?.dance_start_sec ?? null,
+      dance_end_sec: record.result?.dance_end_sec ?? null,
+      duration: record.duration,
+      labeled_at: labelsForAnalysis.reduce(
+        (max, l) => (l.updated_at > max ? l.updated_at : max),
+        labelsForAnalysis[0].updated_at
+      ),
+      truth: labelsForAnalysis.map((l) => ({
+        start: l.start_time,
+        end: l.end_time,
+        name: l.name,
+        variant: l.variant,
+        count: l.count,
+        source: l.source,
+        notes: l.notes,
+      })),
+    });
+  }
+
+  const bundle: ExportBundle = {
+    schema: "swingflow.pattern-labels/v1",
+    exported_at: new Date().toISOString(),
+    clip_count: clips.length,
+    label_count: labels.length,
+    clips,
+  };
+
+  const blob = new Blob([JSON.stringify(bundle, null, 2)], {
+    type: "application/json",
+  });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `swingflow-labels-${new Date().toISOString().slice(0, 10)}.json`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}

--- a/src/lib/pattern-vocabulary.ts
+++ b/src/lib/pattern-vocabulary.ts
@@ -1,0 +1,137 @@
+// Canonical WSDC pattern vocabulary for the /label tab dropdowns.
+// Sourced from UCWDC Syllabus A–D, Library of Dance catalog, and
+// WCS Online Pattern Progress Chart — matches the AI's pattern
+// prompt so labels and AI predictions share the same name space.
+//
+// Keep this in sync with api/src/wcs_api/services/video_analysis/
+// prompts.py — if you add a pattern family there, add it here so
+// users can label it.
+
+export type PatternCount = 6 | 8;
+
+export type PatternFamily = {
+  /** Label family value we store in pattern_labels.name. */
+  id: string;
+  /** Display label for dropdowns. */
+  label: string;
+  /** 6-count, 8-count, or either (null). Used to pre-fill the count
+      field when the user picks this family. */
+  defaultCount: PatternCount | null;
+  /** Optional group — we render one OptGroup per group. */
+  group: "6-count" | "8-count whip family" | "8-count other" | "position" | "styling";
+  /** Aliases the AI might emit — used to normalize AI-predicted names
+      onto this family when pre-populating the label editor. */
+  aliases?: string[];
+};
+
+export type PatternVariant = {
+  /** Variant value stored in pattern_labels.variant. */
+  id: string;
+  /** Display label. */
+  label: string;
+  /** Family ids this variant applies to. */
+  families: string[];
+};
+
+export const PATTERN_FAMILIES: PatternFamily[] = [
+  // 6-count
+  { id: "sugar push", label: "Sugar push", defaultCount: 6, group: "6-count", aliases: ["push break"] },
+  { id: "sugar tuck", label: "Sugar tuck", defaultCount: 6, group: "6-count", aliases: ["same side tuck"] },
+  { id: "left side pass", label: "Left side pass", defaultCount: 6, group: "6-count" },
+  { id: "right side pass", label: "Right side pass", defaultCount: 6, group: "6-count", aliases: ["under arm pass", "underarm turn"] },
+  { id: "tuck turn", label: "Tuck turn", defaultCount: 6, group: "6-count", aliases: ["tuck"] },
+  { id: "free spin", label: "Free spin", defaultCount: 6, group: "6-count" },
+  { id: "starter step", label: "Starter step", defaultCount: 6, group: "6-count" },
+  { id: "throwout", label: "Throwout", defaultCount: 6, group: "6-count" },
+  { id: "cutoff", label: "Cutoff", defaultCount: 6, group: "6-count" },
+  { id: "left spinning side pass", label: "Left spinning side pass", defaultCount: 6, group: "6-count" },
+  { id: "inside turn", label: "Inside turn", defaultCount: 6, group: "6-count" },
+  { id: "outside roll", label: "Outside roll", defaultCount: 6, group: "6-count" },
+  { id: "rock and go", label: "Rock and go", defaultCount: 6, group: "6-count" },
+  { id: "6-count elbow catch", label: "6-count elbow catch", defaultCount: 6, group: "6-count" },
+  { id: "bowtie", label: "Bowtie", defaultCount: 6, group: "6-count" },
+  { id: "fold", label: "Fold", defaultCount: 6, group: "6-count", aliases: ["shootout"] },
+  { id: "roll in roll out", label: "Roll in – roll out", defaultCount: 6, group: "6-count" },
+
+  // 8-count whip family
+  { id: "whip", label: "Whip", defaultCount: 8, group: "8-count whip family" },
+  { id: "basket whip", label: "Basket whip", defaultCount: 8, group: "8-count whip family", aliases: ["cradle whip", "cuddle whip", "locked whip"] },
+  { id: "closed whip", label: "Closed whip", defaultCount: 8, group: "8-count whip family" },
+  { id: "inside whip", label: "Inside whip", defaultCount: 8, group: "8-count whip family" },
+  { id: "reverse whip", label: "Reverse whip (left-side whip)", defaultCount: 8, group: "8-count whip family" },
+  { id: "texas tommy", label: "Texas Tommy", defaultCount: 8, group: "8-count whip family", aliases: ["apache whip", "texas tommy whip"] },
+  { id: "tandem whip", label: "Tandem whip", defaultCount: 8, group: "8-count whip family" },
+  { id: "shadow whip", label: "Shadow whip (Titanic)", defaultCount: 8, group: "8-count whip family" },
+  { id: "tunnel whip", label: "Tunnel whip", defaultCount: 8, group: "8-count whip family" },
+  { id: "dishrag whip", label: "Dishrag whip", defaultCount: 8, group: "8-count whip family" },
+  { id: "windows whip", label: "Windows whip", defaultCount: 8, group: "8-count whip family" },
+  { id: "matador whip", label: "Matador whip", defaultCount: 8, group: "8-count whip family" },
+  { id: "same side whip", label: "Same side whip", defaultCount: 8, group: "8-count whip family" },
+  { id: "hustle whip", label: "Hustle whip", defaultCount: 8, group: "8-count whip family" },
+  { id: "carwash whip", label: "Carwash whip", defaultCount: 8, group: "8-count whip family" },
+  { id: "pull through whip", label: "Pull-through whip", defaultCount: 8, group: "8-count whip family" },
+  { id: "decapitive whip", label: "Decapitive whip (decap)", defaultCount: 8, group: "8-count whip family", aliases: ["decap whip"] },
+  { id: "behind the back whip", label: "Behind-the-back whip", defaultCount: 8, group: "8-count whip family" },
+  { id: "over the head whip", label: "Over-the-head whip", defaultCount: 8, group: "8-count whip family" },
+  { id: "outside walking whip", label: "Outside walking whip", defaultCount: 8, group: "8-count whip family" },
+  { id: "underarm whip", label: "Underarm whip", defaultCount: 8, group: "8-count whip family" },
+  { id: "half whip & throwout", label: "Half whip & throwout", defaultCount: 8, group: "8-count whip family" },
+  { id: "continuous whip", label: "Continuous whip (rolling)", defaultCount: 8, group: "8-count whip family" },
+  { id: "extended whip", label: "Extended whip", defaultCount: 8, group: "8-count whip family" },
+  { id: "catch and release", label: "Catch and release", defaultCount: 8, group: "8-count whip family" },
+  { id: "reverse catch and release", label: "Reverse catch and release", defaultCount: 8, group: "8-count whip family" },
+  { id: "around the world", label: "Around the world", defaultCount: 8, group: "8-count whip family" },
+  { id: "lead's cradle whip", label: "Lead's cradle whip", defaultCount: 8, group: "8-count whip family" },
+
+  // 8-count other
+  { id: "slingshot", label: "Slingshot", defaultCount: 8, group: "8-count other" },
+  { id: "hip catch", label: "Hip catch", defaultCount: 8, group: "8-count other" },
+  { id: "barrel roll", label: "Barrel roll", defaultCount: 8, group: "8-count other" },
+  { id: "changing places", label: "Changing places", defaultCount: 8, group: "8-count other", aliases: ["change of places"] },
+  { id: "arm bar", label: "Arm bar", defaultCount: 8, group: "8-count other" },
+  { id: "single-double", label: "Single-double", defaultCount: 8, group: "8-count other" },
+  { id: "wrap in wrap out", label: "Wrap in – wrap out", defaultCount: 8, group: "8-count other" },
+  { id: "wrapping side pass", label: "Wrapping side pass", defaultCount: 8, group: "8-count other" },
+  { id: "rolling off the back pass", label: "Rolling off the back pass", defaultCount: 8, group: "8-count other" },
+];
+
+// Variants applicable to multiple families. We show these in the
+// variant dropdown, filtered to those that apply to the picked family.
+export const PATTERN_VARIANTS: PatternVariant[] = [
+  { id: "basic", label: "basic", families: ["*"] },
+  { id: "with inside turn", label: "with inside turn", families: ["sugar push", "sugar tuck", "left side pass", "right side pass", "whip", "tuck turn"] },
+  { id: "with outside turn", label: "with outside turn", families: ["left side pass", "right side pass", "whip"] },
+  { id: "with double inside turn", label: "with double inside turn", families: ["whip", "tuck turn"] },
+  { id: "with double outside turn", label: "with double outside turn", families: ["whip"] },
+  { id: "with free spin", label: "with free spin", families: ["whip"] },
+  { id: "with double free spin", label: "with double free spin", families: ["whip"] },
+  { id: "with hand change", label: "with hand change", families: ["sugar push", "left side pass", "right side pass", "tuck turn"] },
+  { id: "with hand change behind the back", label: "with hand change behind the back", families: ["sugar push", "whip"] },
+  { id: "with hand change behind the head", label: "with hand change behind the head", families: ["whip"] },
+  { id: "with rock and go", label: "with rock-and-go anchor", families: ["*"] },
+  { id: "double tuck", label: "double tuck", families: ["tuck turn"] },
+  { id: "single", label: "single (360°)", families: ["free spin"] },
+  { id: "double", label: "double (720°)", families: ["free spin"] },
+  { id: "triple", label: "triple (1080°)", families: ["free spin"] },
+];
+
+/**
+ * Normalize an AI-emitted pattern name onto a canonical family id.
+ * Returns null when the name doesn't match any known family or alias,
+ * so the caller can surface a "non-canonical" indicator in the editor.
+ */
+export function normalizePatternName(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  const norm = raw.trim().toLowerCase();
+  for (const f of PATTERN_FAMILIES) {
+    if (f.id === norm) return f.id;
+    if (f.aliases?.some((a) => a === norm)) return f.id;
+  }
+  return null;
+}
+
+export function variantsFor(familyId: string): PatternVariant[] {
+  return PATTERN_VARIANTS.filter(
+    (v) => v.families.includes("*") || v.families.includes(familyId)
+  );
+}

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -465,3 +465,80 @@ begin
   delete from public.usage_events where id = p_id;
 end;
 $$;
+
+-- ────────────────────────────────────────────────────────────
+-- Pattern labels (#142) — user-authored ground truth
+--
+-- Lets users correct the AI's pattern identifications via the /label
+-- tab. Each row is one time-ranged pattern assignment on an analysis
+-- the user owns. Exported as JSON for the grading harness (#139) and
+-- eventually for fine-tuning a better model.
+--
+-- RLS is strict: a user can only read/write labels on analyses they
+-- own. We don't check video_analyses.user_id in RLS (that'd require a
+-- join); instead we trust the pattern_labels.user_id column and let
+-- the insert-time check (matching auth.uid()) pin ownership.
+-- ────────────────────────────────────────────────────────────
+
+create table if not exists public.pattern_labels (
+  id uuid primary key default gen_random_uuid(),
+  analysis_id uuid not null references public.video_analyses(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  start_time numeric(8,3) not null,
+  end_time numeric(8,3) not null,
+  name text not null,
+  variant text,
+  count int,
+  confidence numeric(3,2),
+  -- source: 'user' (from scratch), 'ai_accepted' (user clicked accept
+  -- on an AI block, no edits), 'ai_edited' (user started from an AI
+  -- block and changed something). Distinguishes labels that represent
+  -- fresh user judgment from ones that are AI inheritance.
+  source text not null default 'user' check (source in ('user','ai_accepted','ai_edited')),
+  notes text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint pattern_labels_time_order check (end_time > start_time)
+);
+
+create index if not exists pattern_labels_analysis_idx
+  on public.pattern_labels(analysis_id, start_time);
+
+create index if not exists pattern_labels_user_idx
+  on public.pattern_labels(user_id);
+
+alter table public.pattern_labels enable row level security;
+
+drop policy if exists pattern_labels_select_own on public.pattern_labels;
+create policy pattern_labels_select_own on public.pattern_labels
+  for select using (auth.uid() = user_id);
+
+drop policy if exists pattern_labels_insert_own on public.pattern_labels;
+create policy pattern_labels_insert_own on public.pattern_labels
+  for insert with check (auth.uid() = user_id);
+
+drop policy if exists pattern_labels_update_own on public.pattern_labels;
+create policy pattern_labels_update_own on public.pattern_labels
+  for update using (auth.uid() = user_id) with check (auth.uid() = user_id);
+
+drop policy if exists pattern_labels_delete_own on public.pattern_labels;
+create policy pattern_labels_delete_own on public.pattern_labels
+  for delete using (auth.uid() = user_id);
+
+grant select, insert, update, delete on public.pattern_labels to authenticated;
+
+-- Keep updated_at fresh automatically.
+create or replace function public.pattern_labels_touch_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists pattern_labels_touch_updated_at on public.pattern_labels;
+create trigger pattern_labels_touch_updated_at
+  before update on public.pattern_labels
+  for each row execute function public.pattern_labels_touch_updated_at();


### PR DESCRIPTION
Implements #142. New top-level **Label** tab where users correct the AI's pattern identifications on their own clips — every label becomes training data.

## Flow

1. \`/label\` — list of user's analyses with progress bar (labels / AI pattern count)
2. Click an analysis → \`/label/editor?id=X\`
3. Editor has two sections:
   - **AI-predicted patterns (pending review)** — each block has **Accept** (source=\`ai_accepted\`) and **Fix** (opens edit dialog, saves as \`ai_edited\`)
   - **Your labels** — everything saved, with edit / delete per row + color-coded source badge
4. \"Add at {playhead}\" button pre-fills timestamps from the video's current time
5. \"Export JSON\" on the list page downloads the training-ready schema

## Data

\`pattern_labels\` table with strict RLS (user can only touch own rows). Cascades from \`video_analyses\`. \`source\` column distinguishes fresh-user / ai-accepted / ai-edited so the grader + trainer can weight them differently.

## Files

- \`src/lib/pattern-vocabulary.ts\` — canonical WSDC list + variants + AI-alias normalizer
- \`src/hooks/use-pattern-labels.ts\` — CRUD + useLabelCounts for progress
- \`src/lib/label-export.ts\` — client-side JSON download in #139 schema
- \`src/app/(app)/label/page.tsx\` — list page
- \`src/app/(app)/label/editor/page.tsx\` — editor page
- \`src/components/sidebar-nav.tsx\` — new \"Label\" entry
- \`supabase/schema.sql\` — new table + RLS + trigger

## Mobile

Not added to mobile nav (stays at 4 tabs). Labeling wants keyboard + big screen.

## Migration required

Re-run \`supabase/schema.sql\` so \`pattern_labels\` exists in prod. Idempotent (\`create table if not exists\`, \`drop policy if exists\` / \`create policy\`).

## Verified

- \`npx tsc --noEmit\` clean
- Suspense + useSearchParams used for the editor (compatible with static export)