### PR TITLE
Stop model gaming the anti-null variant rule via low confidence

### DIFF
--- a/api/src/wcs_api/services/video_analysis/prompts.py
+++ b/api/src/wcs_api/services/video_analysis/prompts.py
@@ -770,23 +770,26 @@ ANTI-DEFAULT RULES (user feedback shows this tool over-uses "basic"):
   itself is clear but the variant is genuinely unreadable (bad camera
   angle, dancers obscured). If you use null, confidence must be <0.7.
 
-ANTI-NULL RULE (recent regression, real example: 33 patterns
-identified, 33 variants returned as null — that is a model bug, not a
-clean clip):
-- If you can confidently name the family (`name` is set, confidence
-  ≥0.7), you MUST commit to a variant. Either pick the specific
-  variant you saw, or "basic" if you watched the full pattern and saw
-  no distinguishing features.
-- Returning `variant: null` while also reporting `confidence ≥ 0.7`
-  is contradictory — if you could see the pattern clearly enough to
-  call its family with high confidence, you saw enough to know whether
-  it had variant features or executed plain. Pick "basic" or pick the
-  variant; do not abstain.
+ANTI-NULL RULE (regression observed: 33 patterns identified, 33
+variants returned as null — that is a model bug, not a clean clip):
+- If you set a pattern `name`, you MUST set `variant`. The two are a
+  paired commitment: naming the family without naming the variant is
+  not a valid response.
+- "basic" is the correct value when you watched the pattern and saw
+  no distinguishing features. It is NOT a low-confidence answer — it
+  is a positive observation ("I saw plain execution").
+- A specific variant ("with inside turn", "basket", "reverse") is the
+  correct value when you saw a distinguishing feature.
+- DO NOT lower your confidence on the pattern just to legitimize
+  returning variant=null. If you saw the pattern well enough to name
+  its family at all, you saw enough to call "basic" vs. specific
+  variant. Confidence reflects the family identification, not the
+  variant choice.
 - An entire dance returning all-null variants is almost never correct.
   Real WCS dances mix basic patterns with at least a few variants
   (inside-turn passes, sugar tucks, reverse whips, basket whips). If
-  your draft has zero variants in 20+ patterns, re-watch — you are
-  almost certainly missing them.
+  your draft has zero non-basic variants in 20+ patterns, re-watch —
+  you are almost certainly missing them.
 
 Example: a clear basket whip → `{name: "whip", variant: "basket",
 visual_cue: "follower's hand held behind back from 3-5"}`. A plain


### PR DESCRIPTION
## Summary

#148's anti-null rule said: *'variant=null while confidence ≥0.7 is contradictory'*. The model's response on the very next re-analysis was to **drop confidence to 0.2–0.3 across all 28 patterns** so it could legitimately keep returning null variants. That cratered downstream `pattern_summary` aggregation (filters at confidence <0.5) and starved the new strengths/improvements fallback of any data — making the panels emptier than before #148.

Reframe without giving the model a confidence escape hatch:

- If you set `name`, you **must** set `variant`. They're paired — no escape.
- `'basic'` is a positive observation ('I saw plain execution'), not a low-confidence answer.
- Confidence reflects the family identification, not the variant choice — don't lower confidence to legitimize null.

The strengths/improvements fallback from #148 stays — it's the right behavior when `pattern_summary` has data. This fix is what makes `pattern_summary` actually have data again.

## Test plan

- [ ] After deploy: re-analyze IMG_8665, confirm:
  - confidences come back in the 0.6–0.9 range, not 0.2 across the board
  - `pattern_summary` is non-empty
  - some patterns have non-basic variants (or all-basic with reasonable confidence is fine — just not all-null with 0.2 conf)
  - strengths/improvements panels populate (either from model directly OR from fallback)