### PR TITLE
Fix reset-all-data, Infinity-duration rejection, unsaved-analysis warning

### DIFF
--- a/src/app/(app)/analyze/page.tsx
+++ b/src/app/(app)/analyze/page.tsx
@@ -214,7 +214,12 @@ export default function AnalyzePage() {
       if (quota) {
         try {
           const dur = await probeDuration(f);
-          if (dur > quota.max_seconds) {
+          // Some MOV/WebM files report duration === Infinity until a
+          // seek. Only reject on a real finite over-limit reading —
+          // otherwise this guard blocked valid clips with "Video is
+          // Infinitys". Non-finite probes fall through to the
+          // server-side enforcement, same as a failed probe.
+          if (Number.isFinite(dur) && dur > quota.max_seconds) {
             setLocalError(
               `Video is ${Math.round(dur)}s; clips must be ${quota.max_seconds}s or less.`
             );
@@ -535,6 +540,19 @@ export default function AnalyzePage() {
       {/* Result */}
       {state.status === "success" && state.result && (
         <>
+          {/* The analysis ran (and the credit was spent) but the DB
+              insert failed, so this result exists only on this page.
+              Without a warning the user refreshes, loses it, and
+              can't tell why their history is missing an entry. */}
+          {!state.result.analysis_id && (
+            <Card className="border-amber-500/40 bg-amber-500/10">
+              <CardContent className="py-3 text-sm text-amber-300">
+                This analysis couldn&apos;t be saved to your history — it
+                will disappear when you leave this page. Screenshot or
+                copy anything you want to keep.
+              </CardContent>
+            </Card>
+          )}
           <ScoreResultCard
             result={state.result.result}
             duration={state.result.duration}

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -10,10 +10,21 @@ export default function SettingsPage() {
   const handleClearData = () => {
     if (
       confirm(
-        "This will reset all your progress (review deck, checklists, streaks, practice history). Are you sure?"
+        "This will reset all your progress (review deck, checklists, streaks, practice history) and local preferences. Are you sure?"
       )
     ) {
-      localStorage.removeItem("swingflow-data");
+      // The app writes under two prefixes ("swingflow-data",
+      // "swingflow-rhythm-history") plus colon-namespaced keys
+      // ("swingflow:playbackRate", per-analysis loop / dance-start
+      // overrides, overlay toggles). Sweep them all — removing only
+      // swingflow-data left rhythm history and every preference
+      // behind, which broke the promise this dialog makes.
+      const doomed: string[] = [];
+      for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i);
+        if (key && key.startsWith("swingflow")) doomed.push(key);
+      }
+      doomed.forEach((key) => localStorage.removeItem(key));
       window.location.reload();
     }
   };


### PR DESCRIPTION
Three small correctness fixes from the functionality audit:

## Reset all data actually resets all data
`Settings → Reset all data` removed only `swingflow-data`. Rhythm practice history lives under `swingflow-rhythm-history` and survived — despite the confirm dialog explicitly promising practice history would be cleared — along with every preference (`swingflow:playbackRate`, overlay toggles, per-analysis `swingflow:loop:*` / `swingflow:dance-start-override:*`). Now sweeps every key with the `swingflow` prefix.

## Infinity-duration clips no longer rejected with nonsense copy
Some MOV/WebM files report `video.duration === Infinity` until a seek. The pre-upload guard read that as over-limit and blocked the clip with *"Video is Infinitys; clips must be 200s or less."* Now only a **finite** over-limit reading rejects; non-finite probes fall through to server-side enforcement (same path as a failed probe).

## Unsaved analysis gets a visible warning
When the analysis completes but the DB insert fails, the credit is spent and `analysis_id` comes back null — the result renders inline and silently vanishes on refresh. Now an amber banner says it won't survive leaving the page.

## Testing
`tsc --noEmit` clean, `next build` passes, no new eslint issues (the 2 flagged errors pre-exist on main).