### PR TITLE
Surface analysis data the model already produces

### DIFF
--- a/api/src/wcs_api/services/peer_reviews.py
+++ b/api/src/wcs_api/services/peer_reviews.py
@@ -131,7 +131,8 @@ async def list_for_analysis(
                 f"&requester_user_id=eq.{user_id}"
                 "&select=id,token,requested_at,reviewer_name,reviewer_role,"
                 "timing_score,technique_score,teamwork_score,presentation_score,"
-                "overall_notes,per_moment_notes,submitted_at"
+                "overall_notes,per_moment_notes,submitted_at,"
+                "requester_prompt,focus_categories"
                 "&order=requested_at.desc"
             ),
             headers=_headers(),

--- a/src/app/shared/page.tsx
+++ b/src/app/shared/page.tsx
@@ -16,6 +16,7 @@ import {
 } from "lucide-react";
 import { fetchSharedAnalysis, type SharedAnalysis } from "@/lib/wcs-api";
 import { TimelineView } from "@/components/analyze/timeline-view";
+import { FollowerInitiativeCard } from "@/components/analyze/score-result-card";
 import {
   PatternSummaryCard,
   derivePatternSummary,
@@ -176,6 +177,14 @@ function SharedAnalysisContent() {
                 <span className="text-2xl text-muted-foreground">/10</span>
               </div>
               <Badge className="text-sm px-3 py-0.5">{overall.grade}</Badge>
+              {result.observed_level && (
+                <span className="text-xs text-muted-foreground">
+                  Scored as{" "}
+                  <span className="font-medium text-foreground">
+                    {result.observed_level}
+                  </span>
+                </span>
+              )}
               {overall.impression && (
                 <p className="text-sm text-muted-foreground italic text-center max-w-lg pt-1">
                   <Quote className="inline h-3 w-3 mr-1 -mt-0.5 opacity-50" />
@@ -238,6 +247,16 @@ function SharedAnalysisContent() {
             <PatternSummaryCard summary={summary} />
           ) : null;
         })()}
+
+        {/* Follower voice — the moments the follower authored are
+            among the most shareable insights; the owner view has
+            always shown them, so the shared view should too. */}
+        {result.follower_initiative &&
+          result.follower_initiative.length > 0 && (
+            <FollowerInitiativeCard
+              initiative={result.follower_initiative}
+            />
+          )}
 
         {/* Strengths */}
         {Array.isArray(result.strengths) && result.strengths.length > 0 && (

--- a/src/components/analyze/peer-reviews-section.tsx
+++ b/src/components/analyze/peer-reviews-section.tsx
@@ -270,9 +270,28 @@ export function PeerReviewsSection({ analysisId }: { analysisId: string }) {
                     <code className="text-xs text-muted-foreground truncate block">
                       {url}
                     </code>
-                    <p className="text-[11px] text-muted-foreground mt-0.5">
-                      Requested{" "}
-                      {new Date(r.requested_at).toLocaleDateString()}
+                    {/* Echo the brief so the owner can tell multiple
+                        outstanding requests apart ("the anchor one"
+                        vs "the connection one"). */}
+                    {r.requester_prompt && (
+                      <p className="text-[11px] text-foreground/80 mt-1 line-clamp-2">
+                        &ldquo;{r.requester_prompt}&rdquo;
+                      </p>
+                    )}
+                    <p className="text-[11px] text-muted-foreground mt-0.5 flex items-center gap-1.5 flex-wrap">
+                      <span>
+                        Requested{" "}
+                        {new Date(r.requested_at).toLocaleDateString()}
+                      </span>
+                      {(r.focus_categories ?? []).map((c) => (
+                        <Badge
+                          key={c}
+                          variant="outline"
+                          className="text-[9px] px-1 py-0 h-3.5 capitalize"
+                        >
+                          {c}
+                        </Badge>
+                      ))}
                     </p>
                   </div>
                   <Button
@@ -422,6 +441,14 @@ function ReviewCard({
           <X className="h-3.5 w-3.5" />
         </Button>
       </div>
+
+      {/* What the owner asked for, alongside the answer — reviews
+          only make sense against the question that prompted them. */}
+      {review.requester_prompt && (
+        <p className="text-xs text-muted-foreground border-l-2 border-border pl-2 italic">
+          You asked: &ldquo;{review.requester_prompt}&rdquo;
+        </p>
+      )}
 
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
         {CATEGORIES.map((c) => {

--- a/src/components/analyze/score-result-card.tsx
+++ b/src/components/analyze/score-result-card.tsx
@@ -394,6 +394,48 @@ export function ScoreResultCard({
                       {cat.notes}
                     </p>
                   )}
+                  {/* Category-specific prose the model already emits
+                      (and we already pay tokens for) — surfaced
+                      instead of silently dropped. */}
+                  {key === "timing" && cat.rhythm_consistency && (
+                    <p className="text-xs text-muted-foreground pt-0.5">
+                      <span className="font-medium text-foreground">
+                        Rhythm:
+                      </span>{" "}
+                      {cat.rhythm_consistency}
+                    </p>
+                  )}
+                  {key === "teamwork" && cat.connection && (
+                    <p className="text-xs text-muted-foreground pt-0.5">
+                      <span className="font-medium text-foreground">
+                        Connection:
+                      </span>{" "}
+                      {cat.connection}
+                    </p>
+                  )}
+                  {key === "presentation" && cat.musicality && (
+                    <p className="text-xs text-muted-foreground pt-0.5">
+                      <span className="font-medium text-foreground">
+                        Musicality:
+                      </span>{" "}
+                      {cat.musicality}
+                    </p>
+                  )}
+                  {cat.reasoning && (
+                    <details className="group pt-0.5">
+                      <summary className="cursor-pointer text-xs text-muted-foreground hover:text-foreground list-none inline-flex items-center gap-1">
+                        <span className="group-open:hidden">
+                          Why this score ▾
+                        </span>
+                        <span className="hidden group-open:inline">
+                          Why this score ▴
+                        </span>
+                      </summary>
+                      <p className="text-xs text-muted-foreground pt-1.5 whitespace-pre-wrap">
+                        {cat.reasoning}
+                      </p>
+                    </details>
+                  )}
                   {key === "technique" && (
                     <TechniqueBreakdown technique={cat} />
                   )}
@@ -641,7 +683,7 @@ function formatInitiativeTime(sec: number): string {
   return `${m}:${s.toString().padStart(2, "0")}`;
 }
 
-function FollowerInitiativeCard({
+export function FollowerInitiativeCard({
   initiative,
 }: {
   initiative: FollowerInitiative[];

--- a/src/lib/wcs-api.ts
+++ b/src/lib/wcs-api.ts
@@ -591,6 +591,14 @@ export type PeerReview = {
   overall_notes: string | null;
   per_moment_notes: Array<{ timestamp_sec: number; note: string }>;
   submitted_at: string | null;
+  // The brief the requester attached ("what do you want feedback
+  // on?"). Shown back on pending/submitted rows so the owner can
+  // tell multiple outstanding requests apart. Optional: rows from
+  // before the API returned these fields simply omit them.
+  requester_prompt?: string | null;
+  focus_categories?: Array<
+    "timing" | "technique" | "teamwork" | "presentation"
+  > | null;
 };
 
 export type PeerReviewList = {


### PR DESCRIPTION
A functionality audit found several fields that Gemini is required to emit (and we pay tokens for on every analysis) that the UI never rendered anywhere. This PR surfaces them.

## Category cards (`score-result-card.tsx`)
- `reasoning` — the evidence-based justification behind each category score, the most coaching-dense string the model produces — now renders as a collapsible **Why this score** section under each category.
- `rhythm_consistency` (timing), `connection` (teamwork), `musicality` (presentation) prose now render as labeled lines under their categories.

## Shared view (`/shared`)
- **Observed level** ("Scored as Intermediate") — was owner-only.
- **Follower voice** card — follower-authored moments were stripped from the one public surface despite being among the most shareable insights. (`FollowerInitiativeCard` is now exported from score-result-card.)

## Peer-review brief round-trip
The requester's brief (`requester_prompt` / `focus_categories`) was shown to the *reviewer* but never back to the requester — with two outstanding requests you couldn't tell which link was which.
- Pending rows: show the brief (2-line clamp) + focus badges.
- Submitted reviews: "You asked: …" above the reviewer's answer.
- API: `/peer-reviews/for-analysis` now selects `requester_prompt, focus_categories` (columns already exist in schema; no migration).

## Testing
- `tsc --noEmit` clean, `next build` passes, no new eslint issues (2 flagged errors pre-exist on main)
- API: 33/33 pytest pass

Note: needs a Railway API deploy after merge for the peer-review select change.