### PR TITLE
Coach mode PR 1: audible beat click on detected beats

### DIFF
--- a/src/components/analyze/timeline-view.tsx
+++ b/src/components/analyze/timeline-view.tsx
@@ -11,8 +11,10 @@ import {
   Gauge,
   Crosshair,
   RotateCcw,
+  Drum,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useVideoBeatClick } from "@/hooks/use-video-beat-click";
 import type {
   MusicalMoment,
   VideoPatternIdentified,
@@ -178,6 +180,20 @@ export function TimelineView({
     vAny.mozPreservesPitch = true;
     vAny.webkitPreservesPitch = true;
   }, [videoSrc, playbackRate]);
+
+  // Audible beat click — Web Audio metronome that fires on each beat
+  // extracted from the song (#168-pivot). The video player handles
+  // the song's own audio; this layers a separate "tick" on top that
+  // stays accurate when the video is slowed or sped up, because the
+  // scheduler reads playbackRate. Toggle is persisted in localStorage
+  // so a coach's preference sticks across clips.
+  const beatClick = useVideoBeatClick({
+    beats: result.beat_grid?.beats ?? null,
+    downbeats: result.beat_grid?.downbeats ?? null,
+    videoRef,
+    playing,
+  });
+
   // Detail shown below the bar. Manual intent (hover / tap-select)
   // wins. Otherwise track whatever pattern the video is currently
   // playing through so a user just pressing play watches the detail
@@ -417,6 +433,31 @@ export function TimelineView({
             )}
             <div className="ml-auto flex items-center gap-1">
               <SpeedSelector rate={playbackRate} onChange={applyRate} />
+              {result.beat_grid && (
+                <button
+                  type="button"
+                  onClick={() => beatClick.setEnabled(!beatClick.enabled)}
+                  className={cn(
+                    "p-1 rounded transition-colors",
+                    beatClick.enabled
+                      ? "text-emerald-400 hover:text-emerald-300"
+                      : "text-white/70 hover:text-white"
+                  )}
+                  aria-label={
+                    beatClick.enabled
+                      ? "Mute beat click"
+                      : "Play beat click on each detected beat"
+                  }
+                  aria-pressed={beatClick.enabled}
+                  title={
+                    beatClick.enabled
+                      ? "Beat click on — tap to mute"
+                      : "Beat click off — tap to hear a tick on every detected beat (downbeats louder)"
+                  }
+                >
+                  <Drum className="h-4 w-4" />
+                </button>
+              )}
               <button
                 type="button"
                 onClick={toggleMute}

--- a/src/hooks/use-video-beat-click.ts
+++ b/src/hooks/use-video-beat-click.ts
@@ -1,0 +1,238 @@
+"use client";
+
+// Schedules a Web Audio click on each beat of a video's extracted
+// beat_grid. Distinct from useMetronome (which generates beats from a
+// fixed BPM for the Rhythm trainer): here the beat times come from
+// Beat This!'s analysis of the actual song, so they can be irregular
+// (tempo shifts, fermatas) and the click stays accurate without us
+// re-deriving anything.
+//
+// Coaching use case (#168-pivot): when reviewing a clip you want a
+// metronome that *matches the music as it actually played*. The
+// existing MetronomeDot covers the visual; this covers the audible.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+// How far ahead of video.currentTime we look when scheduling. 250ms
+// is the standard Web Audio metronome lookahead: large enough to ride
+// out main-thread jank, small enough that toggling off feels immediate.
+const SCHEDULER_LOOKAHEAD_SEC = 0.25;
+// How often the scheduler wakes up. 50ms keeps each tick small while
+// still comfortably re-arming inside the lookahead window.
+const SCHEDULER_INTERVAL_MS = 50;
+
+const DOWNBEAT_FREQ = 1100;
+const BEAT_FREQ = 660;
+const CLICK_DURATION = 0.04;
+const DOWNBEAT_GAIN = 0.6;
+const BEAT_GAIN = 0.4;
+
+const STORAGE_KEY = "swingflow:beat-click-enabled";
+
+export type UseVideoBeatClickOptions = {
+  /** Sorted beat timestamps in video seconds. */
+  beats: number[] | null | undefined;
+  /** Subset of `beats` that are downbeats (bar 1). */
+  downbeats: number[] | null | undefined;
+  /** The <video> element to mirror — we read currentTime + playback rate
+   *  here so the click stays in sync when the user slows the video down. */
+  videoRef: React.RefObject<HTMLVideoElement | null>;
+  /** Whether the video is currently playing. Pause clears the queue. */
+  playing: boolean;
+};
+
+export function useVideoBeatClick({
+  beats,
+  downbeats,
+  videoRef,
+  playing,
+}: UseVideoBeatClickOptions) {
+  // Lazy initializer so the localStorage read happens once at mount
+  // and lives in render rather than an effect. Effects-that-setState
+  // trigger a cascading render, which the lint rule rightly flags.
+  const [enabled, setEnabledState] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    return window.localStorage.getItem(STORAGE_KEY) === "true";
+  });
+  // Track which beat indices we've already scheduled in this play
+  // cycle so a single beat doesn't get queued twice when the lookahead
+  // window slides over it on consecutive ticks.
+  const scheduledIdxRef = useRef<Set<number>>(new Set());
+  const audioCtxRef = useRef<AudioContext | null>(null);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const downbeatSetRef = useRef<Set<number>>(new Set());
+  const enabledRef = useRef(false);
+
+  useEffect(() => {
+    enabledRef.current = enabled;
+  }, [enabled]);
+
+  const setEnabled = useCallback((next: boolean) => {
+    setEnabledState(next);
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(STORAGE_KEY, next ? "true" : "false");
+    }
+  }, []);
+
+  // Rebuild downbeat lookup whenever the source data changes. Compare
+  // by exact float equality matches Beat This!'s output (downbeats is
+  // a subset of beats with identical float values).
+  useEffect(() => {
+    downbeatSetRef.current = new Set(downbeats ?? []);
+  }, [downbeats]);
+
+  // Stop scheduler + reset state. Idempotent so we can call it from
+  // any of the effects that might tear things down.
+  const teardown = useCallback(() => {
+    if (timerRef.current) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+    scheduledIdxRef.current = new Set();
+  }, []);
+
+  // Schedule a single click at a precise AudioContext time. Square
+  // wave on a fast envelope reads as a clean "tick" without the
+  // smearing you get from a longer sine fade.
+  const scheduleClick = useCallback(
+    (ctx: AudioContext, atTime: number, isDownbeat: boolean) => {
+      const osc = ctx.createOscillator();
+      const gainNode = ctx.createGain();
+      osc.connect(gainNode);
+      gainNode.connect(ctx.destination);
+      osc.type = "square";
+      osc.frequency.value = isDownbeat ? DOWNBEAT_FREQ : BEAT_FREQ;
+      const peak = isDownbeat ? DOWNBEAT_GAIN : BEAT_GAIN;
+      gainNode.gain.setValueAtTime(peak, atTime);
+      gainNode.gain.exponentialRampToValueAtTime(0.001, atTime + CLICK_DURATION);
+      osc.start(atTime);
+      osc.stop(atTime + CLICK_DURATION);
+    },
+    []
+  );
+
+  // The scheduler tick — finds beats inside the next lookahead window
+  // and queues a click for each one we haven't already scheduled in
+  // this play cycle.
+  const tick = useCallback(() => {
+    if (!enabledRef.current) return;
+    const video = videoRef.current;
+    const ctx = audioCtxRef.current;
+    if (!video || !ctx || video.paused) return;
+    if (!beats || beats.length === 0) return;
+
+    const videoNow = video.currentTime;
+    const rate = video.playbackRate || 1;
+    // beat lands at video timestamp T, so the audio-clock time is
+    //   audioNow + (T - videoNow) / rate
+    // Anything ≤ audioNow has already been missed; skip it.
+    const audioNow = ctx.currentTime;
+    const lookaheadVideoEnd = videoNow + SCHEDULER_LOOKAHEAD_SEC * rate;
+
+    // Binary search for the first beat >= videoNow. Beats are sorted.
+    let lo = 0;
+    let hi = beats.length;
+    while (lo < hi) {
+      const mid = (lo + hi) >> 1;
+      if (beats[mid] < videoNow) lo = mid + 1;
+      else hi = mid;
+    }
+
+    for (let i = lo; i < beats.length; i++) {
+      const beatTime = beats[i];
+      if (beatTime > lookaheadVideoEnd) break;
+      if (scheduledIdxRef.current.has(i)) continue;
+      const audioTime = audioNow + (beatTime - videoNow) / rate;
+      // Past-time defense: occasionally a tick wakes late and the beat
+      // has slid into the past. Drop it rather than fire instantly.
+      if (audioTime < audioNow) {
+        scheduledIdxRef.current.add(i);
+        continue;
+      }
+      const isDownbeat = downbeatSetRef.current.has(beatTime);
+      scheduleClick(ctx, audioTime, isDownbeat);
+      scheduledIdxRef.current.add(i);
+    }
+  }, [beats, scheduleClick, videoRef]);
+
+  // Bring the scheduler up when enabled + playing + we have beats.
+  // Each play cycle gets a fresh AudioContext if the previous one was
+  // closed; reused otherwise so we don't pay the start-up cost on every
+  // play/pause toggle.
+  useEffect(() => {
+    if (!enabled || !playing) {
+      teardown();
+      return;
+    }
+    if (!beats || beats.length === 0) return;
+    let cancelled = false;
+
+    const ensureContext = async () => {
+      let ctx = audioCtxRef.current;
+      if (!ctx || ctx.state === "closed") {
+        ctx = new (window.AudioContext ||
+          (window as unknown as { webkitAudioContext: typeof AudioContext })
+            .webkitAudioContext)();
+        audioCtxRef.current = ctx;
+      }
+      // Browsers freeze suspended contexts after autoplay-policy
+      // rejections — resume() is a no-op when already running.
+      if (ctx.state === "suspended") {
+        try {
+          await ctx.resume();
+        } catch {
+          // ignore; the next user gesture will re-try
+        }
+      }
+      if (cancelled) return;
+      // Fresh schedule set per play cycle so a seek (which fires
+      // pause→play) doesn't permanently mark earlier beats as "already
+      // scheduled".
+      scheduledIdxRef.current = new Set();
+      timerRef.current = setInterval(tick, SCHEDULER_INTERVAL_MS);
+      // Fire once immediately so the very first beat after press-play
+      // doesn't have to wait for the first tick interval.
+      tick();
+    };
+    void ensureContext();
+
+    return () => {
+      cancelled = true;
+      teardown();
+    };
+  }, [enabled, playing, beats, tick, teardown]);
+
+  // Seeking inside a play cycle resets the schedule set — we may
+  // have jumped past beats that are still in scheduledIdxRef, and
+  // we may have jumped backward to beats we'd marked as done.
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video) return;
+    const onSeeked = () => {
+      scheduledIdxRef.current = new Set();
+    };
+    video.addEventListener("seeked", onSeeked);
+    return () => {
+      video.removeEventListener("seeked", onSeeked);
+    };
+  }, [videoRef]);
+
+  // Cleanup on unmount: close the AudioContext so we don't leak
+  // audio devices when the user navigates away.
+  useEffect(() => {
+    return () => {
+      teardown();
+      const ctx = audioCtxRef.current;
+      if (ctx && ctx.state !== "closed") {
+        try {
+          ctx.close();
+        } catch {
+          // ignore
+        }
+      }
+      audioCtxRef.current = null;
+    };
+  }, [teardown]);
+
+  return { enabled, setEnabled };
+}


### PR DESCRIPTION
First slice of the coaching-tools pivot (surgical, keep AI infrastructure for now).

## What this gives you

Tap the **drum icon** in the timeline controls and hear a tick on every beat Beat This! extracted from the song:
- Downbeats louder + higher pitched (1100 Hz)
- Regular beats (660 Hz)
- Clicks stay in sync when you **slow the video down** — the scheduler reads \`playbackRate\`. This is the part you can't get from a phone metronome (those assume a constant tempo, and live music drifts).
- Hidden entirely when there's no \`beat_grid\` (old analyses) — no dead button.
- Off by default — unexpected click track on press-play would be jarring. Preference persists in \`localStorage\` so a coach who turns it on keeps it on across clips.

## How

- New \`useVideoBeatClick\` hook. Standard Web Audio metronome pattern: **250ms lookahead, 50ms tick**, square wave on a 40ms exponential envelope so each click reads as a clean tick (sine fade smears).
- Schedule formula: \`audioCtx.currentTime + (beatTime - video.currentTime) / playbackRate\` — the rate division is what keeps the tick aligned at half-speed.
- Fresh schedule-set per play cycle so a **seek** (which fires pause→play) doesn't permanently mark earlier beats as already-scheduled.
- Cleanup on unmount closes the AudioContext (no leaked audio devices).

Distinct from \`useMetronome\` (which generates fixed-BPM beats for the Rhythm trainer) because here the beats come from the actual song and can be irregular — tempo shifts in the recording follow automatically.

## Verification

- \`tsc --noEmit\` clean
- \`npm run lint\` clean for changed files
- \`npm run build\` succeeds
- Manual: open a clip with detected beats, hit Play, toggle drum icon → ticks land on the music. Slow to 0.5x → ticks halve in real-time but still hit on the beat.

## What's next in the coaching pivot

- PR 2: loop-a-section + J/K/L bindings + frame-step. Small.
- PR 3: MediaPipe pose overlay — body lines and weight-transfer signal. Bigger lift.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Beat-click metronome feature now delivers audible ticks synchronized to the video's beat grid
  * New toggle button enables/disables beat-click overlay in the timeline view
  * Beat-click preference is automatically saved and persists across sessions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sauravpanda/swingflow/pull/172?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->