### PR TITLE
Persist beat_grid_error so silent fails are queryable

### DIFF
--- a/api/src/wcs_api/services/video_analysis/analyzer.py
+++ b/api/src/wcs_api/services/video_analysis/analyzer.py
@@ -257,6 +257,7 @@ def analyze_video_path(
             beat_context,
             first_downbeat_sec,
             beat_grid,
+            beat_grid_error,
         ) = _extract_beat_context(video_path)
         if beat_context:
             prompt = f"{beat_context}\n\n{prompt}"
@@ -505,6 +506,7 @@ def analyze_video_path(
         dance_start_sec=dance_start_sec,
         dance_end_sec=dance_end_sec,
         beat_grid=beat_grid,
+        beat_grid_error=beat_grid_error,
         user_song_style=user_song_style,
     )
 

--- a/api/src/wcs_api/services/video_analysis/media_context.py
+++ b/api/src/wcs_api/services/video_analysis/media_context.py
@@ -120,7 +120,7 @@ def _detect_motion_floor(video_path: str) -> float | None:
 
 def _extract_beat_context(
     video_path: str,
-) -> tuple[str | None, float | None, dict[str, Any] | None]:
+) -> tuple[str | None, float | None, dict[str, Any] | None, str | None]:
     """Pull audio out of the video, run beat tracking (Beat This!
     preferred, librosa fallback), and return a prompt-ready string
     plus the first detected downbeat (seconds) plus a compact
@@ -141,8 +141,11 @@ def _extract_beat_context(
     pulse matches what they hear — a fast diagnostic when the
     pattern timing feels off.
 
-    Silent-fail on any error — this is a best-effort enrichment,
-    not a blocker on the analysis itself.
+    Returns a 4-tuple `(prompt, first_downbeat, beat_grid, error)`.
+    On success, `error` is None. On failure, the first three are None
+    and `error` is a short tag (e.g. `"track_returned_none"`,
+    `"ffmpeg_failed"`, `"exception:ImportError"`) the caller persists
+    so we can grep failing analyses without log diving.
     """
     try:
         from ..beat_tracker import (
@@ -153,26 +156,53 @@ def _extract_beat_context(
 
         wav_path = tempfile.NamedTemporaryFile(delete=False, suffix=".wav").name
         try:
-            subprocess.run(
-                [
-                    "ffmpeg",
-                    "-y",
-                    "-i",
+            try:
+                subprocess.run(
+                    [
+                        "ffmpeg",
+                        "-y",
+                        "-i",
+                        video_path,
+                        "-vn",
+                        "-ac",
+                        "1",
+                        "-ar",
+                        "22050",
+                        wav_path,
+                    ],
+                    capture_output=True,
+                    check=True,
+                    timeout=60,
+                )
+            except subprocess.CalledProcessError as exc:
+                logger.error(
+                    "video_analysis.beat_context_ffmpeg_failed video=%s rc=%s stderr=%r",
                     video_path,
-                    "-vn",
-                    "-ac",
-                    "1",
-                    "-ar",
-                    "22050",
-                    wav_path,
-                ],
-                capture_output=True,
-                check=True,
-                timeout=60,
-            )
+                    exc.returncode,
+                    (exc.stderr or b"")[:500],
+                )
+                return None, None, None, "ffmpeg_failed"
+            except subprocess.TimeoutExpired:
+                logger.error(
+                    "video_analysis.beat_context_ffmpeg_timeout video=%s",
+                    video_path,
+                )
+                return None, None, None, "ffmpeg_timeout"
             result = track_beats(wav_path)
-            if result is None or len(result.beats) < 4:
-                return None, None, None
+            if result is None:
+                logger.error(
+                    "video_analysis.beat_context_track_failed video=%s "
+                    "(both Beat This! and librosa returned None — see prior warnings)",
+                    video_path,
+                )
+                return None, None, None, "track_returned_none"
+            if len(result.beats) < 4:
+                logger.error(
+                    "video_analysis.beat_context_too_few_beats video=%s n_beats=%d",
+                    video_path,
+                    len(result.beats),
+                )
+                return None, None, None, "too_few_beats"
             bpm = result.bpm
             # Swing-ratio heuristic: tells us whether eighth notes are
             # swung (blues, shuffle) or straight (contemporary, pop).
@@ -349,7 +379,7 @@ def _extract_beat_context(
                 "swing_ratio": swing_ratio,
                 "detected_style": detected_style,
             }
-            return prompt_text, first_downbeat_sec, beat_grid
+            return prompt_text, first_downbeat_sec, beat_grid, None
         finally:
             try:
                 os.unlink(wav_path)
@@ -358,15 +388,16 @@ def _extract_beat_context(
     except Exception as exc:  # noqa: BLE001
         # Silent failure here cascades into an empty `beat_grid` and a
         # missing `first_downbeat_sec` floor on the analyzer, which
-        # then lets pre-dance hallucinations through. Log loud enough
-        # that Railway logs show why the beat context is absent when
-        # a real analysis ships with beat_grid={}.
-        logger.warning(
+        # then lets pre-dance hallucinations through. Log at error so
+        # Railway log queries surface it by default, and return the
+        # exception class as the persisted reason so we can grep
+        # video_analyses.result->>beat_grid_error in Supabase.
+        logger.error(
             "video_analysis.beat_context_failed video=%s error=%r",
             video_path,
             exc,
         )
-        return None, None, None
+        return None, None, None, f"exception:{type(exc).__name__}"
 
 
 # ─────────────────────────────────────────────────────────────────────

--- a/api/src/wcs_api/services/video_analysis/response_sanitizer.py
+++ b/api/src/wcs_api/services/video_analysis/response_sanitizer.py
@@ -1091,6 +1091,7 @@ def _shape_response(
     dance_start_sec: float | None = None,
     dance_end_sec: float | None = None,
     beat_grid: dict[str, Any] | None = None,
+    beat_grid_error: str | None = None,
     user_song_style: str | None = None,
 ) -> dict[str, Any]:
     """Map Gemini's rich response into the API's return shape.
@@ -1240,6 +1241,7 @@ def _shape_response(
         "dance_start_sec": dance_start_sec,
         "dance_end_sec": dance_end_sec,
         "beat_grid": beat_grid,
+        "beat_grid_error": beat_grid_error,
         "strengths": strengths,
         "improvements": improvements,
         "lead": parsed.get("lead"),


### PR DESCRIPTION
## Summary

Closes #140 by adding observability — the bug stopped firing on its own around 4/22 (every analysis since then has a populated `beat_grid`), but Railway's log retention had already rotated past the failing window so we couldn't pin the root cause. Make sure the next regression is greppable.

- Differentiate the three silent-return paths in `_extract_beat_context`: `ffmpeg_failed`, `ffmpeg_timeout`, `track_returned_none`, `too_few_beats`, and `exception:<Type>` for the catch-all.
- Bump those logs from warning to error so default Railway queries surface them.
- Return the failure tag as a new 4th tuple element and persist it on the analysis response as `beat_grid_error`. Lets us SQL-query `result->>beat_grid_error` in Supabase instead of digging through container logs.

## Test plan

- [x] `uv run python -m compileall src/wcs_api/services/video_analysis/` clean
- [ ] Frontend reads `beat_grid` only — adding `beat_grid_error` is additive, no UI change needed
- [ ] On next failing analysis, verify the tag appears in `video_analyses.result->>beat_grid_error`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* The video analysis API now returns a `beat_grid_error` field in responses, providing detailed error information when beat grid extraction encounters issues such as FFmpeg failures, timeouts, or insufficient beat detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->