### PR TITLE
Bump Gemini sampling from fps=2 to fps=4 to read rotational patterns

### DIFF
--- a/api/src/wcs_api/services/video_analysis/analyzer.py
+++ b/api/src/wcs_api/services/video_analysis/analyzer.py
@@ -227,12 +227,19 @@ def analyze_video_path(
             state_name = uploaded.state.name if uploaded.state else "UNKNOWN"
             raise VideoAnalysisError(f"Gemini file upload state: {state_name}")
 
-        # Wrap the uploaded video with an explicit fps=2 sampling hint.
-        # Default Gemini sampling is ~1 FPS; doubling it catches the
-        # "&" counts between beats (kick-ball-changes, quick anchor
-        # settles) that 1 FPS routinely misses. Video token cost ~2x,
-        # still bounded because we only upload short clips.
-        video_part = _video_part_with_fps(uploaded, fps=2.0)
+        # Wrap the uploaded video with an explicit fps=4 sampling
+        # hint. Default Gemini sampling is ~1 FPS; at 2 FPS the model
+        # was catching syncopation but routinely confusing rotational
+        # patterns (free spin, catch-and-release, basket whip) with
+        # travelling ones (left/right side pass) — at 2 FPS a 360°
+        # spin lasting ~1 second only shows up in 2 frames, not enough
+        # to read the rotation count vs. a partner pass-through. At
+        # 4 FPS those same spins get 4 frames, enough to lock in
+        # "follower spun in place" vs. "follower travelled past lead".
+        # Video token cost ~2x relative to fps=2 (~4x relative to
+        # default), but our clips are short so the absolute cost stays
+        # bounded.
+        video_part = _video_part_with_fps(uploaded, fps=4.0)
 
         prompt = GEMINI_VIDEO_PROMPT
 


### PR DESCRIPTION
## Summary

User feedback: free spins are routinely getting called left side passes. Both end with the follower on the lead's left, but they're distinguished by HOW the rotation happens (lead releases connection vs. maintains and guides). At fps=2 a 360° spin lasting ~1 second only shows up in **2 frames** — not enough to lock in *'follower spun in place'* vs. *'follower travelled past lead'*. At fps=4 those same spins get 4 frames, enough to catch the connection-release moment that the prompt's RULE #2 already keys on.

Same logic applies to catch-and-release variants and basket whips where the defining cue is a brief hand position that the 0.5-second sampling gap was missing.

## Cost

~2x video tokens vs fps=2, ~4x vs default fps=1. Our clips are short (~2 minutes) so absolute cost stays bounded.

## Test plan

- [ ] Re-analyze IMG_8665 after deploy and check whether more non-basic variants appear, and whether any patterns that previously read as "left side pass" now flip to "free spin" or other rotation-distinguished families.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved video analysis accuracy for detecting movement patterns in uploaded videos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->