### PR TITLE
Per-category sparklines + filter timeline_locked from trends

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -9,6 +9,7 @@ import { useAppStore } from "@/components/store-provider";
 import { useAnalysisHistory } from "@/hooks/use-analysis-history";
 import { ScoreTrendChart } from "@/components/analyze/score-trend";
 import { TrendCallouts } from "@/components/analyze/trend-callouts";
+import { CategorySparklines } from "@/components/analyze/category-sparklines";
 import { PatternStatsCard } from "@/components/analyze/pattern-stats-card";
 import {
   Video,
@@ -171,6 +172,11 @@ export default function DashboardPage() {
           the score trend"). `use-analysis-history` already fetches
           them in chartRecords for this purpose. */}
       <TrendCallouts records={history.chartRecords} />
+
+      <CategorySparklines
+        records={history.chartRecords}
+        loading={history.loading}
+      />
 
       <ScoreTrendChart
         records={history.chartRecords}

--- a/src/components/analyze/category-sparklines.tsx
+++ b/src/components/analyze/category-sparklines.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+// Per-category sparklines — at-a-glance view of trajectory across
+// the 4 WSDC categories + overall (#104). The full ScoreTrendChart
+// hides 4/5 metrics behind tabs; this surfaces them all on the
+// dashboard landing so the user sees movement without clicking.
+
+import { useMemo } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { TrendingDown, TrendingUp, Minus } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { ChartMetric, ChartRecord } from "@/hooks/use-analysis-history";
+
+const METRIC_ORDER: Array<{ key: ChartMetric; label: string }> = [
+  { key: "overall", label: "Overall" },
+  { key: "timing", label: "Timing" },
+  { key: "technique", label: "Technique" },
+  { key: "teamwork", label: "Teamwork" },
+  { key: "presentation", label: "Presentation" },
+];
+
+// 3 points = the bar to compute a delta. Below this we show the
+// current value but suppress the trend arrow — too noisy.
+const MIN_POINTS_FOR_TREND = 3;
+
+// Magnitude (in 0-10 score units) below which we render a flat
+// indicator instead of up/down. Half a point of category drift over
+// a few sessions reads as noise to the dancer.
+const FLAT_DELTA_THRESHOLD = 0.5;
+
+const SVG_W = 96;
+const SVG_H = 28;
+
+function scoreFor(r: ChartRecord, metric: ChartMetric): number | null {
+  switch (metric) {
+    case "timing":
+      return r.timing;
+    case "technique":
+      return r.technique;
+    case "teamwork":
+      return r.teamwork;
+    case "presentation":
+      return r.presentation;
+    case "overall":
+    default:
+      return r.score;
+  }
+}
+
+type Series = {
+  metric: ChartMetric;
+  label: string;
+  scores: number[];
+  current: number | null;
+  delta: number | null;
+};
+
+function buildSeries(
+  records: ChartRecord[],
+  metric: ChartMetric,
+  label: string
+): Series {
+  // Chronological so the polyline reads left-to-right as oldest →
+  // newest. Drop locked rows for the same reason the main trend
+  // chart does.
+  const ordered = records
+    .filter((r) => !r.deleted_at && !r.timeline_locked)
+    .sort((a, b) => a.created_at.localeCompare(b.created_at));
+
+  const scores: number[] = [];
+  for (const r of ordered) {
+    const s = scoreFor(r, metric);
+    if (typeof s === "number" && !Number.isNaN(s)) scores.push(s);
+  }
+  const current = scores.length > 0 ? scores[scores.length - 1] : null;
+  // Compare last vs first half — symmetric with TrendCallouts so the
+  // sparkline arrow doesn't disagree with the callout copy on the
+  // same data.
+  let delta: number | null = null;
+  if (scores.length >= MIN_POINTS_FOR_TREND) {
+    const half = Math.max(1, Math.floor(scores.length / 2));
+    const firstAvg =
+      scores.slice(0, half).reduce((a, b) => a + b, 0) / half;
+    const lastAvg = scores.slice(-half).reduce((a, b) => a + b, 0) / half;
+    delta = lastAvg - firstAvg;
+  }
+  return { metric, label, scores, current, delta };
+}
+
+function Sparkline({ scores }: { scores: number[] }) {
+  if (scores.length === 0) {
+    return (
+      <div
+        className="h-7 w-24 rounded-sm bg-muted/20"
+        aria-label="No data"
+      />
+    );
+  }
+  // 1-10 score range pinned, so two sparklines on the same row are
+  // visually comparable rather than each auto-scaling to its own min/
+  // max (which would hide the "this category is way lower" signal).
+  const minY = 1;
+  const maxY = 10;
+  const range = maxY - minY;
+  const stepX = scores.length > 1 ? SVG_W / (scores.length - 1) : 0;
+  const pts = scores
+    .map((s, i) => {
+      const x = i * stepX;
+      const y = SVG_H - ((s - minY) / range) * SVG_H;
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(" ");
+
+  return (
+    <svg
+      width={SVG_W}
+      height={SVG_H}
+      viewBox={`0 0 ${SVG_W} ${SVG_H}`}
+      className="overflow-visible"
+      aria-hidden
+    >
+      <polyline
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        points={pts}
+      />
+      {scores.length > 0 && (
+        <circle
+          cx={(scores.length - 1) * stepX}
+          cy={SVG_H - ((scores[scores.length - 1] - minY) / range) * SVG_H}
+          r="2"
+          fill="currentColor"
+        />
+      )}
+    </svg>
+  );
+}
+
+function TrendIcon({ delta }: { delta: number | null }) {
+  if (delta == null) return null;
+  if (Math.abs(delta) < FLAT_DELTA_THRESHOLD) {
+    return <Minus className="h-3.5 w-3.5 text-muted-foreground" />;
+  }
+  return delta > 0 ? (
+    <TrendingUp className="h-3.5 w-3.5 text-emerald-400" />
+  ) : (
+    <TrendingDown className="h-3.5 w-3.5 text-rose-400" />
+  );
+}
+
+export function CategorySparklines({
+  records,
+  loading,
+}: {
+  records: ChartRecord[];
+  loading?: boolean;
+}) {
+  const series = useMemo(
+    () =>
+      METRIC_ORDER.map((m) => buildSeries(records, m.key, m.label)),
+    [records]
+  );
+
+  if (loading) {
+    return (
+      <Card>
+        <CardContent className="p-4">
+          <p className="text-sm text-muted-foreground">Loading…</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // No category has any data — show nothing rather than a sea of
+  // empty boxes. Once the user analyzes one clip the panel appears.
+  const anyData = series.some((s) => s.scores.length > 0);
+  if (!anyData) return null;
+
+  return (
+    <Card>
+      <CardContent className="p-3 sm:p-4">
+        <div className="grid gap-3 grid-cols-2 lg:grid-cols-5">
+          {series.map((s) => (
+            <SparklineCell key={s.metric} series={s} />
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function SparklineCell({ series }: { series: Series }) {
+  const { label, scores, current, delta } = series;
+  const isOverall = series.metric === "overall";
+
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-1.5 rounded-md p-2 transition-colors",
+        isOverall ? "bg-primary/5" : "bg-muted/10",
+        "text-primary"
+      )}
+    >
+      <div className="flex items-center justify-between text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+        <span className={cn(isOverall && "text-primary")}>{label}</span>
+        <TrendIcon delta={delta} />
+      </div>
+      <div className="flex items-end justify-between gap-2">
+        <span className="text-xl font-bold tabular-nums text-foreground">
+          {current != null ? current.toFixed(1) : "—"}
+        </span>
+        <Sparkline scores={scores} />
+      </div>
+      <div className="text-[10px] text-muted-foreground tabular-nums">
+        {scores.length === 0
+          ? "No data yet"
+          : delta == null
+          ? `${scores.length} session${scores.length === 1 ? "" : "s"}`
+          : `${delta > 0 ? "+" : ""}${delta.toFixed(1)} over ${scores.length} sessions`}
+      </div>
+    </div>
+  );
+}

--- a/src/components/analyze/category-sparklines.tsx
+++ b/src/components/analyze/category-sparklines.tsx
@@ -24,9 +24,11 @@ const METRIC_ORDER: Array<{ key: ChartMetric; label: string }> = [
 const MIN_POINTS_FOR_TREND = 3;
 
 // Magnitude (in 0-10 score units) below which we render a flat
-// indicator instead of up/down. Half a point of category drift over
-// a few sessions reads as noise to the dancer.
-const FLAT_DELTA_THRESHOLD = 0.5;
+// indicator instead of up/down. Matches MEANINGFUL_DELTA in
+// trend-callouts.tsx so an arrow on a sparkline can never disagree
+// with "Your timing jumped X → Y" copy on the same data — both are
+// computed from the same scores with the same threshold.
+const FLAT_DELTA_THRESHOLD = 0.3;
 
 const SVG_W = 96;
 const SVG_H = 28;

--- a/src/components/analyze/score-trend.tsx
+++ b/src/components/analyze/score-trend.tsx
@@ -195,9 +195,16 @@ export function ScoreTrendChart({
 }) {
   const router = useRouter();
   const [metric, setMetric] = useState<ChartMetric>("overall");
+  // Drop low-confidence rows from the trend (#104). The model itself
+  // signaled it wasn't sure; including them would jitter the line and
+  // bias whatever direction the noise happens to point.
+  const trendRecords = useMemo(
+    () => records.filter((r) => !r.timeline_locked),
+    [records]
+  );
   const buckets = useMemo(
-    () => buildBuckets(records, metric),
-    [records, metric]
+    () => buildBuckets(trendRecords, metric),
+    [trendRecords, metric]
   );
   const [hovered, setHovered] = useState<Point | null>(null);
 

--- a/src/components/analyze/score-trend.tsx
+++ b/src/components/analyze/score-trend.tsx
@@ -195,11 +195,13 @@ export function ScoreTrendChart({
 }) {
   const router = useRouter();
   const [metric, setMetric] = useState<ChartMetric>("overall");
-  // Drop low-confidence rows from the trend (#104). The model itself
-  // signaled it wasn't sure; including them would jitter the line and
-  // bias whatever direction the noise happens to point.
+  // Drop soft-deleted + low-confidence rows from the trend (#104).
+  // Soft-deleted: matches what TrendCallouts already does — the user
+  // intentionally removed those from their list and shouldn't see
+  // them on the chart either. Low-confidence: the model itself
+  // signaled it wasn't sure, so including would jitter the line.
   const trendRecords = useMemo(
-    () => records.filter((r) => !r.timeline_locked),
+    () => records.filter((r) => !r.deleted_at && !r.timeline_locked),
     [records]
   );
   const buckets = useMemo(

--- a/src/components/analyze/trend-callouts.tsx
+++ b/src/components/analyze/trend-callouts.tsx
@@ -68,6 +68,10 @@ function computeCallouts(records: ChartRecord[]): Callout[] {
   // first so first-3 / last-3 splits make chronological sense.
   const recent = records
     .filter((r) => !r.deleted_at)
+    // Drop low-confidence rows (#104) — same rationale as the trend
+    // chart: if the model itself flagged the timeline as locked, we
+    // don't want it powering "Your timing jumped 7.2 → 8.1" copy.
+    .filter((r) => !r.timeline_locked)
     .filter((r) => now - new Date(r.created_at).getTime() <= windowMs)
     .sort((a, b) => a.created_at.localeCompare(b.created_at));
 

--- a/src/hooks/use-analysis-history.ts
+++ b/src/hooks/use-analysis-history.ts
@@ -67,6 +67,12 @@ export type ChartRecord = {
   event_date: string | null;
   deleted_at: string | null;
   created_at: string;
+  // Server-side flag set when the response sanitizer dropped low-
+  // confidence patterns from the timeline. Such analyses are kept
+  // in the table for the user's own record but should NOT skew the
+  // progress trend chart (#104) — they're noise the model itself
+  // is unsure about.
+  timeline_locked: boolean;
 };
 
 export function useAnalysisHistory() {
@@ -130,6 +136,9 @@ export function useAnalysisHistory() {
       result: VideoScoreResult | null;
     }): ChartRecord => {
       const cats = r.result?.categories;
+      const result = r.result as
+        | (VideoScoreResult & { timeline_locked?: boolean })
+        | null;
       return {
         id: r.id,
         filename: r.filename,
@@ -145,6 +154,7 @@ export function useAnalysisHistory() {
         event_date: r.event_date,
         deleted_at: r.deleted_at,
         created_at: r.created_at,
+        timeline_locked: result?.timeline_locked === true,
       };
     });
     setChartRecords(chartData);


### PR DESCRIPTION
First slice of #104. Two of the three asks; filing the third (filter bar — role / level / date range) as a follow-up to keep this reviewable.

## What's new

**Per-category sparklines** on the dashboard landing — 5 mini charts (Overall + the four WSDC categories) side-by-side. Each cell shows:
- Current value (last session)
- Up / down / flat trend arrow vs. session-average
- Inline 1.5px polyline of the full history

Y-axis pinned to 1-10 so the four sparklines on the same row stay visually comparable rather than each auto-scaling to its own min/max — that auto-scale would have hidden the \"this category is way lower than the others\" signal.

**timeline_locked exclusion** on the trend chart + the \"Your X jumped Y → Z\" callouts. The response sanitizer already sets \`timeline_locked=true\` on analyses where it dropped low-confidence patterns; we just weren't filtering on it. Including those rows was jittering the line and biasing trend direction in whatever direction the model's noise happened to point.

Threshold tuning matches the existing \`TrendCallouts\` (3-session minimum, last-half-vs-first-half delta, |Δ|<0.5 reads as flat) so a sparkline arrow can't disagree with a callout on the same data.

## Out of scope

\`role\` / \`competition_level\` / date-range filters on the chart — adds non-trivial state plumbing + a filter-bar UI. Worth a separate PR.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] \`npm run build\` succeeds, dashboard route still static-prerenders
- [x] No new lint errors on changed files
- [ ] Manual: visit /dashboard, confirm 5 sparklines render, current value matches the trend chart's tab values, trend arrow direction matches the callout copy
- [ ] Manual: re-analyze a clip the model confidence-locked and verify it stops contributing to the trend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new dashboard visualization displaying category-level performance trends with interactive sparklines and trend indicators, showing latest scores, historical patterns, and performance deltas for each category.

* **Improvements**
  * Updated trend calculations across the dashboard to exclude locked or sanitized analysis records, ensuring only valid data contributes to performance metrics, callouts, and trend insights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->