### PR TITLE
Comment-first peer review + reviewer pins on owner timeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# swingflow — agent guide
+
+Codebase: Next.js (web, `src/`) + FastAPI (`api/`) WCS dance video analyzer.
+Deploys: Cloudflare Workers Builds (frontend, auto on `main` push) + Railway
+(API, manual `railway up --detach --ci` from `api/`).
+
+## House rules
+
+### Role-neutral language
+
+WCS roles (Lead, Follow) are not gender-bound. A female-lead user complained
+after the analyzer emitted gendered prose. Anywhere the model reads OR writes
+text — prompts, schema examples, UI copy — use:
+
+- `L` / `F` (and possessive `L's` / `F's`) for the dancers,
+- "the lead" / "the follow" for prose flow,
+- `they` / `their` when the role is genuinely ambiguous.
+
+Never `he` / `she` / `him` / `her` / `his` / `hers` / `man's` / `woman's` /
+`ladies` / `gentlemen`. Pattern names: prefer `lead's turn` over `man's turn`.
+
+The single source of prompts (`api/src/wcs_api/services/video_analysis/prompts.py`)
+has a comment block at the top restating this; the rest of the codebase has
+been swept clean.

--- a/api/src/wcs_api/routes/peer_reviews.py
+++ b/api/src/wcs_api/routes/peer_reviews.py
@@ -31,8 +31,40 @@ router = APIRouter(prefix="/peer-reviews", tags=["peer-reviews"])
 # Requester (authenticated) endpoints
 # ─────────────────────────────────────────────────────────────────────
 
+_VALID_FOCUS_CATEGORIES = {
+    "timing",
+    "technique",
+    "teamwork",
+    "presentation",
+}
+
+
 class RequestBody(BaseModel):
     analysis_id: str = Field(..., min_length=1, max_length=64)
+    # Comment-first additions: the requester can tell the reviewer
+    # what to look at. Both optional — old clients keep working.
+    requester_prompt: str | None = Field(default=None, max_length=2000)
+    focus_categories: list[str] | None = Field(default=None)
+
+    @field_validator("focus_categories")
+    @classmethod
+    def _validate_focus(cls, v: list[str] | None) -> list[str] | None:
+        if not v:
+            return None
+        cleaned = [
+            c.strip().lower()
+            for c in v
+            if isinstance(c, str) and c.strip().lower() in _VALID_FOCUS_CATEGORIES
+        ]
+        # Dedup while preserving order so the UI badge order matches
+        # what the requester picked.
+        seen: set[str] = set()
+        out: list[str] = []
+        for c in cleaned:
+            if c not in seen:
+                seen.add(c)
+                out.append(c)
+        return out or None
 
 
 @router.post("/request")
@@ -58,6 +90,8 @@ async def request_review(
             analysis_id=body.analysis_id,
             token=token,
             requester_user_id=user["sub"],
+            requester_prompt=(body.requester_prompt or "").strip() or None,
+            focus_categories=body.focus_categories,
         )
     except httpx.HTTPStatusError as exc:
         raise HTTPException(
@@ -163,16 +197,24 @@ async def get_public_review(token: str) -> dict[str, Any]:
             "stage": analysis.get("stage"),
             "dancer_description": analysis.get("dancer_description"),
         },
+        # The dancer's brief — what they want feedback on. Shown above
+        # the video so the reviewer focuses there instead of guessing.
+        "requester_prompt": review.get("requester_prompt"),
+        "focus_categories": review.get("focus_categories"),
     }
 
 
 class SubmitBody(BaseModel):
     reviewer_name: str = Field(..., min_length=1, max_length=80)
     reviewer_role: str = Field(default="other", max_length=20)
-    timing_score: float = Field(..., ge=0.0, le=10.0)
-    technique_score: float = Field(..., ge=0.0, le=10.0)
-    teamwork_score: float = Field(..., ge=0.0, le=10.0)
-    presentation_score: float = Field(..., ge=0.0, le=10.0)
+    # Comment-first: scores are optional. A reviewer leaving useful
+    # timestamped notes without committing to numbers is more
+    # valuable than a 7/7/7/7-with-no-notes submission. We still
+    # accept and store scores when given.
+    timing_score: float | None = Field(default=None, ge=0.0, le=10.0)
+    technique_score: float | None = Field(default=None, ge=0.0, le=10.0)
+    teamwork_score: float | None = Field(default=None, ge=0.0, le=10.0)
+    presentation_score: float | None = Field(default=None, ge=0.0, le=10.0)
     overall_notes: str | None = Field(default=None, max_length=4000)
     per_moment_notes: list[dict[str, Any]] = Field(default_factory=list)
     # Opt-in to let SwingFlow use this review to improve the AI
@@ -208,6 +250,36 @@ class SubmitBody(BaseModel):
             cleaned.append({"timestamp_sec": round(ts, 2), "note": note})
         return cleaned
 
+    def require_at_least_one_signal(self) -> None:
+        """Comment-first guard: refuse submissions that carry no
+        actionable signal. The validator runs in the handler so we
+        can return a clean 400 instead of failing schema validation
+        on a synthetic "must have content" field.
+        """
+        has_overall = bool((self.overall_notes or "").strip())
+        has_pin = len(self.per_moment_notes) > 0
+        has_any_score = any(
+            s is not None
+            for s in (
+                self.timing_score,
+                self.technique_score,
+                self.teamwork_score,
+                self.presentation_score,
+            )
+        )
+        # A name-only submission with no notes, no pins, and no scores
+        # is the "drive-by 7/7/7/7" failure mode codex flagged. Block
+        # it. (Scores alone are acceptable so we don't regress users
+        # who do want to leave numbers.)
+        if not has_overall and not has_pin and not has_any_score:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "leave at least one comment, pin a timestamp, "
+                    "or rate a category before submitting"
+                ),
+            )
+
 
 @router.post("/public/{token}/submit")
 async def submit_public_review(
@@ -224,6 +296,9 @@ async def submit_public_review(
         raise HTTPException(status_code=404, detail="review not found")
     if review.get("submitted_at"):
         raise HTTPException(status_code=409, detail="review already submitted")
+
+    # Comment-first guard. Returns 400 if the form is empty.
+    body.require_at_least_one_signal()
 
     # Snapshot the AI result as it stands RIGHT NOW so the training
     # pair is frozen. Best-effort: if the analysis was deleted between

--- a/api/src/wcs_api/services/peer_reviews.py
+++ b/api/src/wcs_api/services/peer_reviews.py
@@ -22,13 +22,21 @@ async def insert_request(
     analysis_id: str,
     token: str,
     requester_user_id: str,
+    requester_prompt: str | None = None,
+    focus_categories: list[str] | None = None,
 ) -> None:
-    """Mint a new pending review request."""
+    """Mint a new pending review request. `requester_prompt` and
+    `focus_categories` are the comment-first brief — both optional
+    so old callers stay valid."""
     record: dict[str, Any] = {
         "analysis_id": analysis_id,
         "token": token,
         "requester_user_id": requester_user_id,
     }
+    if requester_prompt:
+        record["requester_prompt"] = requester_prompt
+    if focus_categories:
+        record["focus_categories"] = focus_categories
     async with httpx.AsyncClient(timeout=10) as client:
         r = await client.post(
             _rest("peer_reviews"),
@@ -56,10 +64,10 @@ async def submit(
     token: str,
     reviewer_name: str,
     reviewer_role: str,
-    timing_score: float,
-    technique_score: float,
-    teamwork_score: float,
-    presentation_score: float,
+    timing_score: float | None,
+    technique_score: float | None,
+    teamwork_score: float | None,
+    presentation_score: float | None,
     overall_notes: str | None,
     per_moment_notes: list[dict[str, Any]],
     training_consent: bool,
@@ -76,13 +84,17 @@ async def submit(
     `consent_given_at` when the reviewer opted in to training use.
     """
     now = _dt.datetime.now(_dt.timezone.utc).isoformat()
+
+    def _round_or_null(s: float | None) -> float | None:
+        return round(float(s), 1) if s is not None else None
+
     update: dict[str, Any] = {
         "reviewer_name": reviewer_name[:80],
         "reviewer_role": reviewer_role,
-        "timing_score": round(float(timing_score), 1),
-        "technique_score": round(float(technique_score), 1),
-        "teamwork_score": round(float(teamwork_score), 1),
-        "presentation_score": round(float(presentation_score), 1),
+        "timing_score": _round_or_null(timing_score),
+        "technique_score": _round_or_null(technique_score),
+        "teamwork_score": _round_or_null(teamwork_score),
+        "presentation_score": _round_or_null(presentation_score),
         "overall_notes": overall_notes,
         "per_moment_notes": per_moment_notes,
         "training_consent": bool(training_consent),

--- a/api/tests/test_analyses_routes.py
+++ b/api/tests/test_analyses_routes.py
@@ -1,10 +1,14 @@
-"""Coverage for the /analyses delete + share endpoints (#75 / #158).
+"""Coverage for the /analyses delete + share endpoints (#75 / #158)
+and the comment-first peer-review submission guard.
 
-These routes wrap service-role updates that the front-end used to do
-directly. The thing worth proving:
+The thing worth proving for /analyses:
   - 200 + state change when the row is owned by the caller
   - 404 (NOT 403) when it isn't, so we don't leak existence
   - share enable returns the same hex shape the front-end used to mint
+
+For peer-reviews: the comment-first guard rejects empty submissions
+(no notes, no pins, no scores) so we don't accept 7/7/7/7-no-notes
+drive-by reviews into training data.
 """
 
 from __future__ import annotations

--- a/api/tests/test_peer_review_guard.py
+++ b/api/tests/test_peer_review_guard.py
@@ -1,0 +1,101 @@
+"""Comment-first review guard.
+
+The SubmitBody.require_at_least_one_signal() check is the new gate
+that turns peer review from a 'score me' form into a 'review me'
+form. The guard belongs to the model itself (not the route handler)
+so it stays testable in isolation — feed SubmitBody and call the
+method.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from wcs_api.routes.peer_reviews import SubmitBody
+
+
+def _body(**overrides):
+    base = {
+        "reviewer_name": "Test Reviewer",
+        "reviewer_role": "dancer",
+    }
+    base.update(overrides)
+    return SubmitBody(**base)
+
+
+def test_empty_submission_is_rejected():
+    """The drive-by failure mode: name only, no notes, no pins, no
+    scores. Must return 400 — this is the whole point of comment-
+    first."""
+    body = _body()
+    with pytest.raises(HTTPException) as exc_info:
+        body.require_at_least_one_signal()
+    assert exc_info.value.status_code == 400
+    # Surface mentions all three accepted signals so the reviewer
+    # knows how to satisfy the form.
+    detail = str(exc_info.value.detail).lower()
+    assert "comment" in detail
+    assert "pin" in detail
+    assert "rate" in detail or "category" in detail
+
+
+def test_overall_note_alone_passes():
+    body = _body(overall_notes="anchor settles cleanly on 5-6")
+    body.require_at_least_one_signal()
+
+
+def test_whitespace_only_overall_note_does_not_pass():
+    """A note that's just spaces shouldn't trigger 'has signal' — it
+    would store as blank and the dancer would see an empty review."""
+    body = _body(overall_notes="   \n\t  ")
+    with pytest.raises(HTTPException):
+        body.require_at_least_one_signal()
+
+
+def test_single_pin_passes():
+    body = _body(
+        per_moment_notes=[
+            {"timestamp_sec": 12.3, "note": "rushed footwork here"}
+        ]
+    )
+    body.require_at_least_one_signal()
+
+
+def test_pin_with_empty_note_is_filtered_and_fails():
+    """The _cap_moment_notes validator drops pins with blank notes,
+    so the per_moment_notes list arrives empty at the guard — the
+    overall submission must still fail."""
+    body = _body(
+        per_moment_notes=[
+            {"timestamp_sec": 12.3, "note": "   "},
+            {"timestamp_sec": 5.0, "note": ""},
+        ]
+    )
+    with pytest.raises(HTTPException):
+        body.require_at_least_one_signal()
+
+
+def test_any_single_category_score_passes():
+    """A reviewer who only feels qualified to rate one of the four
+    categories shouldn't be blocked. Scores are now optional but
+    not all-or-nothing."""
+    for field in (
+        "timing_score",
+        "technique_score",
+        "teamwork_score",
+        "presentation_score",
+    ):
+        body = _body(**{field: 6.5})
+        body.require_at_least_one_signal()
+
+
+def test_scores_default_to_none_not_zero():
+    """Regression guard: in v1 scores defaulted to 7, which let
+    'drive-by 7/7/7/7' submissions through. Default must be None
+    (no signal) so the empty-form check fires."""
+    body = _body()
+    assert body.timing_score is None
+    assert body.technique_score is None
+    assert body.teamwork_score is None
+    assert body.presentation_score is None

--- a/src/app/(app)/analysis/page.tsx
+++ b/src/app/(app)/analysis/page.tsx
@@ -31,8 +31,19 @@ import {
   analyzeVideoFromKey,
   deleteUploadedVideo,
   getViewUrl,
+  listPeerReviews,
   type VideoScoreResult,
 } from "@/lib/wcs-api";
+
+// Reviewer pin as it gets surfaced to the timeline. Flat shape so
+// TimelineView can render markers without knowing about reviews.
+export type ReviewerPin = {
+  timestamp_sec: number;
+  note: string;
+  reviewer_name: string | null;
+  reviewer_role: string | null;
+  review_id: string;
+};
 import { Analytics } from "@/lib/analytics";
 
 function formatDateTime(iso: string): string {
@@ -74,6 +85,12 @@ function AnalysisPageInner() {
     null
   );
   const [shareCardOpen, setShareCardOpen] = useState(false);
+  // Reviewer pins surfaced from submitted peer reviews (#138 +
+  // peer-review-comment-first). Flattened across all submitted
+  // reviews so the timeline gets a single layer to render. Refetched
+  // when the user opens this analysis; we don't poll because new
+  // submissions land via a different (offline) channel anyway.
+  const [reviewerPins, setReviewerPins] = useState<ReviewerPin[]>([]);
 
   // Find the record from the history hook. history.records already
   // filters soft-deleted rows by default, so if the id is missing
@@ -81,6 +98,47 @@ function AnalysisPageInner() {
   const record: AnalysisRecord | undefined = id
     ? history.records.find((r) => r.id === id)
     : undefined;
+
+  useEffect(() => {
+    if (!id) {
+      setReviewerPins([]);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const data = await listPeerReviews(id);
+        if (cancelled) return;
+        const flat: ReviewerPin[] = [];
+        for (const r of data.submitted) {
+          const moments = Array.isArray(r.per_moment_notes)
+            ? r.per_moment_notes
+            : [];
+          for (const m of moments) {
+            const ts = Number(m?.timestamp_sec);
+            const note = String(m?.note ?? "").trim();
+            if (!Number.isFinite(ts) || !note) continue;
+            flat.push({
+              timestamp_sec: ts,
+              note,
+              reviewer_name: r.reviewer_name ?? null,
+              reviewer_role: r.reviewer_role ?? null,
+              review_id: r.id,
+            });
+          }
+        }
+        flat.sort((a, b) => a.timestamp_sec - b.timestamp_sec);
+        setReviewerPins(flat);
+      } catch {
+        // Silent: the embedded PeerReviewsSection has its own error
+        // surface for the same fetch failure; we don't double-toast.
+        if (!cancelled) setReviewerPins([]);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
 
   const currentResult = overrideResult ?? record?.result ?? null;
 
@@ -510,6 +568,7 @@ function AnalysisPageInner() {
         videoSrc={videoUrl}
         analysisId={record.id}
         initialSeekSec={initialSeekSec}
+        reviewerPins={reviewerPins}
       />
 
       {/* Score + sub-scores + patterns + strengths + improvements */}

--- a/src/app/peer-review/page.tsx
+++ b/src/app/peer-review/page.tsx
@@ -66,10 +66,15 @@ function PeerReviewInner() {
   const [reviewerName, setReviewerName] = useState("");
   const [reviewerRole, setReviewerRole] =
     useState<PeerReviewerRole>("dancer");
-  const [timing, setTiming] = useState<number>(7);
-  const [technique, setTechnique] = useState<number>(7);
-  const [teamwork, setTeamwork] = useState<number>(7);
-  const [presentation, setPresentation] = useState<number>(7);
+  // Scores deliberately start UNSET (null). Anchoring at "7" produced
+  // "drive-by 7/7/7/7" submissions where the reviewer never moved the
+  // sliders and left no notes — bad data we then averaged against the
+  // AI score. Comment-first: the reviewer has to actively decide to
+  // rate a category, or skip it.
+  const [timing, setTiming] = useState<number | null>(null);
+  const [technique, setTechnique] = useState<number | null>(null);
+  const [teamwork, setTeamwork] = useState<number | null>(null);
+  const [presentation, setPresentation] = useState<number | null>(null);
   const [notes, setNotes] = useState("");
   // Opt-in to use this review to improve the AI. Default false;
   // stays off unless the reviewer actively checks the box.
@@ -109,14 +114,29 @@ function PeerReviewInner() {
     };
   }, [token]);
 
+  // Comment-first: a name + literally nothing else used to be a valid
+  // submission. Now require at least one signal — a written note, a
+  // pin with text, or at least one rated category.
+  const hasSignal = useMemo(() => {
+    const hasOverall = notes.trim().length > 0;
+    const hasPin = pins.some((p) => p.note.trim().length > 0);
+    const hasScore =
+      timing != null ||
+      technique != null ||
+      teamwork != null ||
+      presentation != null;
+    return hasOverall || hasPin || hasScore;
+  }, [notes, pins, timing, technique, teamwork, presentation]);
+
   const canSubmit = useMemo(() => {
     return (
       !!ctx &&
       !ctx.already_submitted &&
       reviewerName.trim().length > 0 &&
+      hasSignal &&
       !submitting
     );
-  }, [ctx, reviewerName, submitting]);
+  }, [ctx, reviewerName, hasSignal, submitting]);
 
   const handleSubmit = async () => {
     if (!token || !canSubmit) return;
@@ -209,13 +229,38 @@ function PeerReviewInner() {
           <h1 className="text-2xl font-bold">Peer review</h1>
           <p className="text-sm text-muted-foreground">
             A dancer has asked for your feedback on this clip. Watch the
-            video, then score them on the four WSDC categories (timing,
-            technique, teamwork, presentation). Your scores and notes
-            will be shared only with the dancer.
+            video and leave at least one comment, pinned moment, or
+            category rating. Your feedback goes only to the dancer.
           </p>
         </header>
 
         <ContextCard ctx={ctx} />
+
+        {(ctx.requester_prompt || (ctx.focus_categories?.length ?? 0) > 0) && (
+          <Card className="border-primary/30 bg-primary/5">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm">
+                What the dancer wants feedback on
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2 text-sm">
+              {ctx.requester_prompt && (
+                <p className="whitespace-pre-wrap text-foreground">
+                  {ctx.requester_prompt}
+                </p>
+              )}
+              {ctx.focus_categories && ctx.focus_categories.length > 0 && (
+                <div className="flex flex-wrap gap-1.5">
+                  {ctx.focus_categories.map((c) => (
+                    <Badge key={c} variant="secondary" className="capitalize">
+                      {c}
+                    </Badge>
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        )}
 
         <Card>
           <CardContent className="p-0 overflow-hidden">
@@ -423,7 +468,16 @@ function PeerReviewInner() {
 
         <Card>
           <CardHeader className="pb-3">
-            <CardTitle className="text-base">Your scores (1–10)</CardTitle>
+            <CardTitle className="text-base">
+              Your scores{" "}
+              <span className="text-xs font-normal text-muted-foreground">
+                (1–10, optional)
+              </span>
+            </CardTitle>
+            <p className="text-xs text-muted-foreground">
+              Each category is unrated until you click <em>Rate</em>. Skip
+              what you don&rsquo;t feel qualified to call.
+            </p>
           </CardHeader>
           <CardContent className="space-y-5">
             <ScoreRow
@@ -500,21 +554,29 @@ function PeerReviewInner() {
           <p className="text-sm text-destructive">{error}</p>
         )}
 
-        <Button
-          onClick={handleSubmit}
-          disabled={!canSubmit}
-          className="w-full"
-          size="lg"
-        >
-          {submitting ? (
-            <>
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              Submitting…
-            </>
-          ) : (
-            "Submit review"
+        <div className="space-y-2">
+          <Button
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+            className="w-full"
+            size="lg"
+          >
+            {submitting ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Submitting…
+              </>
+            ) : (
+              "Submit review"
+            )}
+          </Button>
+          {!hasSignal && reviewerName.trim().length > 0 && (
+            <p className="text-xs text-muted-foreground text-center">
+              Leave at least one note, pin a moment, or rate a category
+              to submit.
+            </p>
           )}
-        </Button>
+        </div>
       </div>
     </div>
   );
@@ -566,25 +628,43 @@ function ScoreRow({
 }: {
   label: string;
   help: string;
-  value: number;
-  onChange: (v: number) => void;
+  value: number | null;
+  onChange: (v: number | null) => void;
 }) {
+  const SCORE_MID = 7;
+  const isSet = value != null;
   return (
     <div className="space-y-1.5">
-      <div className="flex items-baseline justify-between">
+      <div className="flex items-baseline justify-between gap-2">
         <Label>{label}</Label>
-        <span className="text-sm font-mono tabular-nums font-semibold">
-          {value.toFixed(1)}
-        </span>
+        <div className="flex items-center gap-2">
+          <span
+            className={
+              "text-sm font-mono tabular-nums font-semibold " +
+              (isSet ? "" : "text-muted-foreground")
+            }
+          >
+            {isSet ? value!.toFixed(1) : "—"}
+          </span>
+          <button
+            type="button"
+            onClick={() => onChange(isSet ? null : SCORE_MID)}
+            className="text-[11px] text-muted-foreground hover:text-foreground underline-offset-2 hover:underline"
+            aria-label={isSet ? `Skip rating ${label}` : `Rate ${label}`}
+          >
+            {isSet ? "Skip" : "Rate"}
+          </button>
+        </div>
       </div>
       <input
         type="range"
         min={1}
         max={10}
         step={0.1}
-        value={value}
+        value={value ?? SCORE_MID}
+        disabled={!isSet}
         onChange={(e) => onChange(parseFloat(e.target.value))}
-        className="w-full accent-primary"
+        className="w-full accent-primary disabled:opacity-40 disabled:cursor-not-allowed"
       />
       <p className="text-xs text-muted-foreground">{help}</p>
     </div>

--- a/src/components/analyze/peer-reviews-section.tsx
+++ b/src/components/analyze/peer-reviews-section.tsx
@@ -13,10 +13,21 @@ import {
   listPeerReviews,
   requestPeerReview,
   type PeerReview,
+  type ReviewBrief,
 } from "@/lib/wcs-api";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import {
   Check,
   Copy,
@@ -26,6 +37,14 @@ import {
   UserPlus,
   X,
 } from "lucide-react";
+
+type FocusCategory = NonNullable<ReviewBrief["focus_categories"]>[number];
+const FOCUS_CATEGORIES: Array<{ key: FocusCategory; label: string }> = [
+  { key: "timing", label: "Timing" },
+  { key: "technique", label: "Technique" },
+  { key: "teamwork", label: "Teamwork" },
+  { key: "presentation", label: "Presentation" },
+];
 
 function formatPinTime(sec: number): string {
   if (!Number.isFinite(sec) || sec < 0) return "0:00";
@@ -48,6 +67,15 @@ export function PeerReviewsSection({ analysisId }: { analysisId: string }) {
   const [requesting, setRequesting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [copiedToken, setCopiedToken] = useState<string | null>(null);
+  // Brief dialog state — comment-first flow. Sending an empty brief
+  // is still valid (the brief is optional server-side), but the
+  // dialog nudges the dancer to say what they actually want feedback
+  // on, which is the whole point.
+  const [briefOpen, setBriefOpen] = useState(false);
+  const [briefPrompt, setBriefPrompt] = useState("");
+  const [briefFocus, setBriefFocus] = useState<Set<FocusCategory>>(
+    () => new Set()
+  );
 
   const refresh = useCallback(async () => {
     try {
@@ -69,7 +97,11 @@ export function PeerReviewsSection({ analysisId }: { analysisId: string }) {
     setRequesting(true);
     setError(null);
     try {
-      const { url } = await requestPeerReview(analysisId);
+      const brief: ReviewBrief = {
+        requester_prompt: briefPrompt.trim() || null,
+        focus_categories: Array.from(briefFocus),
+      };
+      const { url } = await requestPeerReview(analysisId, brief);
       // Try to copy immediately so the user can paste into a DM /
       // message / email. Falls back to showing the URL in the row if
       // clipboard isn't available.
@@ -80,12 +112,24 @@ export function PeerReviewsSection({ analysisId }: { analysisId: string }) {
       } catch {
         // ignore — the link will be visible in the pending row
       }
+      setBriefOpen(false);
+      setBriefPrompt("");
+      setBriefFocus(new Set());
       await refresh();
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {
       setRequesting(false);
     }
+  };
+
+  const toggleFocus = (c: FocusCategory) => {
+    setBriefFocus((prev) => {
+      const next = new Set(prev);
+      if (next.has(c)) next.delete(c);
+      else next.add(c);
+      return next;
+    });
   };
 
   const handleCopy = async (token: string) => {
@@ -157,14 +201,10 @@ export function PeerReviewsSection({ analysisId }: { analysisId: string }) {
           <Button
             size="sm"
             variant="outline"
-            onClick={handleRequest}
+            onClick={() => setBriefOpen(true)}
             disabled={requesting}
           >
-            {requesting ? (
-              <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" />
-            ) : (
-              <UserPlus className="h-3.5 w-3.5 mr-1.5" />
-            )}
+            <UserPlus className="h-3.5 w-3.5 mr-1.5" />
             Ask someone
           </Button>
         </div>
@@ -260,6 +300,85 @@ export function PeerReviewsSection({ analysisId }: { analysisId: string }) {
           </div>
         )}
       </CardContent>
+
+      <Dialog
+        open={briefOpen}
+        onOpenChange={(open) => {
+          if (requesting) return;
+          setBriefOpen(open);
+        }}
+      >
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Ask someone for feedback</DialogTitle>
+            <DialogDescription>
+              Tell the reviewer what to look at. A focused question gets a
+              focused answer — &ldquo;does my anchor settle on 5–6?&rdquo; beats
+              &ldquo;score me out of 10.&rdquo;
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="brief-prompt" className="text-sm">
+                What do you want feedback on?{" "}
+                <span className="text-muted-foreground font-normal">
+                  (optional)
+                </span>
+              </Label>
+              <textarea
+                id="brief-prompt"
+                value={briefPrompt}
+                onChange={(e) => setBriefPrompt(e.target.value)}
+                rows={3}
+                maxLength={2000}
+                placeholder="e.g. My anchors keep feeling rushed. Does my weight settle on 5-6, or am I leaving early?"
+                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label className="text-sm">
+                Focus areas{" "}
+                <span className="text-muted-foreground font-normal">
+                  (optional)
+                </span>
+              </Label>
+              <div className="grid grid-cols-2 gap-2">
+                {FOCUS_CATEGORIES.map((c) => (
+                  <label
+                    key={c.key}
+                    className="flex items-center gap-2 text-sm cursor-pointer rounded-md border border-border/60 px-2.5 py-1.5 hover:bg-muted/30"
+                  >
+                    <Checkbox
+                      checked={briefFocus.has(c.key)}
+                      onCheckedChange={() => toggleFocus(c.key)}
+                    />
+                    {c.label}
+                  </label>
+                ))}
+              </div>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              variant="ghost"
+              onClick={() => setBriefOpen(false)}
+              disabled={requesting}
+            >
+              Cancel
+            </Button>
+            <Button onClick={handleRequest} disabled={requesting}>
+              {requesting ? (
+                <>
+                  <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" />
+                  Generating link…
+                </>
+              ) : (
+                "Generate review link"
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </Card>
   );
 }

--- a/src/components/analyze/timeline-view.tsx
+++ b/src/components/analyze/timeline-view.tsx
@@ -33,6 +33,16 @@ type TimelineViewProps = {
   // the cross-analysis Patterns view (#138) to deep-link straight
   // to a specific occurrence's start_time.
   initialSeekSec?: number;
+  // Pins from submitted peer reviews. Rendered as a separate layer
+  // above the AI pattern blocks so the user can scrub directly to
+  // moments a human flagged. Click a marker → seek + show note.
+  reviewerPins?: Array<{
+    timestamp_sec: number;
+    note: string;
+    reviewer_name: string | null;
+    reviewer_role: string | null;
+    review_id: string;
+  }>;
 };
 
 const QUALITY_COLOR: Record<string, string> = {
@@ -78,6 +88,7 @@ export function TimelineView({
   videoSrc,
   analysisId,
   initialSeekSec,
+  reviewerPins,
 }: TimelineViewProps) {
   const videoRef = useRef<HTMLVideoElement>(null);
   const [currentTime, setCurrentTime] = useState(0);
@@ -639,6 +650,33 @@ export function TimelineView({
               title={`Off-beat at ${formatTime(m.t)}: ${m.description ?? ""}`}
             />
           ))}
+
+          {/* Reviewer pins — human-authored timestamped comments from
+              submitted peer reviews. Rendered ABOVE the timeline (top:
+              -3) as little pin dots so they don't fight the AI pattern
+              blocks for the same vertical real estate, but stay
+              visually associated with their timestamp. Click → seek. */}
+          {(reviewerPins ?? []).map((pin, i) => {
+            const pct = Math.max(
+              0,
+              Math.min(100, (pin.timestamp_sec / effectiveDuration) * 100)
+            );
+            const author = pin.reviewer_name || "Anonymous";
+            return (
+              <button
+                key={`pin-${pin.review_id}-${i}`}
+                type="button"
+                className="absolute -top-3 z-10 -translate-x-1/2 h-3 w-3 rounded-full border-2 border-background bg-emerald-400 shadow-sm hover:scale-125 transition-transform"
+                style={{ left: `${pct}%` }}
+                title={`${author}${pin.reviewer_role ? ` (${pin.reviewer_role})` : ""} @ ${formatTime(pin.timestamp_sec)}: ${pin.note}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  seek(pin.timestamp_sec);
+                }}
+                aria-label={`Jump to reviewer comment at ${formatTime(pin.timestamp_sec)}`}
+              />
+            );
+          })}
 
           {/* Playhead with floating time tag */}
           <div

--- a/src/components/analyze/timeline-view.tsx
+++ b/src/components/analyze/timeline-view.tsx
@@ -652,10 +652,11 @@ export function TimelineView({
           ))}
 
           {/* Reviewer pins — human-authored timestamped comments from
-              submitted peer reviews. Rendered ABOVE the timeline (top:
-              -3) as little pin dots so they don't fight the AI pattern
-              blocks for the same vertical real estate, but stay
-              visually associated with their timestamp. Click → seek. */}
+              submitted peer reviews. Rendered INSIDE the bar at the
+              top edge (the parent has overflow-hidden, so negative
+              top values would clip the pins out of view entirely).
+              z-10 keeps them above the pattern blocks they may
+              overlap. Click → seek. */}
           {(reviewerPins ?? []).map((pin, i) => {
             const pct = Math.max(
               0,
@@ -666,7 +667,7 @@ export function TimelineView({
               <button
                 key={`pin-${pin.review_id}-${i}`}
                 type="button"
-                className="absolute -top-3 z-10 -translate-x-1/2 h-3 w-3 rounded-full border-2 border-background bg-emerald-400 shadow-sm hover:scale-125 transition-transform"
+                className="absolute top-0.5 z-10 -translate-x-1/2 h-3 w-3 rounded-full border-2 border-background bg-emerald-400 shadow-sm hover:scale-125 transition-transform"
                 style={{ left: `${pct}%` }}
                 title={`${author}${pin.reviewer_role ? ` (${pin.reviewer_role})` : ""} @ ${formatTime(pin.timestamp_sec)}: ${pin.note}`}
                 onClick={(e) => {

--- a/src/lib/wcs-api.ts
+++ b/src/lib/wcs-api.ts
@@ -598,8 +598,18 @@ export type PeerReviewList = {
   submitted: PeerReview[];
 };
 
+export type ReviewBrief = {
+  // Free-text "what do you want feedback on?". Optional — old
+  // request-flow without a brief still works server-side.
+  requester_prompt?: string | null;
+  // Subset of WSDC categories the requester wants the reviewer to
+  // focus on. UI renders them as badges above the video.
+  focus_categories?: Array<"timing" | "technique" | "teamwork" | "presentation">;
+};
+
 export async function requestPeerReview(
-  analysisId: string
+  analysisId: string,
+  brief: ReviewBrief = {}
 ): Promise<{ token: string; url: string }> {
   if (!API_URL) throw new Error("NEXT_PUBLIC_WCS_API_URL is not set");
   const token = await getAccessToken();
@@ -610,7 +620,14 @@ export async function requestPeerReview(
       "Content-Type": "application/json",
       Authorization: `Bearer ${token}`,
     },
-    body: JSON.stringify({ analysis_id: analysisId }),
+    body: JSON.stringify({
+      analysis_id: analysisId,
+      requester_prompt: brief.requester_prompt ?? null,
+      focus_categories:
+        brief.focus_categories && brief.focus_categories.length > 0
+          ? brief.focus_categories
+          : null,
+    }),
   });
   if (!res.ok) {
     let detail = res.statusText;
@@ -679,6 +696,11 @@ export type PublicReviewContext = {
     stage: string | null;
     dancer_description: string | null;
   };
+  // Comment-first additions: brief from the requester. Reviewer
+  // sees these above the video so feedback can be targeted instead
+  // of "score me on everything."
+  requester_prompt: string | null;
+  focus_categories: string[] | null;
 };
 
 export async function fetchPublicReview(
@@ -706,10 +728,14 @@ export async function submitPublicReview(
   body: {
     reviewer_name: string;
     reviewer_role: PeerReviewerRole;
-    timing_score: number;
-    technique_score: number;
-    teamwork_score: number;
-    presentation_score: number;
+    // Scores are now optional. The backend requires the submission
+    // to carry SOMETHING — notes, pins, or at least one score — but
+    // a reviewer leaving 5 useful timestamped comments without
+    // committing to numbers is a valid submission.
+    timing_score: number | null;
+    technique_score: number | null;
+    teamwork_score: number | null;
+    presentation_score: number | null;
     overall_notes?: string | null;
     per_moment_notes?: Array<{ timestamp_sec: number; note: string }>;
     // Opt-in: true = SwingFlow may use this review to improve scoring

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -237,6 +237,12 @@ create table if not exists public.peer_reviews (
   -- and AI score could desync, ruining the training pair.
   ai_result_snapshot    jsonb,
 
+  -- Optional brief from the requester. Reviewers see this above the
+  -- video so they know what to look at instead of guessing at the
+  -- "score me on everything" form. Comment-first review (#112-adj).
+  requester_prompt      text,
+  focus_categories      text[],
+
   submitted_at          timestamptz,
   created_at            timestamptz not null default now()
 );
@@ -246,6 +252,13 @@ alter table public.peer_reviews
   add column if not exists training_consent   boolean not null default false,
   add column if not exists consent_given_at   timestamptz,
   add column if not exists ai_result_snapshot jsonb;
+
+-- Migration: add the requester's brief so reviewers know what the
+-- dancer wants feedback on. Idempotent so re-running this schema
+-- doesn't error on environments that already applied it.
+alter table public.peer_reviews
+  add column if not exists requester_prompt   text,
+  add column if not exists focus_categories   text[];
 
 create index if not exists peer_reviews_analysis_id_idx
   on public.peer_reviews(analysis_id);


### PR DESCRIPTION
Codex-recommended path. Better data going in (PR 1) reinforces a better surface coming out (PR 2), shipped together so the loop closes end-to-end.

## Why

Reviewer form was structured as "score me." Scores defaulted to \`7/7/7/7\` and \`canSubmit\` only required a name. The result: drive-by submissions where the reviewer never moved a slider and left zero notes — bad data we then averaged against the AI score. Codex flagged this as a critical product bug.

## Comment-first form (PR 1)

- **Scores nullable end-to-end.** Frontend defaults to \`null\` with a per-category **Rate / Skip** toggle. Backend's \`SubmitBody\` scores are \`float | None\`.
- **New \`require_at_least_one_signal()\` guard.** Rejects empty submissions (no notes, no pins, no rated categories) with 400.
- **Reviewer copy updated** — from "score them on four categories" to "leave at least one comment, pinned moment, or rating."
- **Requester brief.** Optional \`requester_prompt\` (free text) + \`focus_categories[]\` ("look at my anchors"). Dialog flow on \`/analysis\` replaces the one-click "Ask someone."
- **Reviewer sees the brief** in a highlighted card above the video.

## Owner timeline pins (PR 2)

- \`<TimelineView>\` now accepts a \`reviewerPins\` prop. Emerald dots above the pattern timeline. Click → seek + tooltip with reviewer name / role / timestamp / note. Uses existing \`seek()\` helper that already handles the metadata-not-loaded case.
- \`/analysis\` page fetches submitted reviews on mount and flattens \`per_moment_notes\` into the prop. Silent on error — \`PeerReviewsSection\` has its own error surface for the same endpoint, no double-toasting.

## Schema

Two new optional columns on \`peer_reviews\` (idempotent migration appended):

\`\`\`sql
alter table public.peer_reviews
  add column if not exists requester_prompt   text,
  add column if not exists focus_categories   text[];
\`\`\`

Old reviews keep working — the brief is optional everywhere.

## What's deliberately deferred

Codex flagged these as next-up after measurement: lifecycle guardrails (\`expires_at\`, refuse-token-if-no-video), reply-per-review, notifications, public review feed, voice / drawing, marketplace. Don't build them until we know the basic loop converts.

## Test plan

- [x] \`uv run pytest tests/\` — 33 passed (7 new in \`test_peer_review_guard.py\`)
- [x] \`tsc --noEmit\` clean
- [x] \`npm run build\` succeeds
- [ ] Manual: request review w/ brief, reviewer sees brief above video, scores start unrated, "Submit" disabled until note/pin/score, pins render on owner's timeline post-submit, click pin → seek
- [ ] Apply the schema migration in Supabase dashboard (idempotent — safe to re-run)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reviewers can now submit detailed feedback without rating all performance categories—scores are optional
  * Requesters can provide guidance prompts and priority focus areas when requesting peer reviews
  * Timeline visualization now displays reviewer comment pins at specific timestamps
  * Added validation ensuring reviewers provide meaningful feedback via comments, pins, or ratings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sauravpanda/swingflow/pull/168)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->