### PR TITLE
Cross-analysis Patterns view with filters + sort

### DIFF
--- a/src/app/(app)/analysis/page.tsx
+++ b/src/app/(app)/analysis/page.tsx
@@ -49,6 +49,16 @@ function AnalysisPageInner() {
   const params = useSearchParams();
   const router = useRouter();
   const id = params.get("id");
+  // Optional deep-link timestamp (#138) — the cross-analysis Patterns
+  // view links here with `&t=<seconds>` so the video starts paused at
+  // the occurrence's start. We pass it down once; the timeline ignores
+  // changes to a value it has already honored for the current src.
+  const seekParam = params.get("t");
+  const initialSeekSec = (() => {
+    if (seekParam == null) return undefined;
+    const n = Number(seekParam);
+    return Number.isFinite(n) && n >= 0 ? n : undefined;
+  })();
 
   const history = useAnalysisHistory();
   const [videoUrl, setVideoUrl] = useState<string | null>(null);
@@ -499,6 +509,7 @@ function AnalysisPageInner() {
         duration={record.duration ?? 0}
         videoSrc={videoUrl}
         analysisId={record.id}
+        initialSeekSec={initialSeekSec}
       />
 
       {/* Score + sub-scores + patterns + strengths + improvements */}

--- a/src/app/(app)/dashboard/patterns/page.tsx
+++ b/src/app/(app)/dashboard/patterns/page.tsx
@@ -1,0 +1,526 @@
+"use client";
+
+// Cross-analysis "My patterns" view (#138). Aggregates
+// patterns_identified across the user's whole history with
+// filters (date / stage / level) and sort modes (frequency /
+// weakest / most recent). Shares aggregation logic with the
+// dashboard snapshot card via @/lib/pattern-aggregation so the
+// numbers stay in lockstep.
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { ChevronDown, ChevronRight, ArrowLeft, Filter, Grip } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useAnalysisHistory } from "@/hooks/use-analysis-history";
+import {
+  aggregatePatterns,
+  formatPatternDate,
+  formatPatternTime,
+  titleCasePattern,
+  type PatternAgg,
+} from "@/lib/pattern-aggregation";
+
+type SortMode = "frequency" | "weakest" | "recent" | "best";
+type DatePreset = "all" | "7d" | "30d" | "90d" | "365d";
+
+const DATE_PRESET_DAYS: Record<Exclude<DatePreset, "all">, number> = {
+  "7d": 7,
+  "30d": 30,
+  "90d": 90,
+  "365d": 365,
+};
+
+const ANY = "__any__";
+
+function weaknessScore(a: PatternAgg): number {
+  // Higher score = weaker. Weighted so weak/needs_work dominate over
+  // raw count — a single weak rep ranks above two solids of the same
+  // family. Returns 0 when the pattern has no quality signal at all.
+  const denom = a.strong + a.solid + a.needsWork + a.weak;
+  if (denom === 0) return 0;
+  return (a.weak * 3 + a.needsWork * 2) / denom;
+}
+
+function bestScore(a: PatternAgg): number {
+  const denom = a.strong + a.solid + a.needsWork + a.weak;
+  if (denom === 0) return 0;
+  return (a.strong * 3 + a.solid * 2) / denom;
+}
+
+function lastSeenIso(a: PatternAgg): string {
+  return a.occurrences.reduce(
+    (max, o) => (o.createdAt > max ? o.createdAt : max),
+    ""
+  );
+}
+
+function firstSeenIso(a: PatternAgg): string {
+  if (a.occurrences.length === 0) return "";
+  return a.occurrences.reduce(
+    (min, o) => (min === "" || o.createdAt < min ? o.createdAt : min),
+    ""
+  );
+}
+
+export default function CrossAnalysisPatternsPage() {
+  const history = useAnalysisHistory();
+  const [sortMode, setSortMode] = useState<SortMode>("frequency");
+  const [datePreset, setDatePreset] = useState<DatePreset>("all");
+  const [stageFilter, setStageFilter] = useState<string>(ANY);
+  const [levelFilter, setLevelFilter] = useState<string>(ANY);
+  const [eventFilter, setEventFilter] = useState<string>(ANY);
+  const [expanded, setExpanded] = useState<string | null>(null);
+  // Snapshot "now" once at mount so the date-range cutoff is stable
+  // across re-renders. The lint rule flags Date.now() in render bodies
+  // because it makes the component non-idempotent; pinning it here
+  // also means "last 7 days" doesn't tick forward by the second
+  // while the user is interacting with filters.
+  const [nowMs] = useState<number>(() => Date.now());
+
+  // Build the filter dropdowns from the records we actually have —
+  // free-text fields (stage, competition_level, event_name) get
+  // de-duped + sorted so picking the same value the user typed
+  // upstream just works. "Any" stays first.
+  const allRecords = useMemo(
+    () => history.records.filter((r) => !r.deleted_at),
+    [history.records]
+  );
+
+  const stageOptions = useMemo(() => extractStrings(allRecords, "stage"), [
+    allRecords,
+  ]);
+  const levelOptions = useMemo(
+    () => extractStrings(allRecords, "competition_level"),
+    [allRecords]
+  );
+  const eventOptions = useMemo(
+    () => extractStrings(allRecords, "event_name"),
+    [allRecords]
+  );
+
+  const filtered = useMemo(() => {
+    const cutoff =
+      datePreset === "all"
+        ? null
+        : new Date(
+            nowMs - DATE_PRESET_DAYS[datePreset] * 24 * 60 * 60 * 1000
+          ).toISOString();
+    return allRecords.filter((r) => {
+      if (cutoff && r.created_at < cutoff) return false;
+      if (stageFilter !== ANY && (r.stage ?? "") !== stageFilter) return false;
+      if (
+        levelFilter !== ANY &&
+        (r.competition_level ?? "") !== levelFilter
+      )
+        return false;
+      if (
+        eventFilter !== ANY &&
+        (r.event_name ?? "") !== eventFilter
+      )
+        return false;
+      return true;
+    });
+  }, [allRecords, datePreset, stageFilter, levelFilter, eventFilter, nowMs]);
+
+  const aggs = useMemo(() => {
+    const base = aggregatePatterns(filtered);
+    switch (sortMode) {
+      case "weakest":
+        // Patterns with no quality signal sink to the bottom so they
+        // don't masquerade as "perfect."
+        return [...base].sort(
+          (a, b) =>
+            weaknessScore(b) - weaknessScore(a) ||
+            b.count - a.count ||
+            a.name.localeCompare(b.name)
+        );
+      case "best":
+        return [...base].sort(
+          (a, b) =>
+            bestScore(b) - bestScore(a) ||
+            b.count - a.count ||
+            a.name.localeCompare(b.name)
+        );
+      case "recent":
+        return [...base].sort((a, b) =>
+          lastSeenIso(b).localeCompare(lastSeenIso(a))
+        );
+      case "frequency":
+      default:
+        return base;
+    }
+  }, [filtered, sortMode]);
+
+  const totalOccurrences = aggs.reduce((s, a) => s + a.count, 0);
+  const totalAnalyses = filtered.length;
+
+  return (
+    <div className="space-y-4 sm:space-y-6 max-w-5xl mx-auto">
+      <div className="flex items-center gap-2">
+        <Button asChild variant="ghost" size="sm" className="-ml-2 h-8">
+          <Link href="/dashboard">
+            <ArrowLeft className="h-4 w-4 mr-1" />
+            Dashboard
+          </Link>
+        </Button>
+      </div>
+
+      <div>
+        <h1 className="text-2xl font-bold flex items-center gap-2">
+          <Grip className="h-5 w-5 text-primary" />
+          My patterns
+        </h1>
+        <p className="text-muted-foreground">
+          Every pattern family across all your analyses. Filter by date,
+          event, or stage; sort by frequency, weakness, or recency.
+        </p>
+      </div>
+
+      {/* ─── Filter bar ─── */}
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-sm flex items-center gap-2">
+            <Filter className="h-3.5 w-3.5 text-muted-foreground" />
+            Filters
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <FilterPicker
+            label="Date range"
+            value={datePreset}
+            onValueChange={(v) => setDatePreset(v as DatePreset)}
+            options={[
+              { value: "all", label: "All time" },
+              { value: "7d", label: "Last 7 days" },
+              { value: "30d", label: "Last 30 days" },
+              { value: "90d", label: "Last 90 days" },
+              { value: "365d", label: "Last year" },
+            ]}
+          />
+          <FilterPicker
+            label="Stage"
+            value={stageFilter}
+            onValueChange={setStageFilter}
+            options={[
+              { value: ANY, label: "Any stage" },
+              ...stageOptions.map((v) => ({ value: v, label: v })),
+            ]}
+            disabled={stageOptions.length === 0}
+          />
+          <FilterPicker
+            label="Level"
+            value={levelFilter}
+            onValueChange={setLevelFilter}
+            options={[
+              { value: ANY, label: "Any level" },
+              ...levelOptions.map((v) => ({ value: v, label: v })),
+            ]}
+            disabled={levelOptions.length === 0}
+          />
+          <FilterPicker
+            label="Event"
+            value={eventFilter}
+            onValueChange={setEventFilter}
+            options={[
+              { value: ANY, label: "Any event" },
+              ...eventOptions.map((v) => ({ value: v, label: v })),
+            ]}
+            disabled={eventOptions.length === 0}
+          />
+        </CardContent>
+      </Card>
+
+      {/* ─── Sort + counts row ─── */}
+      <div className="flex flex-wrap items-center gap-3 justify-between">
+        <span className="text-sm text-muted-foreground tabular-nums">
+          {history.loading
+            ? "Loading…"
+            : `${totalOccurrences} occurrences · ${aggs.length} patterns · ${totalAnalyses} analyses`}
+        </span>
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-muted-foreground">Sort by</span>
+          <Select
+            value={sortMode}
+            onValueChange={(v) => setSortMode(v as SortMode)}
+          >
+            <SelectTrigger className="h-8 text-sm w-[160px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="frequency">Most danced</SelectItem>
+              <SelectItem value="weakest">Weakest first</SelectItem>
+              <SelectItem value="best">Strongest first</SelectItem>
+              <SelectItem value="recent">Most recent</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {/* ─── Pattern list ─── */}
+      {history.loading ? (
+        <p className="text-sm text-muted-foreground">Loading patterns…</p>
+      ) : aggs.length === 0 ? (
+        <Card>
+          <CardContent className="py-10 text-center text-sm text-muted-foreground">
+            No patterns matched these filters.{" "}
+            {totalAnalyses === 0 && allRecords.length > 0 && (
+              <>Loosen the date/event/stage selection above.</>
+            )}
+            {allRecords.length === 0 && (
+              <>
+                Analyze a few clips and your patterns will roll up here.{" "}
+                <Link href="/analyze" className="underline">
+                  Analyze a video →
+                </Link>
+              </>
+            )}
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-2">
+          {aggs.map((agg) => (
+            <PatternRow
+              key={agg.name}
+              agg={agg}
+              isOpen={expanded === agg.name}
+              onToggle={() =>
+                setExpanded((prev) => (prev === agg.name ? null : agg.name))
+              }
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function FilterPicker({
+  label,
+  value,
+  onValueChange,
+  options,
+  disabled,
+}: {
+  label: string;
+  value: string;
+  onValueChange: (v: string) => void;
+  options: { value: string; label: string }[];
+  disabled?: boolean;
+}) {
+  return (
+    <div className="space-y-1">
+      <label className="text-xs text-muted-foreground">{label}</label>
+      <Select
+        value={value}
+        onValueChange={onValueChange}
+        disabled={disabled}
+      >
+        <SelectTrigger className="h-9 text-sm">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {options.map((o) => (
+            <SelectItem key={o.value} value={o.value}>
+              {o.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
+
+function PatternRow({
+  agg,
+  isOpen,
+  onToggle,
+}: {
+  agg: PatternAgg;
+  isOpen: boolean;
+  onToggle: () => void;
+}) {
+  const qSum = agg.strong + agg.solid + agg.needsWork + agg.weak;
+  const tSum = agg.onBeat + agg.slightlyOff + agg.offBeat;
+  const pct = (part: number) => (qSum > 0 ? (part / qSum) * 100 : 0);
+  const last = lastSeenIso(agg);
+  const first = firstSeenIso(agg);
+
+  return (
+    <div className="rounded-md border border-border bg-muted/10 overflow-hidden">
+      <button
+        type="button"
+        className="w-full flex items-center gap-2 px-3 py-2.5 text-sm hover:bg-muted/20 transition-colors text-left"
+        onClick={onToggle}
+        aria-expanded={isOpen}
+      >
+        {isOpen ? (
+          <ChevronDown className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+        ) : (
+          <ChevronRight className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+        )}
+        <span className="font-medium flex-1 min-w-0 truncate">
+          {titleCasePattern(agg.name)}
+        </span>
+        <span className="tabular-nums text-muted-foreground text-xs shrink-0">
+          ×{agg.count}
+        </span>
+        <div
+          className="flex h-2 w-24 sm:w-32 rounded-sm overflow-hidden bg-muted/30 shrink-0"
+          title={`${agg.strong} strong · ${agg.solid} solid · ${agg.needsWork} needs work · ${agg.weak} weak`}
+        >
+          {pct(agg.strong) > 0 && (
+            <span
+              className="bg-emerald-500/80"
+              style={{ width: `${pct(agg.strong)}%` }}
+            />
+          )}
+          {pct(agg.solid) > 0 && (
+            <span
+              className="bg-primary/80"
+              style={{ width: `${pct(agg.solid)}%` }}
+            />
+          )}
+          {pct(agg.needsWork) > 0 && (
+            <span
+              className="bg-amber-500/80"
+              style={{ width: `${pct(agg.needsWork)}%` }}
+            />
+          )}
+          {pct(agg.weak) > 0 && (
+            <span
+              className="bg-rose-500/80"
+              style={{ width: `${pct(agg.weak)}%` }}
+            />
+          )}
+        </div>
+      </button>
+      {isOpen && (
+        <div className="border-t border-border bg-background/40 px-3 py-3 text-xs space-y-3">
+          <div className="flex flex-wrap gap-x-4 gap-y-1 text-muted-foreground">
+            <span>
+              <span className="text-emerald-400 font-medium">{agg.strong}</span>{" "}
+              strong
+            </span>
+            <span>
+              <span className="text-primary font-medium">{agg.solid}</span>{" "}
+              solid
+            </span>
+            <span>
+              <span className="text-amber-400 font-medium">{agg.needsWork}</span>{" "}
+              needs work
+            </span>
+            <span>
+              <span className="text-rose-400 font-medium">{agg.weak}</span>{" "}
+              weak
+            </span>
+            {tSum > 0 && (
+              <span className="sm:ml-auto">
+                Timing:{" "}
+                <span className="text-foreground font-medium">
+                  {Math.round((agg.onBeat / tSum) * 100)}%
+                </span>{" "}
+                on-beat
+              </span>
+            )}
+          </div>
+          {(first || last) && (
+            <div className="flex flex-wrap gap-x-3 gap-y-1 text-[11px] text-muted-foreground">
+              {first && (
+                <span>
+                  First seen:{" "}
+                  <span className="text-foreground">
+                    {formatPatternDate(first)}
+                  </span>
+                </span>
+              )}
+              {last && (
+                <span>
+                  Last seen:{" "}
+                  <span className="text-foreground">
+                    {formatPatternDate(last)}
+                  </span>
+                </span>
+              )}
+            </div>
+          )}
+          <div className="space-y-1">
+            {agg.occurrences
+              .slice()
+              .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+              .map((occ, i) => (
+                <Link
+                  key={`${occ.analysisId}-${i}`}
+                  href={`/analysis?id=${encodeURIComponent(occ.analysisId)}`}
+                  className="flex items-center gap-2 rounded px-1.5 py-1 hover:bg-muted/30 transition-colors"
+                >
+                  <span
+                    className={cn(
+                      "inline-block h-2 w-2 rounded-sm shrink-0",
+                      occ.quality === "strong"
+                        ? "bg-emerald-500"
+                        : occ.quality === "solid"
+                        ? "bg-primary"
+                        : occ.quality === "needs_work"
+                        ? "bg-amber-500"
+                        : occ.quality === "weak"
+                        ? "bg-rose-500"
+                        : "bg-muted-foreground/40"
+                    )}
+                  />
+                  <span className="text-muted-foreground shrink-0 tabular-nums">
+                    {formatPatternDate(occ.createdAt)}
+                  </span>
+                  {occ.startTime != null && (
+                    <span className="text-muted-foreground tabular-nums shrink-0">
+                      {formatPatternTime(occ.startTime)}
+                    </span>
+                  )}
+                  <span className="text-foreground truncate flex-1 min-w-0">
+                    {occ.filename ?? "Untitled"}
+                  </span>
+                  {occ.timing && (
+                    <span className="text-[10px] text-muted-foreground shrink-0">
+                      {occ.timing.replace("_", " ")}
+                    </span>
+                  )}
+                  {(occ.stage || occ.competitionLevel) && (
+                    <span className="text-[10px] text-muted-foreground shrink-0">
+                      {[occ.competitionLevel, occ.stage]
+                        .filter(Boolean)
+                        .join(" · ")}
+                    </span>
+                  )}
+                </Link>
+              ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function extractStrings(
+  records: { stage: string | null; competition_level: string | null; event_name: string | null }[],
+  field: "stage" | "competition_level" | "event_name"
+): string[] {
+  const set = new Set<string>();
+  for (const r of records) {
+    const v = r[field];
+    if (v && v.trim()) set.add(v.trim());
+  }
+  return Array.from(set).sort((a, b) => a.localeCompare(b));
+}

--- a/src/app/(app)/dashboard/patterns/page.tsx
+++ b/src/app/(app)/dashboard/patterns/page.tsx
@@ -166,7 +166,15 @@ export default function CrossAnalysisPatternsPage() {
   }, [filtered, sortMode]);
 
   const totalOccurrences = aggs.reduce((s, a) => s + a.count, 0);
-  const totalAnalyses = filtered.length;
+  // Count unique analyses that actually CONTRIBUTED a pattern, not
+  // every record that passed the filters. Matches the dashboard
+  // snapshot card's denominator so the two views stay consistent for
+  // users who eyeball both ("7 analyses" can't say 10 here and 7
+  // there for the same data).
+  const contributingAnalyses = new Set(
+    aggs.flatMap((a) => a.occurrences.map((o) => o.analysisId))
+  ).size;
+  const matchedClips = filtered.length;
 
   return (
     <div className="space-y-4 sm:space-y-6 max-w-5xl mx-auto">
@@ -249,7 +257,7 @@ export default function CrossAnalysisPatternsPage() {
         <span className="text-sm text-muted-foreground tabular-nums">
           {history.loading
             ? "Loading…"
-            : `${totalOccurrences} occurrences · ${aggs.length} patterns · ${totalAnalyses} analyses`}
+            : `${totalOccurrences} occurrences · ${aggs.length} patterns · ${contributingAnalyses} of ${matchedClips} clips`}
         </span>
         <div className="flex items-center gap-2">
           <span className="text-xs text-muted-foreground">Sort by</span>
@@ -277,7 +285,7 @@ export default function CrossAnalysisPatternsPage() {
         <Card>
           <CardContent className="py-10 text-center text-sm text-muted-foreground">
             No patterns matched these filters.{" "}
-            {totalAnalyses === 0 && allRecords.length > 0 && (
+            {matchedClips === 0 && allRecords.length > 0 && (
               <>Loosen the date/event/stage selection above.</>
             )}
             {allRecords.length === 0 && (
@@ -464,7 +472,11 @@ function PatternRow({
               .map((occ, i) => (
                 <Link
                   key={`${occ.analysisId}-${i}`}
-                  href={`/analysis?id=${encodeURIComponent(occ.analysisId)}`}
+                  href={
+                    occ.startTime != null
+                      ? `/analysis?id=${encodeURIComponent(occ.analysisId)}&t=${Math.floor(occ.startTime)}`
+                      : `/analysis?id=${encodeURIComponent(occ.analysisId)}`
+                  }
                   className="flex items-center gap-2 rounded px-1.5 py-1 hover:bg-muted/30 transition-colors"
                 >
                   <span

--- a/src/components/analyze/pattern-stats-card.tsx
+++ b/src/components/analyze/pattern-stats-card.tsx
@@ -8,132 +8,15 @@
 import { useMemo, useState } from "react";
 import Link from "next/link";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { ChevronDown, ChevronRight, Grip } from "lucide-react";
+import { ChevronDown, ChevronRight, Grip, ArrowRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { AnalysisRecord } from "@/hooks/use-analysis-history";
-
-type Occurrence = {
-  analysisId: string;
-  createdAt: string;
-  startTime: number | null;
-  endTime: number | null;
-  quality: string | null;
-  timing: string | null;
-  filename: string | null;
-};
-
-type PatternAgg = {
-  name: string;
-  count: number;
-  strong: number;
-  solid: number;
-  needsWork: number;
-  weak: number;
-  onBeat: number;
-  slightlyOff: number;
-  offBeat: number;
-  occurrences: Occurrence[];
-};
-
-function normalizeName(raw: string): string {
-  // Collapse whitespace + lowercase so "Sugar Push" and "sugar  push"
-  // aggregate together. We don't touch variant/sub-type here — the
-  // family-level roll-up is what the user wants on the dashboard.
-  return raw.trim().toLowerCase().replace(/\s+/g, " ");
-}
-
-function titleCase(s: string): string {
-  return s
-    .split(" ")
-    .filter(Boolean)
-    .map((w) => w[0].toUpperCase() + w.slice(1))
-    .join(" ");
-}
-
-function aggregate(records: AnalysisRecord[]): PatternAgg[] {
-  const byName = new Map<string, PatternAgg>();
-  for (const r of records) {
-    // Skip low-confidence analyses so noisy model output doesn't
-    // pollute the pattern stats. Once timeline_locked lands server-
-    // side this can switch to that flag (see #109 scope notes).
-    if (r.result?.overall?.confidence === "low") continue;
-    const patterns = r.result?.patterns_identified ?? [];
-    for (const p of patterns) {
-      if (!p?.name) continue;
-      const key = normalizeName(p.name);
-      if (!key) continue;
-      const existing =
-        byName.get(key) ??
-        ({
-          name: key,
-          count: 0,
-          strong: 0,
-          solid: 0,
-          needsWork: 0,
-          weak: 0,
-          onBeat: 0,
-          slightlyOff: 0,
-          offBeat: 0,
-          occurrences: [],
-        } satisfies PatternAgg);
-      existing.count += 1;
-      switch (p.quality) {
-        case "strong":
-          existing.strong += 1;
-          break;
-        case "solid":
-          existing.solid += 1;
-          break;
-        case "needs_work":
-          existing.needsWork += 1;
-          break;
-        case "weak":
-          existing.weak += 1;
-          break;
-      }
-      switch (p.timing) {
-        case "on_beat":
-          existing.onBeat += 1;
-          break;
-        case "slightly_off":
-          existing.slightlyOff += 1;
-          break;
-        case "off_beat":
-          existing.offBeat += 1;
-          break;
-      }
-      existing.occurrences.push({
-        analysisId: r.id,
-        createdAt: r.created_at,
-        startTime: typeof p.start_time === "number" ? p.start_time : null,
-        endTime: typeof p.end_time === "number" ? p.end_time : null,
-        quality: p.quality ?? null,
-        timing: p.timing ?? null,
-        filename: r.filename,
-      });
-      byName.set(key, existing);
-    }
-  }
-  // Sort by count desc, then name for determinism.
-  return Array.from(byName.values()).sort(
-    (a, b) => b.count - a.count || a.name.localeCompare(b.name)
-  );
-}
-
-function formatTime(sec: number): string {
-  if (!Number.isFinite(sec) || sec < 0) return "0:00";
-  const m = Math.floor(sec / 60);
-  const s = Math.floor(sec % 60);
-  return `${m}:${s.toString().padStart(2, "0")}`;
-}
-
-function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  });
-}
+import {
+  aggregatePatterns,
+  formatPatternDate,
+  formatPatternTime,
+  titleCasePattern,
+} from "@/lib/pattern-aggregation";
 
 export function PatternStatsCard({
   records,
@@ -143,7 +26,7 @@ export function PatternStatsCard({
   loading: boolean;
 }) {
   const [expanded, setExpanded] = useState<string | null>(null);
-  const aggs = useMemo(() => aggregate(records), [records]);
+  const aggs = useMemo(() => aggregatePatterns(records), [records]);
   // Cap the panel so the dashboard stays scannable. Anything past
   // the top 8 is long-tail and better viewed via /analyze → filter.
   const TOP_N = 8;
@@ -205,7 +88,7 @@ export function PatternStatsCard({
                       <ChevronRight className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
                     )}
                     <span className="font-medium flex-1 min-w-0 truncate">
-                      {titleCase(agg.name)}
+                      {titleCasePattern(agg.name)}
                     </span>
                     <span className="tabular-nums text-muted-foreground text-xs shrink-0">
                       ×{agg.count}
@@ -307,11 +190,11 @@ export function PatternStatsCard({
                                 )}
                               />
                               <span className="text-muted-foreground shrink-0 tabular-nums">
-                                {formatDate(occ.createdAt)}
+                                {formatPatternDate(occ.createdAt)}
                               </span>
                               {occ.startTime != null && (
                                 <span className="text-muted-foreground tabular-nums shrink-0">
-                                  {formatTime(occ.startTime)}
+                                  {formatPatternTime(occ.startTime)}
                                 </span>
                               )}
                               <span className="text-foreground truncate flex-1 min-w-0">
@@ -330,10 +213,16 @@ export function PatternStatsCard({
                 </div>
               );
             })}
-            {aggs.length > TOP_N && (
-              <p className="text-[11px] text-muted-foreground text-center pt-1">
-                Showing top {TOP_N} of {aggs.length} patterns.
-              </p>
+            {aggs.length > 0 && (
+              <Link
+                href="/dashboard/patterns"
+                className="flex items-center justify-center gap-1 text-[11px] text-muted-foreground hover:text-foreground transition-colors pt-1"
+              >
+                {aggs.length > TOP_N
+                  ? `View all ${aggs.length} patterns with filters`
+                  : "Open full pattern history"}
+                <ArrowRight className="h-3 w-3" />
+              </Link>
             )}
           </div>
         )}

--- a/src/components/analyze/timeline-view.tsx
+++ b/src/components/analyze/timeline-view.tsx
@@ -29,6 +29,10 @@ type TimelineViewProps = {
   // on the shared view (no stable per-user id) so anonymous visitors
   // can't fiddle with the timeline. See #70.
   analysisId?: string;
+  // Initial seek target (seconds) honored once on mount. Used by
+  // the cross-analysis Patterns view (#138) to deep-link straight
+  // to a specific occurrence's start_time.
+  initialSeekSec?: number;
 };
 
 const QUALITY_COLOR: Record<string, string> = {
@@ -73,6 +77,7 @@ export function TimelineView({
   duration,
   videoSrc,
   analysisId,
+  initialSeekSec,
 }: TimelineViewProps) {
   const videoRef = useRef<HTMLVideoElement>(null);
   const [currentTime, setCurrentTime] = useState(0);
@@ -211,6 +216,24 @@ export function TimelineView({
   useEffect(() => {
     setVideoDuration(0);
   }, [videoSrc]);
+
+  // Honor the deep-link seek (`?t=...` from the cross-analysis
+  // Patterns view, #138) once per (video, target) pair. The
+  // `seek()` helper handles the not-yet-loaded case via a
+  // loadedmetadata listener, so we don't have to wait here.
+  const initialSeekKey = `${videoSrc ?? ""}|${initialSeekSec ?? ""}`;
+  const seekedForKeyRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (initialSeekSec == null || !Number.isFinite(initialSeekSec)) return;
+    if (!videoSrc) return;
+    if (seekedForKeyRef.current === initialSeekKey) return;
+    seekedForKeyRef.current = initialSeekKey;
+    seek(initialSeekSec);
+    // `seek` is referenced via closure and its identity changes per
+    // render; we intentionally only re-run when the deep-link key
+    // (videoSrc + target) changes, not on unrelated re-renders.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialSeekKey]);
 
   const seek = (t: number) => {
     const clamped = Math.max(0, Math.min(t, effectiveDuration));

--- a/src/lib/pattern-aggregation.ts
+++ b/src/lib/pattern-aggregation.ts
@@ -1,0 +1,140 @@
+// Cross-analysis pattern aggregation. Used by the dashboard
+// "My patterns" snapshot card and the full /dashboard/patterns
+// drill-down page. Keep both consumers on the same shape so the
+// snapshot's numbers match the full-page view exactly.
+
+import type { AnalysisRecord } from "@/hooks/use-analysis-history";
+
+export type Occurrence = {
+  analysisId: string;
+  createdAt: string;
+  startTime: number | null;
+  endTime: number | null;
+  quality: string | null;
+  timing: string | null;
+  filename: string | null;
+  // Surface routing context so per-occurrence rows can show context
+  // chips (e.g. "Strictly · All-Star") without the consumer needing
+  // to re-join against AnalysisRecord.
+  stage: string | null;
+  competitionLevel: string | null;
+  eventName: string | null;
+};
+
+export type PatternAgg = {
+  name: string;
+  count: number;
+  strong: number;
+  solid: number;
+  needsWork: number;
+  weak: number;
+  onBeat: number;
+  slightlyOff: number;
+  offBeat: number;
+  occurrences: Occurrence[];
+};
+
+/** Collapse whitespace + lowercase so "Sugar Push" and "sugar  push"
+ *  aggregate together. We don't touch variant/sub-type — the family-
+ *  level roll-up is what the user wants on the dashboard. */
+export function normalizePatternName(raw: string): string {
+  return raw.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+export function titleCasePattern(s: string): string {
+  return s
+    .split(" ")
+    .filter(Boolean)
+    .map((w) => w[0].toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+export function aggregatePatterns(records: AnalysisRecord[]): PatternAgg[] {
+  const byName = new Map<string, PatternAgg>();
+  for (const r of records) {
+    // Skip low-confidence analyses so noisy model output doesn't
+    // pollute the pattern stats. Once timeline_locked lands server-
+    // side this can switch to that flag (see #109 scope notes).
+    if (r.result?.overall?.confidence === "low") continue;
+    const patterns = r.result?.patterns_identified ?? [];
+    for (const p of patterns) {
+      if (!p?.name) continue;
+      const key = normalizePatternName(p.name);
+      if (!key) continue;
+      const existing =
+        byName.get(key) ??
+        ({
+          name: key,
+          count: 0,
+          strong: 0,
+          solid: 0,
+          needsWork: 0,
+          weak: 0,
+          onBeat: 0,
+          slightlyOff: 0,
+          offBeat: 0,
+          occurrences: [],
+        } satisfies PatternAgg);
+      existing.count += 1;
+      switch (p.quality) {
+        case "strong":
+          existing.strong += 1;
+          break;
+        case "solid":
+          existing.solid += 1;
+          break;
+        case "needs_work":
+          existing.needsWork += 1;
+          break;
+        case "weak":
+          existing.weak += 1;
+          break;
+      }
+      switch (p.timing) {
+        case "on_beat":
+          existing.onBeat += 1;
+          break;
+        case "slightly_off":
+          existing.slightlyOff += 1;
+          break;
+        case "off_beat":
+          existing.offBeat += 1;
+          break;
+      }
+      existing.occurrences.push({
+        analysisId: r.id,
+        createdAt: r.created_at,
+        startTime: typeof p.start_time === "number" ? p.start_time : null,
+        endTime: typeof p.end_time === "number" ? p.end_time : null,
+        quality: p.quality ?? null,
+        timing: p.timing ?? null,
+        filename: r.filename,
+        stage: r.stage,
+        competitionLevel: r.competition_level,
+        eventName: r.event_name,
+      });
+      byName.set(key, existing);
+    }
+  }
+  // Default sort: count desc, then name for determinism. Callers
+  // that need a different sort (weakest first, most recent) re-sort
+  // after the fact rather than passing a comparator down.
+  return Array.from(byName.values()).sort(
+    (a, b) => b.count - a.count || a.name.localeCompare(b.name)
+  );
+}
+
+export function formatPatternTime(sec: number): string {
+  if (!Number.isFinite(sec) || sec < 0) return "0:00";
+  const m = Math.floor(sec / 60);
+  const s = Math.floor(sec % 60);
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
+export function formatPatternDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}


### PR DESCRIPTION
Closes #138.

## Summary

New \`/dashboard/patterns\` page that aggregates \`patterns_identified\` across the user's whole history. Answers questions the per-analysis view can't:

- *What's my weakest pattern across 20 clips?*
- *Am I getting better at whips?*
- *How many sugar pushes have I danced this year?*

## What's there

- **Filters:** date range preset (7d / 30d / 90d / 365d / all), stage, level, event — dropdowns populate from values the user has actually tagged on past uploads (no hardcoded enum to drift).
- **Sort modes:** most danced (default), weakest first (weighted toward weak/needs_work proportion so a single weak rep ranks above two solids), strongest first, most recent.
- **Drill-down:** every occurrence per pattern — date, jump-to timestamp, filename, timing tag, stage/level chip.
- **First-seen / last-seen** markers per pattern.
- Dashboard snapshot card now links to the full view instead of a static \"top 8 of N\" footer.

## Why this lib refactor

The existing \`PatternStatsCard\` already had a perfectly good \`aggregate()\` function; copying it into the new page would have meant two sources of truth for \"my patterns\" counts. Extracted to \`@/lib/pattern-aggregation\` so the snapshot card and the full page can never drift on counts or occurrence shape.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] \`npm run lint\` clean for changed files
- [x] \`npm run build\` registers \`/dashboard/patterns\` static route
- [x] Dev server returns 200 on \`/dashboard/patterns\`
- [ ] Manual: open the page on production data, filter by date / stage, switch sort modes, expand a pattern, click an occurrence → land on /analysis with timestamp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added a patterns dashboard that displays your complete analysis history with customizable filtering by date and other criteria
* Sort patterns by weakness, best performance, or first/last seen dates
* View detailed pattern information including quality categories, on-beat timing percentages, and linked occurrences with full metadata
* Quick access links to the full pattern analysis view from your dashboard

<!-- end of auto-generated comment: release notes by coderabbit.ai -->