### PR TITLE
Stamp prompt_version + sanity_retry into stored analysis results

### DIFF
--- a/api/src/wcs_api/services/video_analysis/analyzer.py
+++ b/api/src/wcs_api/services/video_analysis/analyzer.py
@@ -39,6 +39,7 @@ from .media_context import (
 from .prompts import (
     GEMINI_VIDEO_PROMPT,
     PATTERN_SEGMENTATION_PROMPT,
+    PROMPT_VERSION,
     _build_sanity_retry_prompt,
     _build_user_context,
     _format_pattern_timeline,
@@ -508,6 +509,7 @@ def analyze_video_path(
         beat_grid=beat_grid,
         beat_grid_error=beat_grid_error,
         user_song_style=user_song_style,
+        prompt_version=PROMPT_VERSION,
     )
 
 

--- a/api/src/wcs_api/services/video_analysis/analyzer.py
+++ b/api/src/wcs_api/services/video_analysis/analyzer.py
@@ -212,6 +212,11 @@ def analyze_video_path(
     total_response_tokens = 0
 
     sanity_warnings: list[str] = []
+    # Whether the corrective retry call actually fired — distinct from
+    # sanity_warnings, which holds only the RESIDUAL issues. A retry
+    # that fully fixed the response leaves warnings empty but must
+    # still be recorded (it cost a call and shaped the result).
+    sanity_retry_attempted = False
 
     try:
         # Poll until the file is ACTIVE on Gemini's side. Inside the
@@ -440,6 +445,7 @@ def analyze_video_path(
                 dance_start_sec=dance_start_sec,
                 dance_end_sec=dance_end_sec,
             )
+            sanity_retry_attempted = True
             try:
                 # Preserve the full original prompt context on retry:
                 # user metadata, beat context, motion-floor note, and
@@ -492,7 +498,7 @@ def analyze_video_path(
             settings.gemini_model, total_prompt_tokens, total_response_tokens
         ),
         "pricing_updated_on": pricing_updated_on(),
-        "sanity_retry": bool(sanity_warnings),
+        "sanity_retry": sanity_retry_attempted,
     }
 
     from .prompts import extract_song_style_from_tags
@@ -510,6 +516,7 @@ def analyze_video_path(
         beat_grid_error=beat_grid_error,
         user_song_style=user_song_style,
         prompt_version=PROMPT_VERSION,
+        sanity_retry_attempted=sanity_retry_attempted,
     )
 
 

--- a/api/src/wcs_api/services/video_analysis/prompts.py
+++ b/api/src/wcs_api/services/video_analysis/prompts.py
@@ -21,6 +21,17 @@ from .response_sanitizer import _sanitize_user_field
 # below already model the convention.
 
 
+# Version stamp for the scoring prompt. Stored inside every
+# analysis's result jsonb (result.analysis_meta.prompt_version) so
+# score distributions are comparable across prompt revisions — without
+# this, a rubric edit silently mixes old- and new-prompt scores in
+# every trend chart and calibration query.
+#
+# BUMP THIS whenever a change to this file could shift what the model
+# emits: rubric wording, schema fields, calibration anchors, example
+# changes. Formatting-only edits (comments, whitespace) don't count.
+PROMPT_VERSION = "v1"
+
 # Song-style labels we recognize from user-supplied tags. Keys are the
 # lowercased tokens we match against; values are the canonical label
 # we surface in the UI and hand to the prompt. `mix` is deliberately

--- a/api/src/wcs_api/services/video_analysis/response_sanitizer.py
+++ b/api/src/wcs_api/services/video_analysis/response_sanitizer.py
@@ -1094,6 +1094,7 @@ def _shape_response(
     beat_grid_error: str | None = None,
     user_song_style: str | None = None,
     prompt_version: str | None = None,
+    sanity_retry_attempted: bool = False,
 ) -> dict[str, Any]:
     """Map Gemini's rich response into the API's return shape.
 
@@ -1263,10 +1264,13 @@ def _shape_response(
         # the DB insert — cost data stays admin-only), this block is
         # deliberately kept INSIDE the stored result jsonb so any
         # calibration/eval query can group scores by prompt revision
-        # and see whether a sanity retry shaped the run.
+        # and see whether a sanity retry shaped the run. sanity_retry
+        # records that the corrective call FIRED — not whether issues
+        # remain (that's sanity_warnings): a retry that fully fixed
+        # the response must still be attributable.
         "analysis_meta": {
             "prompt_version": prompt_version,
-            "sanity_retry": bool(sanity_warnings),
+            "sanity_retry": sanity_retry_attempted,
         },
         "usage": usage,
     }

--- a/api/src/wcs_api/services/video_analysis/response_sanitizer.py
+++ b/api/src/wcs_api/services/video_analysis/response_sanitizer.py
@@ -1093,6 +1093,7 @@ def _shape_response(
     beat_grid: dict[str, Any] | None = None,
     beat_grid_error: str | None = None,
     user_song_style: str | None = None,
+    prompt_version: str | None = None,
 ) -> dict[str, Any]:
     """Map Gemini's rich response into the API's return shape.
 
@@ -1258,5 +1259,14 @@ def _shape_response(
         "subject_drift_count": subject_drift_count,
         "timeline_locked": timeline_locked,
         "sanity_warnings": (sanity_warnings or []) + extra_warnings,
+        # Provenance stamp. Unlike `usage` (popped by the route before
+        # the DB insert — cost data stays admin-only), this block is
+        # deliberately kept INSIDE the stored result jsonb so any
+        # calibration/eval query can group scores by prompt revision
+        # and see whether a sanity retry shaped the run.
+        "analysis_meta": {
+            "prompt_version": prompt_version,
+            "sanity_retry": bool(sanity_warnings),
+        },
         "usage": usage,
     }

--- a/api/tests/test_response_sanitizer.py
+++ b/api/tests/test_response_sanitizer.py
@@ -207,3 +207,54 @@ def test_merge_unique_preserves_primary_order_unchanged():
     primary = ["x", "y"]
     fallback = ["z"]
     assert _merge_unique(primary, fallback) == ["x", "y", "z"]
+
+
+# ─── _shape_response: analysis_meta provenance stamp ────────────────
+
+
+def _minimal_parsed() -> dict:
+    return {
+        "timing": {"score": 6.0},
+        "technique": {"score": 6.0},
+        "teamwork": {"score": 6.0},
+        "presentation": {"score": 6.0},
+    }
+
+
+def test_shape_response_stamps_prompt_version_and_retry_flag():
+    from wcs_api.services.video_analysis.response_sanitizer import (
+        _shape_response,
+    )
+
+    shaped = _shape_response(
+        _minimal_parsed(),
+        sanity_warnings=["patterns before dance_start"],
+        prompt_version="v-test",
+    )
+    assert shaped["analysis_meta"] == {
+        "prompt_version": "v-test",
+        "sanity_retry": True,
+    }
+
+
+def test_shape_response_meta_defaults_without_retry():
+    from wcs_api.services.video_analysis.response_sanitizer import (
+        _shape_response,
+    )
+
+    shaped = _shape_response(_minimal_parsed())
+    assert shaped["analysis_meta"]["sanity_retry"] is False
+    assert shaped["analysis_meta"]["prompt_version"] is None
+
+
+def test_analyzer_passes_real_prompt_version():
+    # The analyzer must forward prompts.PROMPT_VERSION — guard against
+    # the stamp silently going stale if the call site is refactored.
+    import inspect
+
+    from wcs_api.services.video_analysis import analyzer
+    from wcs_api.services.video_analysis.prompts import PROMPT_VERSION
+
+    src = inspect.getsource(analyzer)
+    assert "prompt_version=PROMPT_VERSION" in src
+    assert PROMPT_VERSION  # non-empty

--- a/api/tests/test_response_sanitizer.py
+++ b/api/tests/test_response_sanitizer.py
@@ -230,11 +230,31 @@ def test_shape_response_stamps_prompt_version_and_retry_flag():
         _minimal_parsed(),
         sanity_warnings=["patterns before dance_start"],
         prompt_version="v-test",
+        sanity_retry_attempted=True,
     )
     assert shaped["analysis_meta"] == {
         "prompt_version": "v-test",
         "sanity_retry": True,
     }
+
+
+def test_shape_response_records_fully_successful_retry():
+    # A retry that fixed every issue leaves sanity_warnings empty but
+    # must still be stamped — it fired a corrective call and shaped
+    # the result. Deriving the flag from residual warnings (the old
+    # behavior) records exactly the successful case as False.
+    from wcs_api.services.video_analysis.response_sanitizer import (
+        _shape_response,
+    )
+
+    shaped = _shape_response(
+        _minimal_parsed(),
+        sanity_warnings=[],
+        prompt_version="v-test",
+        sanity_retry_attempted=True,
+    )
+    assert shaped["analysis_meta"]["sanity_retry"] is True
+    assert shaped["sanity_warnings"] == []
 
 
 def test_shape_response_meta_defaults_without_retry():
@@ -257,4 +277,5 @@ def test_analyzer_passes_real_prompt_version():
 
     src = inspect.getsource(analyzer)
     assert "prompt_version=PROMPT_VERSION" in src
+    assert "sanity_retry_attempted=sanity_retry_attempted" in src
     assert PROMPT_VERSION  # non-empty


### PR DESCRIPTION
First of a three-PR scoring-quality series (versioning → score evals → rubric anchors).

## Why
Stored analyses carry no record of which prompt revision scored them. Any rubric edit makes before/after score distributions indistinguishable in the DB — trend charts and calibration queries silently mix revisions. The `sanity_retry` flag has been computed since #153 but never persisted (`usage` is popped before the insert).

## What
- `PROMPT_VERSION = "v1"` in `prompts.py`, with the bump rule documented at the constant (bump on any behavior-affecting edit; comments/whitespace don't count).
- `_shape_response` emits `result.analysis_meta = { prompt_version, sanity_retry }` — deliberately **inside** the stored result jsonb, so no schema migration is needed and every calibration/eval query can group by revision.
- The analyzer forwards the constant; a test asserts the call site keeps doing so.

## Testing
36/36 pytest (3 new).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Video analysis results now include prompt version metadata for improved result traceability.
  * Results indicate whether a sanity retry occurred during analysis.

* **Tests**
  * Added coverage validating metadata defaults, prompt version propagation, and retry status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->