### PR TITLE
Lower pattern_summary confidence cutoff from 0.5 to 0.25

### DIFF
--- a/api/src/wcs_api/services/video_analysis/response_sanitizer.py
+++ b/api/src/wcs_api/services/video_analysis/response_sanitizer.py
@@ -403,11 +403,19 @@ def _summarize_patterns(
         # the UI can render them with a "low confidence" marker) but
         # don't contribute to "7 underarm turns" aggregates the user
         # would otherwise read as a definitive tally.
+        #
+        # Threshold is 0.25, not 0.5: post-#147 the model started
+        # hedging confidence to 0.2-0.3 across the board (see
+        # 483af468 / de04ef4a). At 0.5 cutoff that wiped out
+        # pattern_summary entirely on those analyses, which in turn
+        # starved the strengths/improvements fallback in #148. Better
+        # to show a slightly noisier summary than a totally empty
+        # coaching panel.
         try:
             confidence = float(p.get("confidence", _CONFIDENCE_UNSET))
         except (TypeError, ValueError):
             confidence = _CONFIDENCE_UNSET
-        if confidence < 0.5:
+        if confidence < 0.25:
             continue
         # Key on (family + variant) so "basket whip" and "reverse whip"
         # count as distinct patterns even though they share the "whip"


### PR DESCRIPTION
## Summary

Two recent re-analyses (483af468, de04ef4a) came back with confidence 0.2–0.3 across every pattern — the model started hedging confidence universally after the prompt accumulation in #146/#147/#148. At the old 0.5 cutoff that wiped out \`pattern_summary\` entirely (33 patterns in, 0 summary entries out), which then **starved the strengths/improvements fallback added in #148** — leaving the user with empty panels even though the per-pattern coaching tips were fine.

Better to show a slightly noisier summary than a totally empty coaching panel. The detail-timeline entries still carry their confidence value, so the UI can dim or flag low-confidence patterns if it wants to.

## Test plan

- [ ] After deploy: re-analyze IMG_8665, confirm pattern_summary is non-empty and strengths/improvements panels populate