### PR TITLE
Pin ws ^8.20.1 via npm overrides (GHSA uninitialized memory)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8930,9 +8930,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -33,5 +33,8 @@
     "postcss": "^8.5.10",
     "tailwindcss": "^4.1.18",
     "typescript": "^5.9.3"
+  },
+  "overrides": {
+    "ws": "^8.20.1"
   }
 }


### PR DESCRIPTION
Closes Dependabot alert #45.

## Why

\`@supabase/realtime-js\` (transitively from \`@supabase/supabase-js\`) accepts \`ws ^8.18.2\`, which was resolving to \`8.20.0\`. That version has GHSA — uninitialized memory disclosure (medium). The fix is in \`8.20.1\`; @supabase hasn't released a version that bumps it directly yet.

## What

\`overrides\` block in \`package.json\` pinning \`ws: ^8.20.1\`. The canonical npm mechanism for transitive lockdown. The override stays within \`@supabase/realtime-js\`'s accepted semver range, so nothing else breaks.

## Verification

\`npm ls ws\` after \`npm install\`:

\`\`\`
swingflow@0.1.0
└─┬ @supabase/supabase-js@2.103.2
  └─┬ @supabase/realtime-js@2.103.2
    └── ws@8.20.1   ← was 8.20.0
\`\`\`

\`npm run build\` succeeds.

## Removal note

Drop the override once Supabase ships a release where \`@supabase/realtime-js\` depends on \`ws >= 8.20.1\` directly. Until then this is the surgical fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependency management configuration for improved stability and compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sauravpanda/swingflow/pull/170?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->