### PR TITLE
Add api test harness covering recently-touched paths

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -1,0 +1,46 @@
+name: API tests
+
+on:
+  pull_request:
+    paths:
+      - "api/**"
+      - ".github/workflows/api-tests.yml"
+  push:
+    branches: [main]
+    paths:
+      - "api/**"
+      - ".github/workflows/api-tests.yml"
+
+# Cancel an in-flight run when a new commit lands on the same PR /
+# branch — saves CI minutes when iterating.
+concurrency:
+  group: api-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: api
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          # Cache the resolver + virtualenv between runs. The default
+          # cache scope keys on the lockfile so a dep bump invalidates
+          # cleanly.
+          enable-cache: true
+          cache-dependency-glob: "api/uv.lock"
+
+      - name: Install dev deps
+        # `uv sync --dev --no-install-project` skips compiling the
+        # `wcs-api` wheel itself — we don't need the package installed,
+        # only its dependencies. The conftest adds api/src to sys.path
+        # so test imports work without an editable install.
+        run: uv sync --dev --no-install-project
+
+      - name: Run pytest
+        run: uv run pytest tests/

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -20,6 +20,19 @@ dependencies = [
   "torch>=2.0",
 ]
 
+[dependency-groups]
+dev = [
+  "pytest>=8.3",
+  "pytest-asyncio>=0.24",
+]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+# Stop on the first 5 failures so a broken fixture doesn't drown the
+# real signal in 100s of cascading errors.
+addopts = "--maxfail=5 -q"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -1,0 +1,68 @@
+"""Shared fixtures for the wcs_api test suite.
+
+Two themes here:
+  1. Stub `wcs_api.settings.settings` so importing the app doesn't
+     require real Supabase / R2 / Gemini credentials.
+  2. Provide a `client` that bypasses the real `verify_jwt` dependency
+     and returns a known user payload, so route tests can focus on
+     their own logic instead of JWT plumbing.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+# Populate dummy env vars BEFORE importing wcs_api.settings — pydantic-
+# settings raises at import if required values are missing.
+os.environ.setdefault("SUPABASE_URL", "https://test.supabase.co")
+os.environ.setdefault("SUPABASE_SERVICE_ROLE_KEY", "test-service-key")
+os.environ.setdefault("SUPABASE_ANON_KEY", "test-anon-key")
+os.environ.setdefault("SUPABASE_JWT_SECRET", "test-jwt-secret")
+os.environ.setdefault("GEMINI_API_KEY", "test-gemini-key")
+os.environ.setdefault("R2_ACCOUNT_ID", "test-account")
+os.environ.setdefault("R2_ACCESS_KEY_ID", "test-key")
+os.environ.setdefault("R2_SECRET_ACCESS_KEY", "test-secret")
+os.environ.setdefault("R2_BUCKET", "test-bucket")
+os.environ.setdefault("ALLOWED_ORIGINS", "http://localhost:3000")
+
+# Make the `src/` layout importable without an editable install.
+SRC = Path(__file__).resolve().parent.parent / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import pytest  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from wcs_api.auth import verify_jwt  # noqa: E402
+from wcs_api.main import app  # noqa: E402
+
+TEST_USER_ID = "11111111-2222-3333-4444-555555555555"
+
+
+def _fake_verify_jwt() -> dict[str, Any]:
+    """Replaces the real JWT verification — every test request is
+    authenticated as TEST_USER_ID. Tests that need to assert behavior
+    on UNauthenticated requests should override this individually."""
+    return {"sub": TEST_USER_ID, "email": "test@example.com"}
+
+
+@pytest.fixture
+def client() -> TestClient:
+    """FastAPI TestClient with verify_jwt stubbed to a fixed user.
+
+    Uses dependency_overrides so each test gets a clean session — we
+    pop the override after the test so a leak doesn't poison neighbors.
+    """
+    app.dependency_overrides[verify_jwt] = _fake_verify_jwt
+    try:
+        yield TestClient(app)
+    finally:
+        app.dependency_overrides.pop(verify_jwt, None)
+
+
+@pytest.fixture
+def test_user_id() -> str:
+    return TEST_USER_ID

--- a/api/tests/test_analyses_routes.py
+++ b/api/tests/test_analyses_routes.py
@@ -1,0 +1,176 @@
+"""Coverage for the /analyses delete + share endpoints (#75 / #158).
+
+These routes wrap service-role updates that the front-end used to do
+directly. The thing worth proving:
+  - 200 + state change when the row is owned by the caller
+  - 404 (NOT 403) when it isn't, so we don't leak existence
+  - share enable returns the same hex shape the front-end used to mint
+"""
+
+from __future__ import annotations
+
+import re
+
+from wcs_api.services import supabase_admin
+
+ANALYSIS_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+
+# ─── DELETE /analyses/{id} ─────────────────────────────────────────
+
+
+def test_delete_analysis_owned_returns_ok(client, monkeypatch, test_user_id):
+    seen: dict[str, str] = {}
+
+    async def fake_soft_delete(analysis_id: str, user_id: str) -> bool:
+        seen["analysis_id"] = analysis_id
+        seen["user_id"] = user_id
+        return True
+
+    monkeypatch.setattr(
+        supabase_admin, "soft_delete_analysis", fake_soft_delete
+    )
+
+    r = client.delete(f"/analyses/{ANALYSIS_ID}")
+
+    assert r.status_code == 200
+    assert r.json() == {"ok": True}
+    assert seen["analysis_id"] == ANALYSIS_ID
+    assert seen["user_id"] == test_user_id
+
+
+def test_delete_analysis_not_owned_returns_404_not_403(client, monkeypatch):
+    """Returning 403 would confirm the row exists. 404 is the privacy-
+    preserving response for both 'no such row' and 'not yours'."""
+
+    async def fake_soft_delete(analysis_id: str, user_id: str) -> bool:
+        return False
+
+    monkeypatch.setattr(
+        supabase_admin, "soft_delete_analysis", fake_soft_delete
+    )
+
+    r = client.delete(f"/analyses/{ANALYSIS_ID}")
+    assert r.status_code == 404
+
+
+# ─── POST /analyses/{id}/share ─────────────────────────────────────
+
+
+def test_enable_share_returns_32_char_hex_token(client, monkeypatch):
+    captured: dict[str, str] = {}
+
+    async def fake_set_token(
+        analysis_id: str, user_id: str, token: str
+    ) -> bool:
+        captured["token"] = token
+        return True
+
+    monkeypatch.setattr(
+        supabase_admin, "set_analysis_share_token", fake_set_token
+    )
+
+    r = client.post(f"/analyses/{ANALYSIS_ID}/share")
+
+    assert r.status_code == 200
+    body = r.json()
+    token = body["share_token"]
+    # Front-end's old crypto.randomUUID().replace(/-/g, "") produced
+    # exactly 32 hex chars; secrets.token_hex(16) matches that so
+    # /shared/{token} consumers don't notice.
+    assert re.fullmatch(r"[0-9a-f]{32}", token)
+    assert captured["token"] == token
+
+
+def test_enable_share_not_owned_returns_404(client, monkeypatch):
+    async def fake_set_token(*_args, **_kwargs) -> bool:
+        return False
+
+    monkeypatch.setattr(
+        supabase_admin, "set_analysis_share_token", fake_set_token
+    )
+
+    r = client.post(f"/analyses/{ANALYSIS_ID}/share")
+    assert r.status_code == 404
+
+
+def test_enable_share_rotates_token_on_each_call(client, monkeypatch):
+    """Two consecutive calls should mint distinct tokens — confirms
+    the route doesn't cache or memoize."""
+    issued: list[str] = []
+
+    async def fake_set_token(
+        analysis_id: str, user_id: str, token: str
+    ) -> bool:
+        issued.append(token)
+        return True
+
+    monkeypatch.setattr(
+        supabase_admin, "set_analysis_share_token", fake_set_token
+    )
+
+    r1 = client.post(f"/analyses/{ANALYSIS_ID}/share")
+    r2 = client.post(f"/analyses/{ANALYSIS_ID}/share")
+    assert r1.status_code == 200 and r2.status_code == 200
+    assert issued[0] != issued[1]
+
+
+# ─── DELETE /analyses/{id}/share ───────────────────────────────────
+
+
+def test_disable_share_owned_clears_token(client, monkeypatch, test_user_id):
+    seen: dict[str, str] = {}
+
+    async def fake_clear(analysis_id: str, user_id: str) -> bool:
+        seen["analysis_id"] = analysis_id
+        seen["user_id"] = user_id
+        return True
+
+    monkeypatch.setattr(
+        supabase_admin, "clear_analysis_share_token", fake_clear
+    )
+
+    r = client.delete(f"/analyses/{ANALYSIS_ID}/share")
+
+    assert r.status_code == 200
+    assert r.json() == {"ok": True}
+    assert seen == {"analysis_id": ANALYSIS_ID, "user_id": test_user_id}
+
+
+def test_disable_share_not_owned_returns_404(client, monkeypatch):
+    async def fake_clear(*_args, **_kwargs) -> bool:
+        return False
+
+    monkeypatch.setattr(
+        supabase_admin, "clear_analysis_share_token", fake_clear
+    )
+
+    r = client.delete(f"/analyses/{ANALYSIS_ID}/share")
+    assert r.status_code == 404
+
+
+# ─── auth required ─────────────────────────────────────────────────
+
+
+def test_routes_require_auth():
+    """Sanity: unauthenticated requests must NOT reach the route. The
+    `client` fixture stubs verify_jwt; here we use the raw TestClient
+    so the real dependency runs and rejects the missing header."""
+    from fastapi.testclient import TestClient
+
+    from wcs_api.main import app
+
+    raw = TestClient(app)
+    # Defensive: even if the test runs after a fixture leaked an
+    # override, clear it so this assertion is honest.
+    from wcs_api.auth import verify_jwt
+
+    app.dependency_overrides.pop(verify_jwt, None)
+
+    for r in (
+        raw.delete(f"/analyses/{ANALYSIS_ID}"),
+        raw.post(f"/analyses/{ANALYSIS_ID}/share"),
+        raw.delete(f"/analyses/{ANALYSIS_ID}/share"),
+    ):
+        # 401 from missing Authorization header.
+        assert r.status_code == 401

--- a/api/tests/test_response_sanitizer.py
+++ b/api/tests/test_response_sanitizer.py
@@ -1,0 +1,209 @@
+"""Coverage for response_sanitizer's pure helpers — the strengths /
+improvements fallback (PR #148), the pattern_summary confidence cutoff
+(PR #150 — drop from 0.5 to 0.25), and the merge-unique cap.
+
+These functions are private (underscore-prefixed) but they're the
+ones that actually decide whether the user sees a useful coaching
+panel or empty arrays, so they're worth pinning."""
+
+from __future__ import annotations
+
+from wcs_api.services.video_analysis.response_sanitizer import (
+    _improvements_from_summary,
+    _merge_unique,
+    _strengths_from_summary,
+    _summarize_patterns,
+)
+
+
+# ─── _summarize_patterns: confidence cutoff (PR #150) ──────────────
+
+
+def test_summarize_drops_patterns_below_0_25_confidence():
+    """0.5 cutoff in #148 starved the strengths/improvements fallback;
+    #150 lowered it to 0.25 because the model started emitting
+    confidence in the 0.2-0.3 range across the board."""
+    patterns = [
+        {"name": "sugar push", "confidence": 0.6, "quality": "solid"},
+        {"name": "whip", "confidence": 0.30, "quality": "solid"},
+        {"name": "left side pass", "confidence": 0.24, "quality": "solid"},
+        {"name": "tuck turn", "confidence": 0.10, "quality": "solid"},
+    ]
+    summary = _summarize_patterns(patterns)
+    names = {s["name"] for s in summary}
+
+    assert "sugar push" in names  # 0.60 ≥ 0.25 → kept
+    assert "whip" in names  # 0.30 ≥ 0.25 → kept
+    assert "left side pass" not in names  # 0.24 < 0.25 → dropped
+    assert "tuck turn" not in names  # 0.10 < 0.25 → dropped
+
+
+def test_summarize_groups_basic_with_null_variant():
+    """`variant=null` and `variant="basic"` both mean plain execution
+    of the family — they should aggregate into ONE entry, not two."""
+    patterns = [
+        {"name": "sugar push", "confidence": 0.6, "variant": None},
+        {"name": "sugar push", "confidence": 0.6, "variant": "basic"},
+    ]
+    summary = _summarize_patterns(patterns)
+    sugar = [s for s in summary if s["name"] == "sugar push"]
+    assert len(sugar) == 1
+    assert sugar[0]["count"] == 2
+
+
+def test_summarize_separates_distinct_variants():
+    """basket whip and reverse whip are distinct patterns even though
+    they share the 'whip' family — the key includes variant."""
+    patterns = [
+        {"name": "whip", "confidence": 0.6, "variant": "basket"},
+        {"name": "whip", "confidence": 0.6, "variant": "reverse"},
+        {"name": "whip", "confidence": 0.6, "variant": "basket"},
+    ]
+    summary = _summarize_patterns(patterns)
+    by_variant = {(s["name"], s.get("variant")): s["count"] for s in summary}
+    assert by_variant[("whip", "basket")] == 2
+    assert by_variant[("whip", "reverse")] == 1
+
+
+def test_summarize_skips_empty_name():
+    patterns = [
+        {"name": "", "confidence": 0.9, "quality": "solid"},
+        {"name": None, "confidence": 0.9, "quality": "solid"},
+        {"confidence": 0.9, "quality": "solid"},  # missing key
+    ]
+    assert _summarize_patterns(patterns) == []
+
+
+def test_summarize_handles_non_string_quality_gracefully():
+    """Gemini occasionally returns nested objects where a string is
+    expected. The helper has a defensive _s() coercion — proves it
+    doesn't crash."""
+    patterns = [
+        {
+            "name": "sugar push",
+            "confidence": 0.6,
+            "quality": {"value": "solid"},  # wrong shape
+            "notes": 42,  # wrong type
+        }
+    ]
+    out = _summarize_patterns(patterns)
+    assert len(out) == 1
+    assert out[0]["name"] == "sugar push"
+
+
+# ─── _strengths_from_summary (PR #148) ─────────────────────────────
+
+
+def test_strengths_picks_solid_and_excellent_with_notes():
+    summary = [
+        {
+            "name": "sugar push",
+            "quality": "solid",
+            "notes": "anchor settled cleanly on 5-6",
+            "count": 4,
+        },
+        {
+            "name": "whip",
+            "quality": "excellent",
+            "notes": "follow stretches before the rotation",
+            "count": 2,
+        },
+        {
+            "name": "tuck turn",
+            "quality": "needs_work",
+            "notes": "rushed timing",
+            "count": 1,
+        },
+    ]
+    out = _strengths_from_summary(summary)
+    joined = " | ".join(out)
+
+    assert "Sugar push (×4)" in joined
+    assert "anchor settled cleanly" in joined
+    assert "Whip (×2)" in joined
+    # needs_work shouldn't surface as a strength.
+    assert "Tuck turn" not in joined
+
+
+def test_strengths_skips_entries_without_notes():
+    """A 'solid' tag without supporting notes is still ungrounded —
+    should not produce a Strength line."""
+    summary = [
+        {"name": "sugar push", "quality": "solid", "notes": "", "count": 3},
+        {"name": "whip", "quality": "solid", "count": 2},  # missing notes
+    ]
+    assert _strengths_from_summary(summary) == []
+
+
+def test_strengths_caps_at_max_items():
+    summary = [
+        {"name": f"p{i}", "quality": "solid", "notes": "ok", "count": 1}
+        for i in range(10)
+    ]
+    assert len(_strengths_from_summary(summary, max_items=3)) == 3
+
+
+def test_strengths_handles_empty_or_none_input():
+    assert _strengths_from_summary(None) == []
+    assert _strengths_from_summary([]) == []
+
+
+# ─── _improvements_from_summary ────────────────────────────────────
+
+
+def test_improvements_uses_coaching_tip_field():
+    summary = [
+        {
+            "name": "whip",
+            "coaching_tip": "lead earlier on the rotation entry at 0:34",
+            "count": 3,
+        }
+    ]
+    out = _improvements_from_summary(summary)
+    assert len(out) == 1
+    assert "Whip (×3)" in out[0]
+    assert "lead earlier" in out[0]
+
+
+def test_improvements_skips_stock_coaching_phrases():
+    """Even when the model attaches a tip to a real pattern, generic
+    stock advice ('engage your core') still reads as horoscope and
+    should be filtered."""
+    summary = [
+        {
+            "name": "sugar push",
+            "coaching_tip": "engage your core",
+            "count": 5,
+        },
+        {
+            "name": "whip",
+            "coaching_tip": "lift the elbow on beat 5 of the basket entry",
+            "count": 2,
+        },
+    ]
+    out = _improvements_from_summary(summary)
+    # The stock-phrase one is filtered; the specific one stays.
+    assert len(out) == 1
+    assert "Whip" in out[0]
+
+
+# ─── _merge_unique ─────────────────────────────────────────────────
+
+
+def test_merge_unique_appends_only_novel_items_capped_at_3():
+    primary = ["a", "b"]
+    fallback = ["b", "c", "d", "e"]  # b is a dup; cap before e
+    out = _merge_unique(primary, fallback)
+    assert out == ["a", "b", "c"]
+
+
+def test_merge_unique_dedup_is_case_and_whitespace_insensitive():
+    primary = ["Sugar Push: foo "]
+    fallback = ["sugar push: foo"]
+    assert _merge_unique(primary, fallback) == ["Sugar Push: foo "]
+
+
+def test_merge_unique_preserves_primary_order_unchanged():
+    primary = ["x", "y"]
+    fallback = ["z"]
+    assert _merge_unique(primary, fallback) == ["x", "y", "z"]

--- a/api/tests/test_supabase_admin.py
+++ b/api/tests/test_supabase_admin.py
@@ -1,0 +1,125 @@
+"""Coverage for the supabase_admin helpers we've recently touched.
+
+Today: the UUID shape-gate fix (PR #153). The eval CLI uses
+get_analysis_eval_row with either a row UUID or a clip filename like
+'IMG_9577'. PostgREST returns 400 if you filter a uuid column with a
+non-UUID string, so we shape-check first and skip the id query for
+non-UUIDs. Without that, the filename fallback never runs.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from wcs_api.services import supabase_admin
+
+
+def _resp(status: int, json_body: Any = None) -> httpx.Response:
+    return httpx.Response(
+        status_code=status,
+        json=json_body if json_body is not None else [],
+        request=httpx.Request("GET", "https://test"),
+    )
+
+
+class _FakeClient:
+    """Minimal async-context-manager that matches the surface area of
+    httpx.AsyncClient(...) used by supabase_admin: __aenter__ /
+    __aexit__ + .get(). Records every call so we can assert on what
+    PostgREST query was constructed."""
+
+    def __init__(self, responses: list[httpx.Response]):
+        self._responses = list(responses)
+        self.calls: list[dict[str, Any]] = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc) -> None:
+        return None
+
+    async def get(self, url: str, **kwargs):
+        self.calls.append({"url": url, **kwargs})
+        return self._responses.pop(0)
+
+
+# ─── get_analysis_eval_row UUID shape-gate (PR #153) ───────────────
+
+
+async def test_eval_row_lookup_skips_id_query_for_non_uuid(monkeypatch):
+    """Non-UUID ref ('IMG_9577') must NOT hit the id= endpoint —
+    PostgREST would return 400 and r.raise_for_status() would shadow
+    the filename fallback."""
+    fake = _FakeClient([_resp(200, [{"id": "x", "filename": "IMG_9577"}])])
+
+    def _factory(*_a, **_kw):
+        return fake
+
+    monkeypatch.setattr(httpx, "AsyncClient", _factory)
+
+    row = await supabase_admin.get_analysis_eval_row("IMG_9577")
+    assert row is not None
+    assert row["filename"] == "IMG_9577"
+    # Only one HTTP call — the filename one. The id= path was skipped.
+    assert len(fake.calls) == 1
+    params = fake.calls[0].get("params") or {}
+    assert "filename" in params
+    assert "id" not in params
+
+
+async def test_eval_row_lookup_uses_id_query_for_uuid(monkeypatch):
+    uuid_ref = "11111111-2222-3333-4444-555555555555"
+    fake = _FakeClient([_resp(200, [{"id": uuid_ref, "filename": "x.mov"}])])
+
+    def _factory(*_a, **_kw):
+        return fake
+
+    monkeypatch.setattr(httpx, "AsyncClient", _factory)
+
+    row = await supabase_admin.get_analysis_eval_row(uuid_ref)
+    assert row is not None
+    # First call should be the id= query, not the filename fallback.
+    params = fake.calls[0].get("params") or {}
+    assert params.get("id") == f"eq.{uuid_ref}"
+
+
+async def test_eval_row_lookup_falls_back_to_filename_when_uuid_id_misses(
+    monkeypatch,
+):
+    """Valid UUID, but no row matches → fall through to the filename
+    query. Today this only matters if a user's filename happens to be
+    UUID-shaped, but the fallback is still the right behavior."""
+    uuid_ref = "11111111-2222-3333-4444-555555555555"
+    fake = _FakeClient(
+        [
+            _resp(200, []),  # id query — empty
+            _resp(200, [{"id": "different", "filename": uuid_ref}]),
+        ]
+    )
+
+    def _factory(*_a, **_kw):
+        return fake
+
+    monkeypatch.setattr(httpx, "AsyncClient", _factory)
+
+    row = await supabase_admin.get_analysis_eval_row(uuid_ref)
+    assert row is not None
+    assert len(fake.calls) == 2
+    assert fake.calls[1]["params"]["filename"] == f"eq.{uuid_ref}"
+
+
+async def test_eval_row_lookup_returns_none_when_neither_query_matches(
+    monkeypatch,
+):
+    fake = _FakeClient([_resp(200, []), _resp(200, [])])
+
+    def _factory(*_a, **_kw):
+        return fake
+
+    monkeypatch.setattr(httpx, "AsyncClient", _factory)
+
+    row = await supabase_admin.get_analysis_eval_row("does-not-exist")
+    assert row is None

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -649,6 +649,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1168,6 +1177,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "pooch"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1343,12 +1361,50 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
 name = "pyjwt"
 version = "2.12.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]
@@ -2043,6 +2099,12 @@ dependencies = [
     { name = "uvicorn", extra = ["standard"] },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "audioread", specifier = ">=3.0.1" },
@@ -2059,6 +2121,12 @@ requires-dist = [
     { name = "soundfile", specifier = ">=0.12.1" },
     { name = "torch", specifier = ">=2.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.3" },
+    { name = "pytest-asyncio", specifier = ">=0.24" },
 ]
 
 [[package]]


### PR DESCRIPTION
First slice of #83 — lay down a pytest harness and pin the paths we've actively been editing so they can't silently regress.

## What's in the suite (26 tests, ~20ms local)

| File | Covers | Why this first |
|---|---|---|
| \`test_analyses_routes.py\` (8) | 200 + state change when owned, 404 (NOT 403) when not, share token shape + rotation, auth gate fires | These are the new endpoints from PR #158 — they hold the privacy-sensitive writes the front-end used to do directly |
| \`test_response_sanitizer.py\` (14) | confidence cutoff (PR #150), basic-vs-null variant grouping, defensive type coercion, strengths/improvements fallback (PR #148), case-insensitive merge dedup | Most-edited code in the last 30 days; the place a regression hurts the user most directly (empty coaching panels) |
| \`test_supabase_admin.py\` (4) | UUID shape-gate fix (PR #153) — eval CLI passing \`IMG_9577\` no longer 400s | Recent bug fix that we'd want to keep fixed |

## Harness pieces

- **\`api/tests/conftest.py\`** — populates dummy env vars before importing \`wcs_api.settings\` (pydantic-settings raises at import without them), inserts \`api/src\` on sys.path so tests don't need an editable install, provides a \`client\` fixture that overrides \`verify_jwt\` to a fixed user.
- **\`api/pyproject.toml\`** — dev-dep group with pytest + pytest-asyncio, \`asyncio_mode = \"auto\"\`, \`--maxfail=5 -q\` so a broken fixture doesn't drown the real signal.
- **\`.github/workflows/api-tests.yml\`** — first GH Actions workflow in the repo. PR + main-push trigger scoped to \`api/**\`. Concurrency cancels stale runs. uv cache keyed on \`uv.lock\`.

## Out of scope

Everything #83 listed beyond what we just touched:
- video.py quota race + analyze flow (need to mock Gemini + R2 at scale)
- frontend mutation tests (need a separate JS test runner — vitest? jest?)
- timeline scrubbing / malformed result payload tests (frontend)

Better to ship the harness + first batch and prove it works in CI than to land all of it as one giant unreviewable PR.

## Test plan

- [x] Local: \`uv run pytest tests/\` — 26 passed
- [ ] Confirm new \"API tests\" workflow runs + passes on this PR
- [ ] Confirm workflow does NOT run on a frontend-only PR (path filter on \`api/**\`)