### PR TITLE
Move analyses delete + share writes behind backend API

### DIFF
--- a/api/src/wcs_api/main.py
+++ b/api/src/wcs_api/main.py
@@ -1,7 +1,15 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from .routes import health, music, peer_reviews, shared, uploads, video
+from .routes import (
+    analyses,
+    health,
+    music,
+    peer_reviews,
+    shared,
+    uploads,
+    video,
+)
 from .settings import settings
 
 app = FastAPI(title="wcs-api", version="0.1.0")
@@ -10,7 +18,7 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.allowed_origins_list,
     allow_credentials=True,
-    allow_methods=["GET", "POST", "OPTIONS"],
+    allow_methods=["GET", "POST", "DELETE", "OPTIONS"],
     # X-Swingflow-View is sent by fetchSharedAnalysis so the backend
     # knows it's a real frontend load (not a Slackbot unfurl). Custom
     # request headers require explicit CORS allow-list entries or the
@@ -24,3 +32,4 @@ app.include_router(video.router)
 app.include_router(uploads.router)
 app.include_router(shared.router)
 app.include_router(peer_reviews.router)
+app.include_router(analyses.router)

--- a/api/src/wcs_api/routes/analyses.py
+++ b/api/src/wcs_api/routes/analyses.py
@@ -1,0 +1,89 @@
+"""Authenticated writes against `video_analyses`.
+
+Closes #75 — the front-end used to hold the Supabase anon key and
+mutate `deleted_at` / `share_token` directly from the browser. Those
+writes are now scoped to the user via service-role queries on the
+backend, which lets us tighten RLS to read-only for the browser
+without breaking the delete + share flows.
+
+Routes are kept narrow on purpose: only the two privacy-sensitive
+columns the front-end actually needed to write. Anything else (level
+edits, tag edits) still goes through the existing analyze pipeline
+or future explicit endpoints — better to enumerate writes than to
+ship a generic PATCH.
+"""
+
+from __future__ import annotations
+
+import secrets
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+
+from ..auth import verify_jwt
+from ..services import supabase_admin
+
+router = APIRouter(prefix="/analyses", tags=["analyses"])
+
+
+class ShareTokenResponse(BaseModel):
+    share_token: str
+
+
+@router.delete("/{analysis_id}")
+async def delete_analysis(
+    analysis_id: str, user: dict = Depends(verify_jwt)
+) -> dict:
+    """Soft-delete one of the caller's analyses + revoke its share token.
+
+    Returns 404 (not 403) when the row isn't owned by the caller so we
+    don't leak existence to a probing client.
+    """
+    ok = await supabase_admin.soft_delete_analysis(
+        analysis_id, user["sub"]
+    )
+    if not ok:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="analysis not found",
+        )
+    return {"ok": True}
+
+
+@router.post("/{analysis_id}/share", response_model=ShareTokenResponse)
+async def enable_share(
+    analysis_id: str, user: dict = Depends(verify_jwt)
+) -> ShareTokenResponse:
+    """Generate (or rotate) a share token for one of the caller's analyses.
+
+    Token is a 128-bit URL-safe hex string; matches the front-end's
+    prior `crypto.randomUUID().replace(/-/g, "")` shape so existing
+    `/shared/{token}` consumers keep working.
+    """
+    token = secrets.token_hex(16)
+    ok = await supabase_admin.set_analysis_share_token(
+        analysis_id, user["sub"], token
+    )
+    if not ok:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="analysis not found",
+        )
+    return ShareTokenResponse(share_token=token)
+
+
+@router.delete("/{analysis_id}/share")
+async def disable_share(
+    analysis_id: str, user: dict = Depends(verify_jwt)
+) -> dict:
+    """Revoke share token. Idempotent — returns ok=true even if the
+    row had no token to begin with."""
+    ok = await supabase_admin.clear_analysis_share_token(
+        analysis_id, user["sub"]
+    )
+    if not ok:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="analysis not found",
+        )
+    return {"ok": True}

--- a/api/src/wcs_api/services/supabase_admin.py
+++ b/api/src/wcs_api/services/supabase_admin.py
@@ -396,6 +396,77 @@ async def clear_video_analysis_object_key(
         r.raise_for_status()
 
 
+async def soft_delete_analysis(
+    analysis_id: str, user_id: str
+) -> bool:
+    """Soft-delete one of the user's analyses + revoke any share token.
+
+    Scoped via `user_id=eq.{user_id}` so a request for someone else's
+    row matches zero records and the function returns False. Caller
+    should map False to a 404 (don't leak existence by returning 403).
+    Pairs with /analyses DELETE in the new analyses router (#75) — the
+    front-end no longer holds Supabase service-role authority for this
+    write.
+    """
+    now = _now_iso()
+    async with httpx.AsyncClient(timeout=10) as client:
+        r = await client.patch(
+            _rest(
+                f"video_analyses?id=eq.{analysis_id}"
+                f"&user_id=eq.{user_id}"
+            ),
+            headers={**_headers(), "Prefer": "return=representation"},
+            json={"deleted_at": now, "share_token": None},
+        )
+        r.raise_for_status()
+        rows = r.json()
+        return bool(rows)
+
+
+async def set_analysis_share_token(
+    analysis_id: str, user_id: str, token: str
+) -> bool:
+    """Set / rotate share_token on one of the user's analyses.
+    Returns False (caller → 404) when the row isn't owned by user_id.
+    """
+    async with httpx.AsyncClient(timeout=10) as client:
+        r = await client.patch(
+            _rest(
+                f"video_analyses?id=eq.{analysis_id}"
+                f"&user_id=eq.{user_id}"
+            ),
+            headers={**_headers(), "Prefer": "return=representation"},
+            json={"share_token": token},
+        )
+        r.raise_for_status()
+        rows = r.json()
+        return bool(rows)
+
+
+async def clear_analysis_share_token(
+    analysis_id: str, user_id: str
+) -> bool:
+    """Revoke share_token on one of the user's analyses."""
+    async with httpx.AsyncClient(timeout=10) as client:
+        r = await client.patch(
+            _rest(
+                f"video_analyses?id=eq.{analysis_id}"
+                f"&user_id=eq.{user_id}"
+            ),
+            headers={**_headers(), "Prefer": "return=representation"},
+            json={"share_token": None},
+        )
+        r.raise_for_status()
+        rows = r.json()
+        return bool(rows)
+
+
+def _now_iso() -> str:
+    from datetime import datetime, timezone
+
+    return datetime.now(timezone.utc).isoformat()
+
+
 async def count_usage_events_since(
     user_id: str,
     kind: str,

--- a/src/hooks/use-analysis-history.ts
+++ b/src/hooks/use-analysis-history.ts
@@ -3,7 +3,12 @@
 import { useCallback, useEffect, useState } from "react";
 import { getSupabase, isSupabaseConfigured } from "@/lib/supabase";
 import { useUser } from "@/hooks/use-user";
-import type { VideoScoreResult } from "@/lib/wcs-api";
+import {
+  deleteAnalysis,
+  disableAnalysisShare,
+  enableAnalysisShare,
+  type VideoScoreResult,
+} from "@/lib/wcs-api";
 
 export type AnalysisRecord = {
   id: string;
@@ -153,30 +158,16 @@ export function useAnalysisHistory() {
 
   const remove = useCallback(
     async (id: string) => {
-      if (!isSupabaseConfigured) return;
-      const sb = getSupabase();
       // Soft-delete: the row stays in the DB so the score trend
       // chart can still plot it as history, but it disappears from
-      // the analyze-page list. User-intent here is "clean up my
-      // list", not "erase all evidence this ever happened".
-      //
-      // We also null share_token so any public link the user
-      // previously generated stops working — deleting should revoke
-      // sharing. Backend /shared/{token} also filters deleted rows
-      // as defense in depth.
-      //
+      // the analyze-page list. The backend also revokes any
+      // share_token on the same call — deleting should kill sharing.
       // Await the response and bail on error so we don't lie to the
-      // user: if the DB write fails, the row is still visible and
-      // the share link is still live — mutating local state would
-      // make it look like the delete succeeded.
+      // user: if the write fails, the row is still visible and the
+      // share link is still live — mutating local state would make
+      // it look like the delete succeeded.
+      await deleteAnalysis(id);
       const now = new Date().toISOString();
-      const { error } = await sb
-        .from("video_analyses")
-        .update({ deleted_at: now, share_token: null })
-        .eq("id", id);
-      if (error) {
-        throw new Error(`Failed to delete analysis: ${error.message}`);
-      }
       setRecords((rs) => rs.filter((r) => r.id !== id));
       setChartRecords((rs) =>
         rs.map((r) =>
@@ -189,14 +180,7 @@ export function useAnalysisHistory() {
 
   /** Generate (or regenerate) a share_token on a row. Returns the token. */
   const enableSharing = useCallback(async (id: string): Promise<string> => {
-    if (!isSupabaseConfigured) throw new Error("Supabase not configured");
-    const sb = getSupabase();
-    const token = crypto.randomUUID().replace(/-/g, "");
-    const { error } = await sb
-      .from("video_analyses")
-      .update({ share_token: token })
-      .eq("id", id);
-    if (error) throw new Error(error.message);
+    const token = await enableAnalysisShare(id);
     setRecords((rs) =>
       rs.map((r) => (r.id === id ? { ...r, share_token: token } : r))
     );
@@ -205,9 +189,7 @@ export function useAnalysisHistory() {
 
   /** Revoke sharing by nulling the token. Any existing links stop working. */
   const disableSharing = useCallback(async (id: string): Promise<void> => {
-    if (!isSupabaseConfigured) return;
-    const sb = getSupabase();
-    await sb.from("video_analyses").update({ share_token: null }).eq("id", id);
+    await disableAnalysisShare(id);
     setRecords((rs) =>
       rs.map((r) => (r.id === id ? { ...r, share_token: null } : r))
     );

--- a/src/lib/wcs-api.ts
+++ b/src/lib/wcs-api.ts
@@ -49,15 +49,28 @@ export async function analyzeMusic(file: File): Promise<MusicAnalysisResult> {
 }
 
 async function postJson<T>(path: string, body: unknown): Promise<T> {
+  return requestJson<T>("POST", path, body);
+}
+
+async function requestJson<T>(
+  method: "GET" | "POST" | "DELETE",
+  path: string,
+  body?: unknown
+): Promise<T> {
   if (!API_URL) throw new Error("NEXT_PUBLIC_WCS_API_URL is not set");
   const token = await getAccessToken();
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+  };
+  let serialized: BodyInit | undefined;
+  if (body !== undefined) {
+    headers["Content-Type"] = "application/json";
+    serialized = JSON.stringify(body);
+  }
   const res = await fetch(`${API_URL}${path}`, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${token}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(body),
+    method,
+    headers,
+    body: serialized,
   });
   if (!res.ok) {
     let detail = res.statusText;
@@ -70,6 +83,38 @@ async function postJson<T>(path: string, body: unknown): Promise<T> {
     throw new Error(`Request to ${path} failed (${res.status}): ${detail}`);
   }
   return (await res.json()) as T;
+}
+
+// ───────────────────────────────────────────────────────────────────
+// /analyses — authenticated writes against video_analyses (#75).
+// The frontend used to mutate `deleted_at` and `share_token` directly
+// from the browser; these now go through the backend so RLS can be
+// tightened to read-only without breaking delete + share flows.
+
+export async function deleteAnalysis(analysisId: string): Promise<void> {
+  await requestJson<{ ok: boolean }>(
+    "DELETE",
+    `/analyses/${encodeURIComponent(analysisId)}`
+  );
+}
+
+export async function enableAnalysisShare(
+  analysisId: string
+): Promise<string> {
+  const r = await requestJson<{ share_token: string }>(
+    "POST",
+    `/analyses/${encodeURIComponent(analysisId)}/share`
+  );
+  return r.share_token;
+}
+
+export async function disableAnalysisShare(
+  analysisId: string
+): Promise<void> {
+  await requestJson<{ ok: boolean }>(
+    "DELETE",
+    `/analyses/${encodeURIComponent(analysisId)}/share`
+  );
 }
 
 // ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #75.

## Problem

Frontend used to mutate \`video_analyses.deleted_at\` and \`share_token\` directly from the browser via the Supabase anon key. This blocked RLS lockdown — there was no way to make the table read-only for the browser without breaking the delete and share flows.

## What changes

**Backend** — new \`/analyses\` router with three narrow endpoints. All scoped to \`user[\"sub\"]\` via service-role queries that filter by \`user_id\`, so a request for someone else's row matches zero records and we return **404** (not 403, to avoid leaking existence).

| route | purpose | mirrors |
|---|---|---|
| \`DELETE /analyses/{id}\` | soft-delete + revoke share token | hook \`remove\` |
| \`POST /analyses/{id}/share\` | generate / rotate share_token, returns it | hook \`enableSharing\` |
| \`DELETE /analyses/{id}/share\` | null share_token | hook \`disableSharing\` |

\`secrets.token_hex(16)\` replaces the front-end's \`crypto.randomUUID().replace(/-/g, \"\")\` for the share token — both produce a 32-char hex string so \`/shared/{token}\` consumers keep working without redirect.

**Frontend** — \`use-analysis-history.ts\` no longer touches \`video_analyses\` writes. It calls three new \`wcs-api.ts\` helpers (\`deleteAnalysis\`, \`enableAnalysisShare\`, \`disableAnalysisShare\`) which use the existing \`getAccessToken()\` Bearer flow. Optimistic UI behavior preserved — local state still updates after the await resolves.

## Out of scope

Actually tightening RLS in Supabase config (the \"read-only browser\" half). That's a separate Supabase migration that should land once this deploys and the new write path is verified live. Filing as the natural follow-up.

## Test plan

- [x] \`uv run python -m compileall src/wcs_api\` clean
- [x] \`tsc --noEmit\` clean
- [x] \`npm run build\` succeeds
- [x] Routes registered (\`from wcs_api.main import app\` lists \`/analyses/*\`)
- [ ] Manual after deploy: delete an analysis from the dashboard list, share an analysis, revoke share, re-share with new token
- [ ] Manual: confirm 404 (not 500 / not 200) when calling \`DELETE /analyses/<not-mine-uuid>\`