### PR TITLE
Restore count field + extend leading-pattern rewind rule

### DIFF
--- a/api/src/wcs_api/services/video_analysis/prompts.py
+++ b/api/src/wcs_api/services/video_analysis/prompts.py
@@ -889,6 +889,21 @@ started seeing the next one" — which is the same bug in reverse.
 Shorten the previous end_time so the two patterns abut without
 overlap. Contiguous non-overlapping coverage is the goal.
 
+**Leading-pattern check (FIRST pattern in the dance window).** The
+recognition-vs-start rule applies to the very first pattern too.
+If your first pattern's start_time equals dance_start_sec but its
+duration is shorter than the count would predict (a 6-count under
+2.5s or an 8-count under 3.0s), you set start_time to the moment
+you first recognized the pattern, not where it began. The fix is
+to push start_time EARLIER, even before dance_start_sec if needed
+— and revise dance_start_sec down to match. The dancers must have
+started those entry walks somewhere; find them in the frames
+before dance_start_sec. If you genuinely can't see entry walks
+(e.g. mid-song cut), then either the pattern is shorter than a
+full 6/8-count (label it as a partial — the windows-cut-short
+variant) or this is a pre-dance fragment that shouldn't be a
+pattern at all (drop it).
+
 If two patterns look like they overlap, the boundary goes at the
 VISIBLE start of the new pattern's walk (beat 1 weight change),
 not at the audio downbeat.
@@ -1117,6 +1132,7 @@ Respond in this exact JSON format. Fill `reasoning` BEFORE `score` in each categ
     {
       "name": "<pattern family — e.g. sugar push, left side pass, whip, tuck turn>",
       "variant": "<specific sub-type — e.g. 'basket', 'reverse', 'apache', 'with inside turn', 'with outside turn', 'sugar tuck'. Use 'basic' ONLY when you've verified NO variant features are present. If you see any distinguishing feature (turn under arm, hand-behind-back, reversed rotation, cradling arm, sugar tuck compression, release-spin), commit to that variant — do NOT fall back to 'basic'. `null` is last resort for genuinely unreadable variants (bad angle, obscured dancers).>",
+      "count": <REQUIRED — 6 or 8. The WCS count structure of the pattern. Sugar push, sugar tuck, side passes, tuck turn, free spin, throwout, starter step, push break, cutoff, inside turn, outside roll, rock and go, 6-count elbow catch, bowtie, fold = 6. Whip family (basic, basket, reverse, Texas Tommy, tandem, shadow, etc.), slingshot, hip catch, barrel roll, changing places, around the world, catch and release, wrap in/out, wrapping side pass = 8. NEVER null.>,
       "start_time": <seconds from video start, float>,
       "end_time": <seconds from video start, float>,
       "quality": "<strong|solid|needs_work|weak>",


### PR DESCRIPTION
Two follow-ups from re-analyzing IMG_8665 to verify #146.

## 1. \`count\` regressed to \`null\` on every pattern

Re-analysis showed all 35 patterns came back with \`count=None\`. The PRE-pass schema (PATTERN_SEGMENTATION_PROMPT) correctly listed count as a field; the MAIN \`GEMINI_VIDEO_PROMPT\` schema for \`patterns_identified\` had dropped it. The model just stopped emitting it.

**Fix:** explicit \"count: REQUIRED 6 or 8\" line in the patterns_identified schema, with a list of which families map to which count (sugar push / side passes / tuck / etc = 6; whip family / slingshot / hip catch / barrel roll / changing places / catch and release = 8). NEVER null.

This also unblocks the duration sanity check from #146 — it needed \`count\` to know which threshold (2.5s vs 3.0s) to apply.

## 2. Leading-pattern still clipping

Re-analysis showed the FIRST pattern (under arm pass at 17.0–18.5s, 1.5s) still clipped to half its length. #146's rewind rule implicitly assumed a previous pattern to rewind into.

**Fix:** new \"leading-pattern check\" extending the rule to the first pattern in the dance window:
- If first-pattern duration is shorter than its count predicts, push start_time earlier
- Revise \`dance_start_sec\` down if necessary
- Genuine mid-song cuts with no entry: drop the pattern or label it as a windows-cut-short partial

## Verified

- \`uv run python -c \"from wcs_api.services.video_analysis import prompts\"\` clean
- Re-analysis of IMG_8665 with #146 alone confirmed both regressions are real

\`+16 / -1\`. No schema change. Picks up on the next analysis after Railway redeploys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video pattern detection to more accurately identify segment boundaries, including entry movements at the beginning of sequences.
  * Enhanced handling of incomplete video segments that may be cut short, ensuring more reliable pattern recognition.

* **Improvements**
  * Standardized pattern count validation to ensure all detected patterns include consistent count values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->