### PR TITLE
Fix pose overlay accuracy: frame-accurate detection, stable identity, smoothing

### DIFF
--- a/src/components/analyze/pose-overlay.tsx
+++ b/src/components/analyze/pose-overlay.tsx
@@ -82,22 +82,57 @@ const VIS_FLOOR = 0.3;
 // ~3s) but short enough that a slot change between songs / between
 // pattern-blocks gets picked up rather than averaged away.
 const SLOT_BUFFER_MAX = 240;
+// A per-frame jump of either foot-midpoint bigger than this (in
+// normalized coords) is a camera cut or hard pan, not dancing —
+// flush the slot buffer instead of PCA-fitting two different
+// framings together into a meaningless axis.
+const SLOT_JUMP_FLUSH = 0.15;
+// Only draw the PCA slot when the point cloud is meaningfully
+// elongated (std-dev along the axis ≥ 2.5× the lateral std-dev). A
+// couple rotating in place produces a near-isotropic blob whose
+// principal axis is noise; drawing that as "the slot" is misleading.
+const SLOT_MIN_ELONGATION = 2.5;
+// ...and when there's real travel at all — a stationary cluster has
+// a meaningless axis no matter how elongated the jitter is. 0.02 of
+// the frame in std-dev terms ≈ the couple actually moved.
+const SLOT_MIN_SPREAD_SQ = 0.0004;
+// Landmark smoothing: speed-adaptive EMA. The lite model's raw
+// output jitters a couple of pixels even on a still body, and the
+// plumb/loaded-foot metrics amplify that into strobing. Slow motion
+// gets heavy smoothing; fast motion ramps alpha toward 1 so real
+// moves aren't smeared.
+const SMOOTH_ALPHA_MIN = 0.3;
+const SMOOTH_ALPHA_SPEED = 40;
+// Frames a new weight-side call must persist before the displayed
+// loaded-foot ring flips. ~100ms at 30fps — invisible as latency,
+// but stops the ring strobing at the anchor where the weight ratio
+// hovers right at the threshold.
+const WEIGHT_DEBOUNCE_FRAMES = 3;
+// Minimum ankle x-span, as a fraction of the vertical hip-to-ankle
+// drop, before we call a weight side at all. Feet-together collapses
+// the span toward zero and the hip-vs-ankle ratio then explodes on
+// sub-pixel jitter — exactly at the anchor, where coaches look.
+const MIN_STANCE_RATIO = 0.12;
 
 type Landmark = { x: number; y: number; z?: number; visibility?: number };
 
 type PoseMetrics = {
-  // The vertical line a stacked body should fall on, in normalized
-  // x-coordinates [0, 1]. Set to the supporting ankle when one foot
-  // bears the weight, midpoint of both ankles otherwise.
-  plumbX: number;
+  // Instantaneous weight-side call for THIS frame, already gated on
+  // a minimum stance width. Refers to the labeled ankle landmark
+  // (LM_ANKLE_L / LM_ANKLE_R), which stays correct when the clip is
+  // filmed from behind. The component debounces this across frames
+  // before showing it so a single-frame flicker never hits the
+  // screen.
+  rawWeightSide: "left" | "right" | null;
+  // Ankle x-positions so the caller can anchor the plumb line to
+  // the (debounced) loaded ankle, or their midpoint when no side is
+  // confidently loaded.
+  ankleLX: number;
+  ankleRX: number;
   // y of the top of the body (head) and the floor (ankle) so the
   // plumb line is drawn through the body and a touch beyond.
   topY: number;
   bottomY: number;
-  // Which side is currently bearing weight, or null when even / can't
-  // tell. Used to highlight the loaded ankle so a coach scrubbing
-  // through an anchor can see weight settle at a glance.
-  weightSide: "left" | "right" | null;
 };
 
 // Colors for the partnership-level overlays. Distinct from POSE_COLORS
@@ -106,43 +141,194 @@ type PoseMetrics = {
 const CONNECTION_COLOR = "#fbbf24"; // amber — warm, contrasts with cyan/magenta
 const SLOT_COLOR = "#f5f5f4"; // stone — neutral, low-saturation
 
-/** Find the closest wrist pair across the two dancers' poses and
- *  return it when they're plausibly in physical contact. Threshold
- *  is scale-aware (a fraction of shoulder spread) so close-up shots
- *  and wide-shots both work without a manual zoom-knob. */
-function findConnection(
+function isVisible(p: Landmark | undefined): p is Landmark {
+  return !!p && (p.visibility ?? 1) >= VIS_FLOOR;
+}
+
+/** Find wrist pairs across the two dancers' poses that are plausibly
+ *  in physical contact — up to two, so a closed / two-hand hold
+ *  renders as two connection lines instead of misleadingly one.
+ *  Threshold is scale-aware (a fraction of shoulder spread) so
+ *  close-up and wide shots both work without a zoom knob. Scale uses
+ *  the WIDER of the two dancers' spreads: a rotated (foreshortened)
+ *  dancer's spread collapses, and using one dancer alone shrinks the
+ *  threshold until real connections get dropped mid-turn.
+ *  `stickyFactor` > 1 widens the threshold while a connection is
+ *  already showing (hysteresis), so the line doesn't flicker right
+ *  at the boundary during extension. */
+function findConnections(
   a: Landmark[],
-  b: Landmark[]
-): { ax: number; ay: number; bx: number; by: number } | null {
-  const aWrists = [a[LM_WRIST_L], a[LM_WRIST_R]];
-  const bWrists = [b[LM_WRIST_L], b[LM_WRIST_R]];
-  const aSL = a[LM_SHOULDER_L];
-  const aSR = a[LM_SHOULDER_R];
-  if (!aSL || !aSR) return null;
-  // Scale: half the lead-dancer's shoulder width. Hands within this
-  // distance of each other are almost always in connection in WCS —
-  // the dance keeps a one-foot hand connection at minimum, not
-  // arm's-length separation.
-  const shoulderSpread = Math.hypot(aSL.x - aSR.x, aSL.y - aSR.y);
-  const threshold = shoulderSpread * 0.7;
-  let best: {
+  b: Landmark[],
+  stickyFactor: number
+): Array<{ ax: number; ay: number; bx: number; by: number }> {
+  const spread = (p: Landmark[]): number => {
+    const sL = p[LM_SHOULDER_L];
+    const sR = p[LM_SHOULDER_R];
+    if (!isVisible(sL) || !isVisible(sR)) return 0;
+    return Math.hypot(sL.x - sR.x, sL.y - sR.y);
+  };
+  const scale = Math.max(spread(a), spread(b));
+  if (scale <= 0) return [];
+  const threshold = scale * 0.7 * stickyFactor;
+  type Pair = {
     ax: number;
     ay: number;
     bx: number;
     by: number;
     d: number;
-  } | null = null;
-  for (const aw of aWrists) {
-    if (!aw || (aw.visibility ?? 1) < VIS_FLOOR) continue;
-    for (const bw of bWrists) {
-      if (!bw || (bw.visibility ?? 1) < VIS_FLOOR) continue;
+    ai: number;
+    bi: number;
+  };
+  const pairs: Pair[] = [];
+  const aWrists = [a[LM_WRIST_L], a[LM_WRIST_R]];
+  const bWrists = [b[LM_WRIST_L], b[LM_WRIST_R]];
+  aWrists.forEach((aw, ai) => {
+    if (!isVisible(aw)) return;
+    bWrists.forEach((bw, bi) => {
+      if (!isVisible(bw)) return;
       const d = Math.hypot(aw.x - bw.x, aw.y - bw.y);
-      if (d > threshold) continue;
-      if (best && d >= best.d) continue;
-      best = { ax: aw.x, ay: aw.y, bx: bw.x, by: bw.y, d };
+      if (d <= threshold) {
+        pairs.push({ ax: aw.x, ay: aw.y, bx: bw.x, by: bw.y, d, ai, bi });
+      }
+    });
+  });
+  // Greedy matching: closest pair first, then the best pair from the
+  // remaining unused wrists. Each wrist connects at most once.
+  pairs.sort((p, q) => p.d - q.d);
+  const out: Pair[] = [];
+  for (const p of pairs) {
+    if (out.some((o) => o.ai === p.ai || o.bi === p.bi)) continue;
+    out.push(p);
+    if (out.length === 2) break;
+  }
+  return out;
+}
+
+/** Centroid of a pose's confidently-visible landmarks — the anchor
+ *  for frame-to-frame identity matching. Falls back to all landmarks
+ *  when visibility is uniformly poor. */
+function centroidOf(person: Landmark[]): { x: number; y: number } {
+  let sx = 0;
+  let sy = 0;
+  let n = 0;
+  for (const p of person) {
+    if (!isVisible(p)) continue;
+    sx += p.x;
+    sy += p.y;
+    n++;
+  }
+  if (n === 0) {
+    for (const p of person) {
+      sx += p.x;
+      sy += p.y;
+      n++;
     }
   }
-  return best;
+  return n > 0 ? { x: sx / n, y: sy / n } : { x: 0.5, y: 0.5 };
+}
+
+/** Match this frame's poses to persistent display slots so each
+ *  dancer keeps a stable color/identity across frames. MediaPipe's
+ *  result order is NOT stable with numPoses: 2 — the two poses can
+ *  swap array index frame-to-frame (visibly: cyan and magenta
+ *  flickering between the dancers during a whip). We assign by
+ *  minimum total centroid travel vs the previous frame and mutate
+ *  `slots` in place with the new centroids. */
+function assignToSlots(
+  poses: Landmark[][],
+  slots: Array<{ x: number; y: number } | null>
+): Array<Landmark[] | null> {
+  const out: Array<Landmark[] | null> = [null, null];
+  if (poses.length === 0) return out;
+  const cents = poses.slice(0, 2).map(centroidOf);
+  if (poses.length === 1) {
+    // Solo frame: keep the dancer in whichever slot they're nearest
+    // to (their partner may be briefly occluded), defaulting to
+    // slot 0 when we've never seen anyone.
+    const d = (s: { x: number; y: number } | null) =>
+      s
+        ? Math.hypot(cents[0].x - s.x, cents[0].y - s.y)
+        : Number.POSITIVE_INFINITY;
+    const idx = slots[0] == null && slots[1] == null
+      ? 0
+      : d(slots[1]) < d(slots[0])
+      ? 1
+      : 0;
+    out[idx] = poses[0];
+    slots[idx] = cents[0];
+    return out;
+  }
+  // Two poses: straight vs swapped assignment, whichever moves the
+  // centroids less. An empty slot costs 0 so first-frame assignment
+  // keeps the model's order.
+  const cost = (i: number, s: number) => {
+    const slot = slots[s];
+    return slot ? Math.hypot(cents[i].x - slot.x, cents[i].y - slot.y) : 0;
+  };
+  const straight = cost(0, 0) + cost(1, 1);
+  const swapped = cost(0, 1) + cost(1, 0);
+  const slotForPose = swapped < straight ? [1, 0] : [0, 1];
+  out[slotForPose[0]] = poses[0];
+  out[slotForPose[1]] = poses[1];
+  slots[slotForPose[0]] = cents[0];
+  slots[slotForPose[1]] = cents[1];
+  return out;
+}
+
+/** Speed-adaptive EMA over the 33 landmarks. Small frame-to-frame
+ *  deltas (jitter) get smoothed hard; large deltas (a real move)
+ *  ramp alpha toward 1 so the skeleton tracks the dance instead of
+ *  smearing behind it. */
+function smoothLandmarks(
+  prev: Landmark[] | null,
+  next: Landmark[]
+): Landmark[] {
+  if (!prev || prev.length !== next.length) {
+    return next.map((p) => ({ ...p }));
+  }
+  return next.map((p, i) => {
+    const q = prev[i];
+    const dist = Math.hypot(p.x - q.x, p.y - q.y);
+    const alpha = Math.min(1, SMOOTH_ALPHA_MIN + dist * SMOOTH_ALPHA_SPEED);
+    return {
+      x: q.x + (p.x - q.x) * alpha,
+      y: q.y + (p.y - q.y) * alpha,
+      z: p.z,
+      visibility: p.visibility,
+    };
+  });
+}
+
+type WeightState = {
+  side: "left" | "right" | null;
+  candidate: "left" | "right" | null;
+  count: number;
+};
+
+/** Debounce the instantaneous weight-side call: a new side must
+ *  persist WEIGHT_DEBOUNCE_FRAMES consecutive frames before the
+ *  display flips. Mutates `state`, returns the side to display. */
+function debounceWeightSide(
+  state: WeightState,
+  raw: "left" | "right" | null
+): "left" | "right" | null {
+  if (raw === state.side) {
+    state.candidate = null;
+    state.count = 0;
+    return state.side;
+  }
+  if (raw === state.candidate) {
+    state.count += 1;
+    if (state.count >= WEIGHT_DEBOUNCE_FRAMES) {
+      state.side = raw;
+      state.candidate = null;
+      state.count = 0;
+    }
+  } else {
+    state.candidate = raw;
+    state.count = 1;
+  }
+  return state.side;
 }
 
 /** Foot-midpoints for both dancers in the current frame. Returns
@@ -210,6 +396,15 @@ function fitLinePCA(points: Array<{ x: number; y: number }>): {
   if (trace < 1e-6) return null;
   const diff = Math.sqrt(Math.max(0, (sxx - syy) ** 2 + 4 * sxy * sxy));
   const lambdaMax = (trace + diff) / 2;
+  const lambdaMin = Math.max(0, trace - lambdaMax);
+  // Confidence gates (both in variance terms, hence the squares):
+  // the cloud must show real travel along the axis, and be clearly
+  // elongated rather than an isotropic blob — otherwise the "axis"
+  // is just the noise direction and we'd rather draw nothing.
+  if (lambdaMax / points.length < SLOT_MIN_SPREAD_SQ) return null;
+  if (lambdaMax < SLOT_MIN_ELONGATION * SLOT_MIN_ELONGATION * lambdaMin) {
+    return null;
+  }
   // Eigenvector for the largest eigenvalue. Pick the more numerically
   // stable form depending on which diagonal element is larger.
   let vx: number;
@@ -254,38 +449,37 @@ function computeMetrics(person: Landmark[]): PoseMetrics | null {
   }
 
   const hipMidX = (hL.x + hR.x) / 2;
+  const hipMidY = (hL.y + hR.y) / 2;
   // Weight ratio: 0 = full left, 1 = full right. We project the hip
   // midpoint horizontally and ask how far across the stance it sits.
-  // Anything outside [0, 1] means the dancer is leaning past the
-  // base of support, which is itself a useful signal — clamp + flag.
-  const ankleSpread = aR.x - aL.x;
-  // ankleSpread can be negative when the dancer's body is mirrored
-  // (filmed from behind) or the model swapped L/R. Take abs + remember
-  // which ankle is "near" for the weight call.
-  const span = Math.abs(ankleSpread) || 0.0001;
-  const leftX = Math.min(aL.x, aR.x);
-  const weightRatio = (hipMidX - leftX) / span;
-  // 35/65 is a deliberately wide deadband. WCS anchors hover near
-  // 50/50 with one foot just slightly more loaded; calling weight
-  // sides too eagerly turns the indicator into strobe.
-  let weightSide: "left" | "right" | null = null;
-  if (weightRatio < 0.35) {
-    weightSide = aL.x < aR.x ? "left" : "right";
-  } else if (weightRatio > 0.65) {
-    weightSide = aL.x < aR.x ? "right" : "left";
+  // The x-span can run either direction when the dancer is filmed
+  // from behind (mirrored), so work off abs + the leftmost ankle.
+  const span = Math.abs(aR.x - aL.x);
+  // Stance-width gate: dividing by a near-zero span (feet together,
+  // as at the anchor) turns sub-pixel hip jitter into full-scale
+  // ratio swings. Scale the floor to the dancer's vertical
+  // hip-to-ankle drop — robust to camera distance since dancers are
+  // upright — with a small absolute floor for degenerate poses.
+  const legDrop = Math.abs((aL.y + aR.y) / 2 - hipMidY);
+  let rawWeightSide: "left" | "right" | null = null;
+  if (span > Math.max(0.015, legDrop * MIN_STANCE_RATIO)) {
+    const leftX = Math.min(aL.x, aR.x);
+    const weightRatio = (hipMidX - leftX) / span;
+    // 35/65 is a deliberately wide deadband. WCS anchors hover near
+    // 50/50 with one foot just slightly more loaded; calling weight
+    // sides too eagerly turns the indicator into strobe.
+    if (weightRatio < 0.35) {
+      rawWeightSide = aL.x < aR.x ? "left" : "right";
+    } else if (weightRatio > 0.65) {
+      rawWeightSide = aL.x < aR.x ? "right" : "left";
+    }
   }
 
-  const plumbX =
-    weightSide === "left"
-      ? aL.x
-      : weightSide === "right"
-      ? aR.x
-      : (aL.x + aR.x) / 2;
   // Extend the plumb a hair above the head + below the lower of the
   // two ankles so the line clearly "passes through" the body.
   const topY = Math.max(0, head.y - 0.04);
   const bottomY = Math.min(1, Math.max(aL.y, aR.y) + 0.04);
-  return { plumbX, topY, bottomY, weightSide };
+  return { rawWeightSide, ankleLX: aL.x, ankleRX: aR.x, topY, bottomY };
 }
 
 export type PoseOverlayHandle = {
@@ -326,6 +520,32 @@ export const PoseOverlay = forwardRef<PoseOverlayHandle, PoseOverlayProps>(
     // PCA stays O(N) per draw and the line tracks recent movement
     // instead of being anchored to the start of the dance.
     const slotSamplesRef = useRef<Array<{ x: number; y: number }>>([]);
+    // Identity tracking + temporal state, indexed by display slot
+    // (slot = color). See assignToSlots for why the raw result
+    // order can't be trusted.
+    const slotCentroidsRef = useRef<Array<{ x: number; y: number } | null>>([
+      null,
+      null,
+    ]);
+    const smoothedRef = useRef<Array<Landmark[] | null>>([null, null]);
+    const weightStateRef = useRef<WeightState[]>([
+      { side: null, candidate: null, count: 0 },
+      { side: null, candidate: null, count: 0 },
+    ]);
+    // EMA'd plumb-line x per slot so the line glides between anchor
+    // points instead of snapping a foot-width sideways the moment
+    // the debounced weight side flips.
+    const plumbXRef = useRef<Array<number | null>>([null, null]);
+    // Previous frame's foot midpoints — camera-cut detector for the
+    // slot buffer.
+    const prevMidsRef = useRef<{
+      ax: number;
+      ay: number;
+      bx: number;
+      by: number;
+    } | null>(null);
+    // Whether a connection line rendered last frame (hysteresis).
+    const connectedRef = useRef(false);
 
     const setEnabled = (next: boolean) => {
       setEnabledState(next);
@@ -416,8 +636,26 @@ export const PoseOverlay = forwardRef<PoseOverlayHandle, PoseOverlayProps>(
         const w = canvas.width;
         const h = canvas.height;
         ctx.clearRect(0, 0, w, h);
-        result.landmarks.forEach((person, personIdx) => {
-          const color = POSE_COLORS[personIdx % POSE_COLORS.length];
+        // Stable identity: match this frame's poses to display slots
+        // by centroid proximity, then smooth each slot's landmarks.
+        // Everything below draws from `people` (indexed by slot).
+        const ordered = assignToSlots(
+          result.landmarks,
+          slotCentroidsRef.current
+        );
+        const people: Array<Landmark[] | null> = [null, null];
+        ordered.forEach((rawPerson, slotIdx) => {
+          if (!rawPerson) return;
+          const person = smoothLandmarks(
+            smoothedRef.current[slotIdx],
+            rawPerson
+          );
+          smoothedRef.current[slotIdx] = person;
+          people[slotIdx] = person;
+        });
+        people.forEach((person, slotIdx) => {
+          if (!person) return;
+          const color = POSE_COLORS[slotIdx % POSE_COLORS.length];
           // Edges first so the joint dots draw on top and read as
           // clean punctuation rather than getting overdrawn.
           ctx.strokeStyle = color;
@@ -457,6 +695,27 @@ export const PoseOverlay = forwardRef<PoseOverlayHandle, PoseOverlayProps>(
           // supporting foot" and "which foot has the weight".
           const metrics = computeMetrics(person);
           if (metrics) {
+            // Debounce the side call across frames, then glide the
+            // plumb anchor toward its target instead of snapping —
+            // the line is a stacking *reference*, and a reference
+            // that jumps a foot-width sideways reads as body motion.
+            const side = debounceWeightSide(
+              weightStateRef.current[slotIdx],
+              metrics.rawWeightSide
+            );
+            const targetPlumbX =
+              side === "left"
+                ? metrics.ankleLX
+                : side === "right"
+                ? metrics.ankleRX
+                : (metrics.ankleLX + metrics.ankleRX) / 2;
+            const prevPlumb = plumbXRef.current[slotIdx];
+            const plumbX =
+              prevPlumb == null
+                ? targetPlumbX
+                : prevPlumb + (targetPlumbX - prevPlumb) * 0.35;
+            plumbXRef.current[slotIdx] = plumbX;
+
             // Plumb line — translucent, dashed, person's color. A
             // well-stacked dancer has head, shoulders, and hips all
             // intersecting this line; deviation reads visually
@@ -467,26 +726,19 @@ export const PoseOverlay = forwardRef<PoseOverlayHandle, PoseOverlayProps>(
             ctx.lineWidth = Math.max(1, Math.min(w, h) / 400);
             ctx.setLineDash([6, 6]);
             ctx.beginPath();
-            ctx.moveTo(metrics.plumbX * w, metrics.topY * h);
-            ctx.lineTo(metrics.plumbX * w, metrics.bottomY * h);
+            ctx.moveTo(plumbX * w, metrics.topY * h);
+            ctx.lineTo(plumbX * w, metrics.bottomY * h);
             ctx.stroke();
             ctx.restore();
 
-            // Loaded-foot highlight — only when we're confident
-            // enough to call a side. The loaded ankle is whichever
-            // one matches plumbX (computeMetrics already set plumbX
-            // to the spatially-loaded ankle, which handles cases
-            // where MediaPipe swapped L/R labels on a behind-camera
-            // shot). A filled ring + brighter inner dot reads as
-            // "this foot has weight" without adding text.
-            if (metrics.weightSide) {
-              const aL = person[LM_ANKLE_L];
-              const aR = person[LM_ANKLE_R];
+            // Loaded-foot highlight — only when the debounced side
+            // is confident. `side` names the labeled ankle landmark
+            // (computeMetrics already resolved mirroring for
+            // behind-camera shots). A filled ring + brighter inner
+            // dot reads as "this foot has weight" without text.
+            if (side) {
               const loaded =
-                Math.abs(aL.x - metrics.plumbX) <
-                Math.abs(aR.x - metrics.plumbX)
-                  ? aL
-                  : aR;
+                side === "left" ? person[LM_ANKLE_L] : person[LM_ANKLE_R];
               const ringR = Math.max(6, Math.min(w, h) / 90);
               ctx.save();
               ctx.strokeStyle = color;
@@ -501,17 +753,18 @@ export const PoseOverlay = forwardRef<PoseOverlayHandle, PoseOverlayProps>(
               ctx.fill();
               ctx.restore();
             }
+          } else {
+            plumbXRef.current[slotIdx] = null;
           }
         });
 
         // ─── Partnership-level overlays (PR 3c) ───
-        // Connection line + slot axis. Only when MediaPipe found two
-        // dancers; a solo clip just gets the skeletons + per-person
-        // metrics already drawn above.
-        if (result.landmarks.length >= 2) {
-          const a = result.landmarks[0];
-          const b = result.landmarks[1];
-
+        // Connection line + slot axis. Only when both display slots
+        // have a dancer this frame; a solo clip just gets the
+        // skeletons + per-person metrics already drawn above.
+        const pA = people[0];
+        const pB = people[1];
+        if (pA && pB) {
           // Slot axis first (under the connection line so a tight
           // overlap reads as "connection on top of slot").
           //
@@ -522,13 +775,26 @@ export const PoseOverlay = forwardRef<PoseOverlayHandle, PoseOverlayProps>(
           // slot the line follows after ~4 seconds rather than
           // averaging across both forever.
           //
-          // Fallback to the per-frame line-through-foot-midpoints
-          // for the first second or so before the buffer has enough
-          // samples to fit. PCA needs ~8 points to behave; we get
-          // 2 per frame, so the fallback covers the first ~4 frames
-          // and the fit kicks in thereafter.
-          const mids = footMidpoints(a, b);
+          // No per-frame fallback while the buffer warms up: the
+          // line through the two dancers' CURRENT foot midpoints is
+          // the inter-dancer axis, which during a whip (side by
+          // side) sits roughly perpendicular to the actual slot.
+          // Drawing nothing for a few frames beats drawing a
+          // confidently wrong axis.
+          const mids = footMidpoints(pA, pB);
           if (mids) {
+            // Camera-cut detector: if either midpoint teleported
+            // since last frame, the framing changed — flush the
+            // buffer rather than fitting two framings together.
+            const prev = prevMidsRef.current;
+            if (prev) {
+              const jump = Math.max(
+                Math.hypot(mids.ax - prev.ax, mids.ay - prev.ay),
+                Math.hypot(mids.bx - prev.bx, mids.by - prev.by)
+              );
+              if (jump > SLOT_JUMP_FLUSH) slotSamplesRef.current = [];
+            }
+            prevMidsRef.current = mids;
             const buf = slotSamplesRef.current;
             buf.push({ x: mids.ax, y: mids.ay });
             buf.push({ x: mids.bx, y: mids.by });
@@ -536,12 +802,12 @@ export const PoseOverlay = forwardRef<PoseOverlayHandle, PoseOverlayProps>(
           }
 
           const slotFit = fitLinePCA(slotSamplesRef.current);
-          ctx.save();
-          ctx.strokeStyle = SLOT_COLOR;
-          ctx.globalAlpha = 0.35;
-          ctx.lineWidth = Math.max(1, Math.min(w, h) / 350);
-          ctx.setLineDash([10, 6]);
           if (slotFit) {
+            ctx.save();
+            ctx.strokeStyle = SLOT_COLOR;
+            ctx.globalAlpha = 0.35;
+            ctx.lineWidth = Math.max(1, Math.min(w, h) / 350);
+            ctx.setLineDash([10, 6]);
             // PCA gives a centerpoint + unit direction. To draw the
             // axis we just extend it generously in both directions —
             // half the frame's diagonal in each direction always
@@ -557,25 +823,22 @@ export const PoseOverlay = forwardRef<PoseOverlayHandle, PoseOverlayProps>(
             ctx.moveTo(x0 * w, y0 * h);
             ctx.lineTo(x1 * w, y1 * h);
             ctx.stroke();
-          } else if (mids) {
-            // Per-frame fallback — used during the brief warm-up
-            // window before the PCA buffer has enough samples.
-            const dx = mids.bx - mids.ax;
-            const dy = mids.by - mids.ay;
-            ctx.beginPath();
-            ctx.moveTo((mids.ax - dx * 0.25) * w, (mids.ay - dy * 0.25) * h);
-            ctx.lineTo((mids.bx + dx * 0.25) * w, (mids.by + dy * 0.25) * h);
-            ctx.stroke();
+            ctx.restore();
           }
-          ctx.restore();
 
-          // Connection line — drawn solid because connection IS the
+          // Connection lines — drawn solid because connection IS the
           // signal (the slot is geometry; the connection is the
-          // dance). Endpoints get small terminal dots so a brief
-          // single-frame detection reads as a real connection
-          // rather than a stroke artifact.
-          const conn = findConnection(a, b);
-          if (conn) {
+          // dance). Up to two lines so closed / two-hand holds read
+          // as what they are. Hysteresis: once connected, the
+          // distance threshold widens 40% so the line doesn't
+          // flicker right at the boundary during extension.
+          const conns = findConnections(
+            pA,
+            pB,
+            connectedRef.current ? 1.4 : 1
+          );
+          connectedRef.current = conns.length > 0;
+          for (const conn of conns) {
             ctx.save();
             ctx.strokeStyle = CONNECTION_COLOR;
             ctx.lineWidth = Math.max(2, Math.min(w, h) / 200);
@@ -594,12 +857,30 @@ export const PoseOverlay = forwardRef<PoseOverlayHandle, PoseOverlayProps>(
             ctx.fill();
             ctx.restore();
           }
+        } else {
+          connectedRef.current = false;
+          prevMidsRef.current = null;
         }
       };
 
-      const tick = () => {
+      // All temporal state (smoothed pose, weight debounce, plumb
+      // EMA, camera-cut tracker) belongs to a contiguous stretch of
+      // the dance — a seek invalidates it wholesale.
+      const resetTransient = () => {
+        slotCentroidsRef.current = [null, null];
+        smoothedRef.current = [null, null];
+        weightStateRef.current = [
+          { side: null, candidate: null, count: 0 },
+          { side: null, candidate: null, count: 0 },
+        ];
+        plumbXRef.current = [null, null];
+        prevMidsRef.current = null;
+        connectedRef.current = false;
+      };
+
+      const processFrame = (mediaTime: number) => {
         const landmarker = landmarkerRef.current;
-        if (!landmarker) return;
+        if (!landmarker || video.readyState < 2) return;
         // Match canvas pixel dims to the video's intrinsic dims so
         // landmarks (which are normalized to source frame) map to
         // sharp pixels rather than being upscaled by CSS.
@@ -611,35 +892,79 @@ export const PoseOverlay = forwardRef<PoseOverlayHandle, PoseOverlayProps>(
           canvas.width = video.videoWidth;
           canvas.height = video.videoHeight;
         }
-        if (
-          video.readyState >= 2 &&
-          video.currentTime !== lastVideoTimeRef.current
-        ) {
-          lastVideoTimeRef.current = video.currentTime;
-          const ts = performance.now();
-          try {
-            const result = landmarker.detectForVideo(video, ts);
-            draw(result);
-          } catch (err) {
-            // Detection can throw briefly during a src change; one
-            // logged warning is enough, suppress the rest of the
-            // animation frame.
-            console.warn("pose-overlay: detect frame failed", err);
-          }
+        if (mediaTime === lastVideoTimeRef.current) return;
+        if (Math.abs(mediaTime - lastVideoTimeRef.current) > 0.4) {
+          resetTransient();
         }
-        rafRef.current = requestAnimationFrame(tick);
+        lastVideoTimeRef.current = mediaTime;
+        // MediaPipe VIDEO mode requires monotonically increasing
+        // timestamps — performance.now(), not mediaTime, which runs
+        // backwards on a rewind.
+        const ts = performance.now();
+        try {
+          const result = landmarker.detectForVideo(video, ts);
+          draw(result);
+        } catch (err) {
+          // Detection can throw briefly during a src change; one
+          // logged warning is enough, suppress the rest of the
+          // animation frame.
+          console.warn("pose-overlay: detect frame failed", err);
+        }
       };
-      rafRef.current = requestAnimationFrame(tick);
+
+      // Drive detection off requestVideoFrameCallback where the
+      // browser supports it: it fires when a new frame is actually
+      // *presented* — including the repaint after a paused seek — so
+      // the skeleton always belongs to the pixels on screen. The
+      // old rAF gate compared video.currentTime, which updates
+      // synchronously on seek while the new frame decodes async, so
+      // detection ran on the PRE-seek pixels and then marked the
+      // frame as done: every scrub left a stale skeleton.
+      type VideoWithRVFC = HTMLVideoElement & {
+        requestVideoFrameCallback?: (
+          cb: (now: number, meta: { mediaTime: number }) => void
+        ) => number;
+        cancelVideoFrameCallback?: (id: number) => void;
+      };
+      const v = video as VideoWithRVFC;
+      let vfcId: number | null = null;
+      let cancelled = false;
+
+      if (typeof v.requestVideoFrameCallback === "function") {
+        const onFrame = (_now: number, meta: { mediaTime: number }) => {
+          if (cancelled) return;
+          processFrame(meta.mediaTime);
+          vfcId = v.requestVideoFrameCallback!(onFrame);
+        };
+        vfcId = v.requestVideoFrameCallback(onFrame);
+        // rVFC only fires on NEW frames — enabling the overlay on an
+        // already-paused frame would draw nothing until the next
+        // play/seek. Detect the current frame once to cover that.
+        processFrame(video.currentTime);
+      } else {
+        // rAF fallback (pre-rVFC Firefox). Skipping while
+        // video.seeking is the stale-frame fix here: currentTime
+        // moves the instant a seek starts, but the frame isn't
+        // decoded until `seeked` — detecting in between reads the
+        // old pixels.
+        const tick = () => {
+          if (cancelled) return;
+          if (!video.seeking) processFrame(video.currentTime);
+          rafRef.current = requestAnimationFrame(tick);
+        };
+        rafRef.current = requestAnimationFrame(tick);
+      }
       return () => {
+        cancelled = true;
+        if (vfcId != null) v.cancelVideoFrameCallback?.(vfcId);
         if (rafRef.current != null) {
           cancelAnimationFrame(rafRef.current);
           rafRef.current = null;
         }
       };
-      // playing dependency forces a fresh raf cycle when the user
-      // hits play/pause — strictly speaking the loop runs either way,
-      // but re-binding clears any pending frame so we don't double-
-      // schedule when React strict-mode re-runs effects.
+      // playing dependency forces a fresh cycle when the user hits
+      // play/pause — re-binding clears any pending frame so we don't
+      // double-schedule when React strict-mode re-runs effects.
     }, [enabled, status, videoRef, playing]);
 
     // Clean up the landmarker on unmount or when explicitly disabled,
@@ -653,6 +978,19 @@ export const PoseOverlay = forwardRef<PoseOverlayHandle, PoseOverlayProps>(
       }
       setStatus("off");
       slotSamplesRef.current = [];
+      slotCentroidsRef.current = [null, null];
+      smoothedRef.current = [null, null];
+      weightStateRef.current = [
+        { side: null, candidate: null, count: 0 },
+        { side: null, candidate: null, count: 0 },
+      ];
+      plumbXRef.current = [null, null];
+      prevMidsRef.current = null;
+      connectedRef.current = false;
+      // Force a fresh detect on re-enable even if the video hasn't
+      // moved — the canvas was cleared, so the last frame's dedupe
+      // marker no longer reflects what's on screen.
+      lastVideoTimeRef.current = -1;
       const canvas = canvasRef.current;
       if (canvas) {
         const ctx = canvas.getContext("2d");


### PR DESCRIPTION
Fixes the five biggest accuracy problems in the pose overlay, found during a systematic CV audit. All are display-side — no API changes.

## Stale skeleton after every scrub
The rAF loop gated detection on `video.currentTime !== last`, but `currentTime` updates synchronously on seek while the new frame decodes asynchronously — so detection ran on the **pre-seek pixels**, then marked the frame done. Click a pattern block at 0:42 and the skeleton still showed the pose from 0:20.

Now driven by `requestVideoFrameCallback`, which fires when a frame is actually *presented* (including the repaint after a paused seek). Pre-rVFC Firefox falls back to rAF with a `video.seeking` guard, which fixes the same bug there. One immediate detect on enable covers the enable-while-paused case.

## Dancer identity swap
MediaPipe's result order is not stable with `numPoses: 2` — when the dancers cross in a whip, cyan/magenta (plus each dancer's plumb line and loaded-foot ring) flickered between bodies frame-to-frame. Poses are now matched to persistent display slots by minimum centroid travel vs the previous frame.

## Jitter → strobing metrics
No temporal smoothing existed anywhere. Added a speed-adaptive EMA over the 33 landmarks: sub-pixel jitter smooths hard, real moves ramp alpha toward 1 so the skeleton isn't smeared. All temporal state (smoothing, identity, debounce, plumb) resets on time jumps > 0.4s so a seek never blends two moments of the dance.

## Loaded-foot ring strobed at the anchor
The weight ratio divides by ankle x-span — at the anchor the feet come together, the span collapses toward zero, and sub-pixel hip jitter flipped the ring side every frame, precisely at the moment the feature exists to visualize. Fixes:
- minimum stance-width gate (scaled to the dancer's hip-to-ankle drop, so camera distance doesn't matter) before calling a side at all
- 3-frame debounce before the displayed side flips
- the plumb line glides between anchor points instead of snapping a foot-width sideways

## Slot axis pointed up to 90° wrong after seeks
The warm-up fallback drew the line through the two dancers' current foot midpoints — that's the *inter-dancer* axis, which during a whip is roughly perpendicular to the real slot. Removed: nothing draws until the PCA has 8 samples (~4 frames). The fit itself now requires real travel and 2.5× elongation (a couple rotating in place produces an isotropic blob whose principal axis is noise), and the buffer flushes when a foot-midpoint teleports between frames (camera cut/pan mid-playback — `seeked` never fires for those).

## Connection line robustness
Threshold scale now uses the **wider** of the two dancers' shoulder spreads (one rotated dancer's foreshortened spread was shrinking the threshold until real connections dropped mid-turn), with 1.4× sticky hysteresis while connected, and up to two simultaneous lines so closed/two-hand holds render as two connections instead of misleadingly one.

## Testing
- `npx tsc --noEmit` clean, `next build` passes, eslint clean on the file