### PR TITLE
Fix playback correctness: paused frame-step, beat-click cleanup, fullscreen overlay

### DIFF
--- a/src/components/analyze/timeline-view.tsx
+++ b/src/components/analyze/timeline-view.tsx
@@ -430,14 +430,20 @@ export function TimelineView({
     if (!videoSrc) return;
     if (seekedForKeyRef.current === initialSeekKey) return;
     seekedForKeyRef.current = initialSeekKey;
-    seek(initialSeekSec);
+    seek(initialSeekSec, { autoplay: true });
     // `seek` is referenced via closure and its identity changes per
     // render; we intentionally only re-run when the deep-link key
     // (videoSrc + target) changes, not on unrelated re-renders.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialSeekKey]);
 
-  const seek = (t: number) => {
+  // autoplay: start playback after landing the seek. On for "go
+  // watch this moment" intents (pattern block, reviewer pin, bar
+  // click); off for positioning intents (J/L skip, frame-step,
+  // arrow-key scrub) — a paused frame-step that silently resumes
+  // playback blows away the exact frame the user was inspecting.
+  const seek = (t: number, opts?: { autoplay?: boolean }) => {
+    const autoplay = opts?.autoplay ?? false;
     const clamped = Math.max(0, Math.min(t, effectiveDuration));
     setCurrentTime(clamped);
     const v = videoRef.current;
@@ -449,7 +455,7 @@ export function TimelineView({
         const onReady = () => {
           v.currentTime = clamped;
           v.removeEventListener("loadedmetadata", onReady);
-          if (!playing) {
+          if (autoplay && !playing) {
             v.play().catch(() => {
               /* user gesture required */
             });
@@ -459,7 +465,7 @@ export function TimelineView({
         return;
       }
       v.currentTime = clamped;
-      if (!playing) {
+      if (autoplay && !playing) {
         v.play().catch(() => {
           /* user gesture required */
         });
@@ -525,15 +531,16 @@ export function TimelineView({
           seek(v.currentTime + SKIP_SEC);
           break;
         case ",":
-          // Only step frames when paused; stepping while playing
-          // produces a stutter that feels like a bug, not a tool.
-          if (!v.paused) return;
+          // Frame-step pauses first (NLE convention) — stepping
+          // implies the user wants to inspect a single frame, and
+          // stepping mid-playback would otherwise read as a stutter.
           e.preventDefault();
+          if (!v.paused) v.pause();
           seek(v.currentTime - FRAME_SEC);
           break;
         case ".":
-          if (!v.paused) return;
           e.preventDefault();
+          if (!v.paused) v.pause();
           seek(v.currentTime + FRAME_SEC);
           break;
         case "[":
@@ -618,7 +625,7 @@ export function TimelineView({
       0,
       Math.min(1, (e.clientX - rect.left) / rect.width)
     );
-    seek(pct * effectiveDuration);
+    seek(pct * effectiveDuration, { autoplay: true });
   };
 
   const toggleMute = () => {
@@ -628,16 +635,38 @@ export function TimelineView({
     setMuted(v.muted);
   };
 
-  const restart = () => seek(0);
+  const restart = () => seek(0, { autoplay: true });
 
+  // Fullscreen targets the whole player box (video + pose-overlay
+  // canvas + control row), not the bare <video>. Fullscreening only
+  // the video element drops the overlay canvas — it's an absolute
+  // *sibling*, not a child — so the skeleton/plumb/slot lines the
+  // coach was studying silently vanish in fullscreen.
+  const playerBoxRef = useRef<HTMLDivElement>(null);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+  useEffect(() => {
+    const onChange = () =>
+      setIsFullscreen(document.fullscreenElement === playerBoxRef.current);
+    document.addEventListener("fullscreenchange", onChange);
+    return () => document.removeEventListener("fullscreenchange", onChange);
+  }, []);
   const toggleFullscreen = () => {
-    const v = videoRef.current;
-    if (!v) return;
-    if (document.fullscreenElement === v) {
+    if (document.fullscreenElement) {
       document.exitFullscreen().catch(() => {});
-    } else {
-      v.requestFullscreen?.().catch(() => {});
+      return;
     }
+    const box = playerBoxRef.current;
+    if (box?.requestFullscreen) {
+      box.requestFullscreen().catch(() => {});
+      return;
+    }
+    // iPhone Safari has no element fullscreen — fall back to the
+    // video's native fullscreen (overlay won't show there, but a
+    // fullscreen video beats a dead button).
+    const v = videoRef.current as
+      | (HTMLVideoElement & { webkitEnterFullscreen?: () => void })
+      | null;
+    v?.webkitEnterFullscreen?.();
   };
 
   return (
@@ -647,15 +676,28 @@ export function TimelineView({
         // have two scrubbers that don't align), custom control row,
         // then the pattern timeline as the only scrubber. max-h caps
         // the video so portrait clips don't dominate the viewport.
-        <div className="rounded-md bg-black overflow-hidden">
-          <div className="relative">
+        <div
+          ref={playerBoxRef}
+          className={cn(
+            "rounded-md bg-black overflow-hidden",
+            // In fullscreen the box is the viewport: stack video area
+            // over the control row and let the video take the rest.
+            isFullscreen && "flex flex-col"
+          )}
+        >
+          <div className={cn("relative", isFullscreen && "flex-1 min-h-0")}>
             <video
               ref={videoRef}
               src={videoSrc}
               preload="metadata"
               playsInline
               onClick={togglePlay}
-              className="w-full max-h-[60vh] sm:max-h-[520px] object-contain cursor-pointer"
+              className={cn(
+                "w-full object-contain cursor-pointer",
+                isFullscreen
+                  ? "h-full max-h-none"
+                  : "max-h-[60vh] sm:max-h-[520px]"
+              )}
             />
             {/* Pose-skeleton overlay (#168-pivot PR 3). Rendered as
                 an absolute sibling of the video so the canvas
@@ -837,8 +879,8 @@ export function TimelineView({
                 type="button"
                 onClick={toggleFullscreen}
                 className="text-white/70 hover:text-white p-1 rounded transition-colors"
-                aria-label="Fullscreen"
-                title="Fullscreen"
+                aria-label={isFullscreen ? "Exit fullscreen" : "Fullscreen"}
+                title={isFullscreen ? "Exit fullscreen" : "Fullscreen"}
               >
                 <Maximize className="h-4 w-4" />
               </button>
@@ -868,7 +910,7 @@ export function TimelineView({
         <MusicalityStrip
           moments={result.musical_moments ?? []}
           effectiveDuration={effectiveDuration}
-          onSeek={seek}
+          onSeek={(t) => seek(t, { autoplay: true })}
         />
       )}
 
@@ -885,7 +927,7 @@ export function TimelineView({
         effectiveDuration={effectiveDuration}
         currentTime={currentTime}
         playbackRate={playbackRate}
-        onSeek={seek}
+        onSeek={(t) => seek(t, { autoplay: true })}
       />
 
       {/* Pattern timeline = the scrubber (single source of truth) */}
@@ -1059,7 +1101,7 @@ export function TimelineView({
                   // should seek to that pattern's start, not the
                   // block's click x-position.
                   e.stopPropagation();
-                  seek(start);
+                  seek(start, { autoplay: true });
                   setSelected(p);
                 }}
                 onMouseEnter={() => setHovered(p)}
@@ -1102,7 +1144,7 @@ export function TimelineView({
                 title={`${author}${pin.reviewer_role ? ` (${pin.reviewer_role})` : ""} @ ${formatTime(pin.timestamp_sec)}: ${pin.note}`}
                 onClick={(e) => {
                   e.stopPropagation();
-                  seek(pin.timestamp_sec);
+                  seek(pin.timestamp_sec, { autoplay: true });
                 }}
                 aria-label={`Jump to reviewer comment at ${formatTime(pin.timestamp_sec)}`}
               />

--- a/src/hooks/use-video-beat-click.ts
+++ b/src/hooks/use-video-beat-click.ts
@@ -58,6 +58,10 @@ export function useVideoBeatClick({
   // cycle so a single beat doesn't get queued twice when the lookahead
   // window slides over it on consecutive ticks.
   const scheduledIdxRef = useRef<Set<number>>(new Set());
+  // Oscillators queued but not yet finished. Kept so pause / rate
+  // changes can cancel in-flight clicks — without this, up to a full
+  // lookahead window of clicks keeps ticking after the video freezes.
+  const scheduledNodesRef = useRef<Set<OscillatorNode>>(new Set());
   const audioCtxRef = useRef<AudioContext | null>(null);
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const downbeatSetRef = useRef<Set<number>>(new Set());
@@ -81,6 +85,20 @@ export function useVideoBeatClick({
     downbeatSetRef.current = new Set(downbeats ?? []);
   }, [downbeats]);
 
+  // Silence any clicks already queued into the audio graph. Used on
+  // pause/teardown (so clicks stop with the video) and on playback-
+  // rate changes (queued clicks carry the old rate's spacing).
+  const cancelQueuedClicks = useCallback(() => {
+    for (const osc of scheduledNodesRef.current) {
+      try {
+        osc.stop();
+      } catch {
+        // already stopped — fine
+      }
+    }
+    scheduledNodesRef.current.clear();
+  }, []);
+
   // Stop scheduler + reset state. Idempotent so we can call it from
   // any of the effects that might tear things down.
   const teardown = useCallback(() => {
@@ -89,7 +107,8 @@ export function useVideoBeatClick({
       timerRef.current = null;
     }
     scheduledIdxRef.current = new Set();
-  }, []);
+    cancelQueuedClicks();
+  }, [cancelQueuedClicks]);
 
   // Schedule a single click at a precise AudioContext time. Square
   // wave on a fast envelope reads as a clean "tick" without the
@@ -107,6 +126,11 @@ export function useVideoBeatClick({
       gainNode.gain.exponentialRampToValueAtTime(0.001, atTime + CLICK_DURATION);
       osc.start(atTime);
       osc.stop(atTime + CLICK_DURATION);
+      scheduledNodesRef.current.add(osc);
+      osc.onended = () => {
+        scheduledNodesRef.current.delete(osc);
+        gainNode.disconnect();
+      };
     },
     []
   );
@@ -127,7 +151,18 @@ export function useVideoBeatClick({
     //   audioNow + (T - videoNow) / rate
     // Anything ≤ audioNow has already been missed; skip it.
     const audioNow = ctx.currentTime;
-    const lookaheadVideoEnd = videoNow + SCHEDULER_LOOKAHEAD_SEC * rate;
+    // ctx.currentTime is the render-graph clock; sound physically
+    // leaves the device outputLatency later (tens of ms on speakers,
+    // 150-300ms on Bluetooth). Schedule early by that much so the
+    // audible click lands on the on-screen beat instead of trailing
+    // it. Safari has no outputLatency — baseLatency is the best
+    // available stand-in there.
+    const latency = ctx.outputLatency || ctx.baseLatency || 0;
+    // Widen the video-side window by the same amount, otherwise the
+    // latency shift would push every beat near the front of the
+    // window into the past and the defense below would drop it.
+    const lookaheadVideoEnd =
+      videoNow + (SCHEDULER_LOOKAHEAD_SEC + latency) * rate;
 
     // Binary search for the first beat >= videoNow. Beats are sorted.
     let lo = 0;
@@ -142,7 +177,7 @@ export function useVideoBeatClick({
       const beatTime = beats[i];
       if (beatTime > lookaheadVideoEnd) break;
       if (scheduledIdxRef.current.has(i)) continue;
-      const audioTime = audioNow + (beatTime - videoNow) / rate;
+      const audioTime = audioNow + (beatTime - videoNow) / rate - latency;
       // Past-time defense: occasionally a tick wakes late and the beat
       // has slid into the past. Drop it rather than fire instantly.
       if (audioTime < audioNow) {
@@ -205,17 +240,28 @@ export function useVideoBeatClick({
   // Seeking inside a play cycle resets the schedule set — we may
   // have jumped past beats that are still in scheduledIdxRef, and
   // we may have jumped backward to beats we'd marked as done.
+  // A rate change additionally cancels the queued clicks: they were
+  // scheduled with the old rate's spacing, so letting them play out
+  // produces a burst of mistimed ticks against the new tempo. The
+  // next scheduler tick re-queues everything at the new rate.
   useEffect(() => {
     const video = videoRef.current;
     if (!video) return;
     const onSeeked = () => {
       scheduledIdxRef.current = new Set();
+      cancelQueuedClicks();
+    };
+    const onRateChange = () => {
+      scheduledIdxRef.current = new Set();
+      cancelQueuedClicks();
     };
     video.addEventListener("seeked", onSeeked);
+    video.addEventListener("ratechange", onRateChange);
     return () => {
       video.removeEventListener("seeked", onSeeked);
+      video.removeEventListener("ratechange", onRateChange);
     };
-  }, [videoRef]);
+  }, [videoRef, cancelQueuedClicks]);
 
   // Cleanup on unmount: close the AudioContext so we don't leak
   // audio devices when the user navigates away.


### PR DESCRIPTION
Fixes four correctness bugs in the coach-mode player found during a systematic accuracy audit.

## Frame-step resumed playback
`seek()` was written for pattern-block clicks (where auto-play is wanted) and reused everywhere. Because the frame-step keys only ran while paused, every `,`/`.` press stepped one frame and then immediately called `v.play()` — the exact frame the user wanted to inspect flew past. `seek()` now takes an `autoplay` opt (default off):

- **No autoplay**: frame-step, J/L skip, arrow-key scrub on the slider
- **Autoplay kept** (same behavior as before): pattern block click, reviewer pin, musicality moment, beat-panel scrub, bar click, restart, `?t=` deep link

Frame-step during playback now pauses first (NLE convention) instead of silently no-op'ing.

## Beat click: phantom + mistimed clicks
- Queued oscillators (up to a 250ms lookahead window) are now tracked and cancelled on pause/seek/teardown. Previously they kept ticking after the video froze.
- A `ratechange` listener cancels queued clicks and lets the scheduler re-queue at the new rate — changing speed mid-play used to fire a burst of clicks at the old rate's spacing.
- Clicks are scheduled early by `outputLatency` (`baseLatency` fallback on Safari), so the audible tick lands on the on-screen beat instead of trailing it — most noticeable on Bluetooth audio (150-300ms late before this).

## Fullscreen dropped the pose overlay
Fullscreen targeted the bare `<video>`, but the overlay canvas is an absolute *sibling* — so the skeleton/plumb/slot lines vanished in fullscreen. Fullscreen now targets the player box (video + overlay + control row), with a native-video fallback for iPhone Safari which lacks element fullscreen.

## Testing
- `npx tsc --noEmit` clean, `next build` passes
- `eslint` on both touched files: 0 new issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Seeking from timeline markers, patterns, reviewer pins, and deep links now starts playback automatically.
  * Fullscreen mode now includes the video, overlays, and controls.
  * Restarting playback automatically resumes the video.

* **Bug Fixes**
  * Frame-by-frame keyboard stepping now pauses first for smoother results.
  * Beat clicks are better synchronized with video timing and stop cleanly when playback is paused or changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->