### PR TITLE
Restore Strengths/Improvements + push model off all-null variants

### DIFF
--- a/api/src/wcs_api/services/video_analysis/prompts.py
+++ b/api/src/wcs_api/services/video_analysis/prompts.py
@@ -770,6 +770,24 @@ ANTI-DEFAULT RULES (user feedback shows this tool over-uses "basic"):
   itself is clear but the variant is genuinely unreadable (bad camera
   angle, dancers obscured). If you use null, confidence must be <0.7.
 
+ANTI-NULL RULE (recent regression, real example: 33 patterns
+identified, 33 variants returned as null — that is a model bug, not a
+clean clip):
+- If you can confidently name the family (`name` is set, confidence
+  ≥0.7), you MUST commit to a variant. Either pick the specific
+  variant you saw, or "basic" if you watched the full pattern and saw
+  no distinguishing features.
+- Returning `variant: null` while also reporting `confidence ≥ 0.7`
+  is contradictory — if you could see the pattern clearly enough to
+  call its family with high confidence, you saw enough to know whether
+  it had variant features or executed plain. Pick "basic" or pick the
+  variant; do not abstain.
+- An entire dance returning all-null variants is almost never correct.
+  Real WCS dances mix basic patterns with at least a few variants
+  (inside-turn passes, sugar tucks, reverse whips, basket whips). If
+  your draft has zero variants in 20+ patterns, re-watch — you are
+  almost certainly missing them.
+
 Example: a clear basket whip → `{name: "whip", variant: "basket",
 visual_cue: "follower's hand held behind back from 3-5"}`. A plain
 whip with no added features → `{name: "whip", variant: "basic"}`.

--- a/api/src/wcs_api/services/video_analysis/response_sanitizer.py
+++ b/api/src/wcs_api/services/video_analysis/response_sanitizer.py
@@ -887,6 +887,93 @@ def _fmt_timestamp(sec: float) -> str:
     return f"{m}:{s:02d}"
 
 
+def _strengths_from_summary(
+    pattern_summary: list[dict[str, Any]] | None,
+    *,
+    max_items: int = 3,
+) -> list[str]:
+    """Synthesize Strengths entries from pattern_summary when the
+    model's own highlights came back too thin.
+
+    Picks patterns with quality in {"solid", "excellent"} that have
+    actual notes attached, then renders one line per pattern. Grounded
+    by construction — each line names a specific pattern family the
+    dancer demonstrated, with the model's own observation about it.
+    """
+    if not pattern_summary:
+        return []
+    out: list[str] = []
+    for p in pattern_summary:
+        if len(out) >= max_items:
+            break
+        quality = (p.get("quality") or "").lower()
+        if quality not in ("solid", "excellent"):
+            continue
+        notes = (p.get("notes") or "").strip()
+        if not notes:
+            continue
+        name = (p.get("name") or "").strip()
+        if not name:
+            continue
+        cnt = p.get("count")
+        label = f"{name.capitalize()} (×{cnt})" if cnt else name.capitalize()
+        out.append(f"{label}: {notes[:300]}")
+    return out
+
+
+def _improvements_from_summary(
+    pattern_summary: list[dict[str, Any]] | None,
+    *,
+    max_items: int = 3,
+) -> list[str]:
+    """Synthesize Improvements entries from pattern_summary's
+    coaching_tip field when the model's own improvements came back
+    too thin. The per-pattern tips are already grounded — they were
+    written for a specific pattern occurrence and survived the
+    pattern-summary aggregation, so they pass the "anchored to the
+    video" bar that the prompt's de-horoscope rule requires.
+    """
+    if not pattern_summary:
+        return []
+    out: list[str] = []
+    for p in pattern_summary:
+        if len(out) >= max_items:
+            break
+        tip = (p.get("coaching_tip") or "").strip()
+        if not tip:
+            continue
+        # Skip tips that match the stock-coaching filter — even a
+        # pattern-anchored tip phrased as "engage your core" reads as
+        # horoscope to the user.
+        if _is_stock_coaching(tip):
+            continue
+        name = (p.get("name") or "").strip()
+        if not name:
+            continue
+        cnt = p.get("count")
+        label = f"{name.capitalize()} (×{cnt})" if cnt else name.capitalize()
+        out.append(f"{label}: {tip[:300]}")
+    return out
+
+
+def _merge_unique(primary: list[str], fallback: list[str]) -> list[str]:
+    """Append fallback items that aren't already present in primary,
+    capped at 3 total. Comparison is case-insensitive on the trimmed
+    text so "Sugar push: foo" and "sugar push: foo " don't both ship.
+    """
+    seen = {p.strip().lower() for p in primary}
+    out = list(primary)
+    for f in fallback:
+        if len(out) >= 3:
+            break
+        key = f.strip().lower()
+        if key in seen:
+            continue
+        out.append(f)
+        seen.add(key)
+    return out
+
+
 def _sanitize_coaching_list(
     raw: Any,
     *,
@@ -1045,6 +1132,22 @@ def _shape_response(
         dance_end_sec=dance_end_sec,
     )
     pattern_summary = _summarize_patterns(patterns_identified)
+
+    # Fallback: when the de-horoscope filter strips everything, the user
+    # gets blank Strengths / Areas-for-Improvement panels even though
+    # the per-pattern coaching tips are already grounded by construction
+    # (each tip is tied to a specific pattern type the dancer actually
+    # did). Harvest from pattern_summary so the panels stay useful
+    # instead of empty. Only fires when the model's own grounded list
+    # came back too thin to be worth showing.
+    if len(strengths) < 2:
+        strengths = _merge_unique(
+            strengths, _strengths_from_summary(pattern_summary)
+        )
+    if len(improvements) < 2:
+        improvements = _merge_unique(
+            improvements, _improvements_from_summary(pattern_summary)
+        )
     # Top-level flag so the frontend can render a "pattern
     # identification was low confidence on this analysis" banner
     # without having to re-derive it from the timeline. Set when


### PR DESCRIPTION
## Summary

Two regressions surfaced after #146/#147 — both visible on the latest IMG_8665 re-analysis (#147 verification).

**1. Strengths & Areas-for-Improvement rendered empty.**

The de-horoscope filter from earlier work is doing its job — it strips stock phrases like *"engage your core"* and *"roll through the feet"*. But the model now responds by emitting **nothing** at `highlights`/`improvements` top-level instead of grounded alternatives. Meanwhile `pattern_summary[].coaching_tip` already had exactly the kind of moment-anchored coaching we want (e.g. *"Lead: absorb the compression with your core and body weight, not just your biceps."*).

Server-side fallback: when sanitized `strengths` or `improvements` come back with <2 entries, harvest from `pattern_summary` (`coaching_tip` for improvements, notes from solid/excellent patterns for strengths). Grounded by construction — each line names a specific pattern family the dancer demonstrated.

**2. All-null variants.**

The newest IMG_8665 returned 33 patterns with `variant=null` on every single one. The prompt's anti-default rules already forbid this (*"null variant is a last resort"*), but the model is choosing the defensive path universally.

Tightened the rules:
- If `confidence ≥ 0.7` on the family name → must commit to `"basic"` or a specific variant. `null` while confident is contradictory.
- Called out the "all-null in 20+ patterns is almost never correct" failure mode explicitly so the model recognizes the shape.

## Test plan

- [x] Smoke-test the fallback against the live IMG_8665 `pattern_summary` shape — produces 3 strengths + 2 improvements lines as expected
- [x] Python parses cleanly
- [ ] After deploy: re-analyze IMG_8665 again, confirm strengths/improvements panels populate AND variants are no longer 33/33 null

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved pattern recognition: when confidence thresholds are met, the system now reliably selects specific pattern variants instead of null values for more precise analysis.
  * Enhanced feedback sections: strengths and improvements panels automatically populate from pattern data when needed, ensuring complete and detailed feedback in all analysis results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->