### PR TITLE
Revert fps to 2; label editor: custom patterns + 10/12/16 counts

### DIFF
--- a/api/src/wcs_api/services/video_analysis/analyzer.py
+++ b/api/src/wcs_api/services/video_analysis/analyzer.py
@@ -227,19 +227,21 @@ def analyze_video_path(
             state_name = uploaded.state.name if uploaded.state else "UNKNOWN"
             raise VideoAnalysisError(f"Gemini file upload state: {state_name}")
 
-        # Wrap the uploaded video with an explicit fps=4 sampling
-        # hint. Default Gemini sampling is ~1 FPS; at 2 FPS the model
-        # was catching syncopation but routinely confusing rotational
-        # patterns (free spin, catch-and-release, basket whip) with
-        # travelling ones (left/right side pass) — at 2 FPS a 360°
-        # spin lasting ~1 second only shows up in 2 frames, not enough
-        # to read the rotation count vs. a partner pass-through. At
-        # 4 FPS those same spins get 4 frames, enough to lock in
-        # "follower spun in place" vs. "follower travelled past lead".
-        # Video token cost ~2x relative to fps=2 (~4x relative to
-        # default), but our clips are short so the absolute cost stays
-        # bounded.
-        video_part = _video_part_with_fps(uploaded, fps=4.0)
+        # Wrap the uploaded video with an explicit fps=2 sampling hint.
+        # Default Gemini sampling is ~1 FPS; doubling it catches the
+        # "&" counts between beats (kick-ball-changes, quick anchor
+        # settles) that 1 FPS routinely misses. Video token cost ~2x,
+        # still bounded because we only upload short clips.
+        #
+        # NOTE: We tried fps=4 in #151 to give the model more frames
+        # to distinguish rotational patterns (free spin) from
+        # travelling ones (side pass), but on the verification re-run
+        # the model didn't identify any new free spins or non-basic
+        # variants — pattern variety actually went down slightly. The
+        # fps lever isn't the bottleneck for that recognition; it's
+        # the model's defaulting behavior. Reverted to fps=2 to save
+        # the 2x video token cost.
+        video_part = _video_part_with_fps(uploaded, fps=2.0)
 
         prompt = GEMINI_VIDEO_PROMPT
 

--- a/src/app/(app)/label/editor/page.tsx
+++ b/src/app/(app)/label/editor/page.tsx
@@ -61,6 +61,9 @@ import {
 } from "@/hooks/use-pattern-labels";
 import {
   PATTERN_FAMILIES,
+  PATTERN_COUNTS,
+  CUSTOM_FAMILY_SENTINEL,
+  isKnownFamily,
   normalizePatternName,
   variantsFor,
   type PatternFamily,
@@ -672,7 +675,20 @@ function EditLabelDialog({
   const canSave =
     state.name.trim().length > 0 && state.end_time > state.start_time;
 
+  // True when the editor is in custom-pattern mode: either the user
+  // just picked "Other" (state.name === "") or the existing label was
+  // saved with a non-canonical name we don't recognize. Custom mode
+  // hides the variant dropdown (variants are family-scoped and don't
+  // make sense for ad-hoc labels) and shows a free-text input.
+  const isCustom = !isKnownFamily(state.name);
+
   const handleFamilyChange = (id: string) => {
+    if (id === CUSTOM_FAMILY_SENTINEL) {
+      // Drop into custom mode with a fresh empty name. The text input
+      // below will collect what the user actually wants to call it.
+      onChange({ ...state, name: "", variant: "" });
+      return;
+    }
     const fam = PATTERN_FAMILIES.find((f) => f.id === id);
     onChange({
       ...state,
@@ -731,7 +747,10 @@ function EditLabelDialog({
 
           <div className="space-y-1.5">
             <Label>Pattern family</Label>
-            <Select value={state.name} onValueChange={handleFamilyChange}>
+            <Select
+              value={isCustom ? CUSTOM_FAMILY_SENTINEL : state.name}
+              onValueChange={handleFamilyChange}
+            >
               <SelectTrigger>
                 <SelectValue placeholder="Pick a pattern" />
               </SelectTrigger>
@@ -748,11 +767,36 @@ function EditLabelDialog({
                     ))}
                   </SelectGroup>
                 ))}
+                <SelectGroup>
+                  <SelectLabel className="text-[10px] uppercase tracking-wide">
+                    custom
+                  </SelectLabel>
+                  <SelectItem value={CUSTOM_FAMILY_SENTINEL}>
+                    Other (type your own)
+                  </SelectItem>
+                </SelectGroup>
               </SelectContent>
             </Select>
           </div>
 
-          {availableVariants.length > 1 && (
+          {isCustom && (
+            <div className="space-y-1.5">
+              <Label htmlFor="custom-name">Pattern name</Label>
+              <Input
+                id="custom-name"
+                value={state.name}
+                onChange={(e) => onChange({ ...state, name: e.target.value })}
+                placeholder="e.g. sugar push + tuck combo"
+                maxLength={120}
+                autoFocus
+              />
+              <p className="text-[11px] text-muted-foreground">
+                Use this for conjoined patterns or moves not in the dropdown.
+              </p>
+            </div>
+          )}
+
+          {!isCustom && availableVariants.length > 1 && (
             <div className="space-y-1.5">
               <Label>Variant</Label>
               <Select
@@ -782,11 +826,15 @@ function EditLabelDialog({
               }
             >
               <SelectTrigger>
-                <SelectValue placeholder="6 or 8" />
+                <SelectValue placeholder="6, 8, or longer" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="6">6-count</SelectItem>
-                <SelectItem value="8">8-count</SelectItem>
+                {PATTERN_COUNTS.map((n) => (
+                  <SelectItem key={n} value={String(n)}>
+                    {n}-count
+                    {n > 8 ? " (conjoined)" : ""}
+                  </SelectItem>
+                ))}
               </SelectContent>
             </Select>
           </div>

--- a/src/lib/pattern-vocabulary.ts
+++ b/src/lib/pattern-vocabulary.ts
@@ -135,3 +135,18 @@ export function variantsFor(familyId: string): PatternVariant[] {
     (v) => v.families.includes("*") || v.families.includes(familyId)
   );
 }
+
+/** Sentinel value the family Select uses to switch into free-text mode.
+ *  Never written to pattern_labels.name — the editor swaps it out for
+ *  whatever the user types. */
+export const CUSTOM_FAMILY_SENTINEL = "__custom__";
+
+/** Counts available in the editor. 6 and 8 cover the canonical WCS
+ *  patterns; 10 / 12 / 16 are for conjoined / extended patterns
+ *  (e.g. a sugar push joined with a tuck and a free spin makes a
+ *  multi-phrase block the user wants to label as one unit). */
+export const PATTERN_COUNTS: number[] = [6, 8, 10, 12, 16];
+
+export function isKnownFamily(name: string): boolean {
+  return PATTERN_FAMILIES.some((f) => f.id === name);
+}


### PR DESCRIPTION
Two unrelated changes bundled because both came from the same user testing pass.

## 1. Revert Gemini fps to 2 (undo #151)

The verification re-run on IMG_8665 didn't identify any new free spins or non-basic variants vs. the fps=2 baseline — pattern variety actually decreased slightly. The fps lever isn't the bottleneck for variant recognition; the model's defaulting behavior is. Reverted to save the 2x video token cost. Added a comment so future-me doesn't try the same thing again.

## 2. Label editor: custom patterns + extended counts

User wanted to label:
- **Conjoined patterns** — e.g. *sugar push + tuck + free spin* as one block
- **Moves not in the canonical dropdown** — anything that's not standard WSDC vocabulary

Changes:
- Family picker has a new \`Other (type your own)\` item that flips into a free-text input
- Count picker now offers 6 / 8 / **10 / 12 / 16** (10+ get a "(conjoined)" suffix)
- Variant dropdown is hidden in custom mode (variants are family-scoped, don't make sense for ad-hoc labels)

The \`pattern_labels\` table already has \`name text\` and \`count int\` with no constraints, so no schema change.

## Test plan

- [ ] After deploy: open /label/editor on any analysis, click Add label, pick "Other" — confirm a text input appears with autofocus
- [ ] Pick a count >8 — confirm it saves and reloads correctly